### PR TITLE
feat(perf): canvas renderer and map performance optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "webmap-dev",
-  "version": "1.0.0",
+  "version": "0.2.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webmap-dev",
-      "version": "1.0.0",
+      "version": "0.2.0-beta",
       "dependencies": {
         "esri-leaflet": "^3.0.12",
         "esri-leaflet-geocoder": "^3.1.4",
-        "leaflet": "^1.9.4"
+        "leaflet": "^1.9.4",
+        "simplify-js": "^1.2.4"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.14",
@@ -2286,6 +2287,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/simplify-js": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.4.tgz",
+      "integrity": "sha512-vITfSlwt7h/oyrU42R83mtzFpwYk3+mkH9bOHqq/Qw6n8rtR7aE3NZQ5fbcyCUVVmuMJR6ynsAhOfK2qoah8Jg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "esri-leaflet": "^3.0.12",
     "esri-leaflet-geocoder": "^3.1.4",
-    "leaflet": "^1.9.4"
+    "leaflet": "^1.9.4",
+    "simplify-js": "^1.2.4"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.14",

--- a/src/idle.ts
+++ b/src/idle.ts
@@ -1,0 +1,31 @@
+// Intent: Custom map idle event — Leaflet has no native idle event.
+// Fires the callback once after `ms` of inactivity following a moveend,
+// resetting if a new movestart arrives before the timeout expires.
+// Use for debounced operations like reverse-geocoding on map pan.
+import type L from 'leaflet';
+
+export function addIdleListener(map: L.Map, callback: () => void, ms = 400): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function onMoveEnd(): void {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(callback, ms);
+  }
+
+  function onMoveStart(): void {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  map.on('moveend', onMoveEnd);
+  map.on('movestart', onMoveStart);
+
+  // Returns a cleanup function to remove the listeners
+  return () => {
+    if (timer !== undefined) clearTimeout(timer);
+    map.off('moveend', onMoveEnd);
+    map.off('movestart', onMoveStart);
+  };
+}

--- a/src/map.ts
+++ b/src/map.ts
@@ -25,7 +25,6 @@ export function createMap(): L.Map {
       return container;
     },
   });
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   new (ZoomViewer as new (opts: L.ControlOptions) => L.Control)({
     position: 'bottomleft',
   }).addTo(map);

--- a/src/map.ts
+++ b/src/map.ts
@@ -37,6 +37,10 @@ export function createMap(): L.Map {
   // tradeoff: Mapbox requires a token but provides the best outdoor/trail data.
   // OSM is the anonymous fallback; Google satellite is included for imagery context.
   const mapboxToken = import.meta.env.VITE_MAPBOX_TOKEN;
+  // keepBuffer: extra tiles to cache beyond the viewport (smoother panning)
+  // updateWhenZooming: false defers tile loads during pinch-zoom animation
+  const tilePerf = { keepBuffer: 3, updateWhenZooming: false } as const;
+
   const elevationWithTrails = L.tileLayer(
     `https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`,
     {
@@ -46,6 +50,7 @@ export function createMap(): L.Map {
       maxNativeZoom: 18,
       minZoom: 2,
       minNativeZoom: 2,
+      ...tilePerf,
     },
   ).addTo(map);
 
@@ -56,6 +61,7 @@ export function createMap(): L.Map {
     maxNativeZoom: 18,
     minZoom: 2,
     minNativeZoom: 2,
+    ...tilePerf,
   });
 
   const gsi = L.tileLayer('https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
@@ -66,6 +72,7 @@ export function createMap(): L.Map {
     maxNativeZoom: 18,
     minZoom: 2,
     minNativeZoom: 2,
+    ...tilePerf,
   });
 
   const baseMaps = { Imagery: gsi, Streets: osm, Trails: elevationWithTrails };


### PR DESCRIPTION
## Summary

- Replaces the per-fix `circleMarker` trail with a single `L.Polyline` (`smoothFactor: 2`) — Canvas renderer handles polylines 10-100x faster than SVG for many paths
- Installs `simplify-js` to prune trail points above 5,000, keeping `setLatLngs` bounded across long sessions
- Gates polyline updates behind `requestAnimationFrame` to avoid blocking paint frames during GPS follow mode
- Adds `keepBuffer: 3` and `updateWhenZooming: false` to all tile layers for smoother panning and deferred loads during pinch-zoom
- Keeps only the latest accuracy circle on the map (eliminates accumulation across session)
- Debounces reverse geocoding dblclick handler at 300ms
- Adds `addIdleListener()` utility (`src/idle.ts`) for future debounced moveend geocoding

## Changes

- `src/types.ts` — adds `trailPoints`, `trailPolyline`, `accuracyCircle` to `AppState`
- `src/location.ts` — rewrites GPS event handler to maintain a single polyline with simplify-js and rAF
- `src/map.ts` — adds `keepBuffer` / `updateWhenZooming` to all three tile layers (canvas was already enabled)
- `src/geocoding.ts` — inline `debounce` utility + debounced dblclick handler
- `src/idle.ts` — new: custom `addIdleListener()` utility (moveend/movestart timeout pattern)
- `package.json` — adds `simplify-js` dependency

## Test plan

- [ ] `npm run type-check && npm run lint && npm run build` passes (verified locally)
- [ ] Enable tracking — confirm a single blue trail polyline renders instead of individual dots
- [ ] Generate 1000+ trail points — confirm no frame drops and smooth rendering
- [ ] Pan/zoom map rapidly — confirm tiles load smoothly with reduced flicker during zoom animation
- [ ] Double-click to drop a pin — confirm reverse geocode fires once (not on every rapid double-click)
- [ ] Accuracy circle — confirm only the latest accuracy circle is visible (not accumulating)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)