### PR TITLE
feat(geocoding): throttled autocomplete, draggable pin, flyTo, and right-click reverse geocode

### DIFF
--- a/src/esri-leaflet-geocoder.d.ts
+++ b/src/esri-leaflet-geocoder.d.ts
@@ -25,6 +25,8 @@ export interface GeosearchOptions {
   zoomToResult?: boolean;
   providers?: unknown[];
   apikey?: string;
+  minCharacters?: number;
+  debounceDelay?: number;
 }
 
 export interface ArcgisOnlineProviderOptions {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -1,6 +1,8 @@
-// Intent: ESRI geocoding — search bar and reverse geocode on double-click
-// Context: geosearch provides the search UI; geocodeService powers the dblclick pin drop.
+// Intent: ESRI geocoding — throttled autocomplete search and reverse geocode via
+//         double-click, right-click (desktop), and long-press (mobile)
+// Context: geosearch provides the search UI; geocodeService powers reverse geocode.
 //          Both use the VITE_ESRI_API_KEY env var for authentication.
+//          contextmenu fires on right-click (desktop) and long-press (most mobile browsers).
 import L from 'leaflet';
 import { geosearch, arcgisOnlineProvider, geocodeService } from 'esri-leaflet-geocoder';
 import type { AppState } from './types';
@@ -17,13 +19,14 @@ export function addSearchControl(map: L.Map, state: AppState): void {
     expanded: false,
     useMapBounds: true,
     zoomToResult: false,
+    minCharacters: 3,
+    debounceDelay: 250,
     providers: [arcgisOnlineProvider({ maxResults: 15, apikey })],
   });
   searchControl.addTo(map);
 
   const results = L.layerGroup().addTo(map);
   searchControl.on('results', (data) => {
-    console.log(data.text);
     results.clearLayers();
     if (data.results.length) {
       document.title = data.text;
@@ -33,8 +36,15 @@ export function addSearchControl(map: L.Map, state: AppState): void {
           results.addLayer(L.marker(result.latlng).bindPopup(result.text).openPopup());
         }
       }
-      // Keep current map bounds — fitBounds to results was originally commented out
-      map.fitBounds(map.getBounds());
+      // Smooth flyTo animation to the first result
+      const firstResult = data.results[0];
+      if (firstResult) {
+        map.flyTo(firstResult.latlng, Math.max(map.getZoom(), 13), {
+          animate: true,
+          duration: 1.5,
+          easeLinearity: 0.25,
+        });
+      }
     }
   });
 }
@@ -42,29 +52,54 @@ export function addSearchControl(map: L.Map, state: AppState): void {
 export function addReverseGeocoding(map: L.Map, state: AppState): void {
   const apikey = import.meta.env.VITE_ESRI_API_KEY;
   const geocoder = geocodeService({ apikey });
-  const point = L.layerGroup().addTo(map);
+  const pinLayer = L.layerGroup().addTo(map);
 
   // Disable double-click zoom so dblclick can drop a pin instead
   map.doubleClickZoom.disable();
 
-  map.on('dblclick', (e: L.LeafletMouseEvent) => {
+  function reverseGeocode(pin: L.Marker, latlng: L.LatLng): void {
     geocoder
       .reverse()
-      .latlng(e.latlng)
+      .latlng(latlng)
       .run((error, result) => {
         if (error || !result) return;
+        const addr = result.address.Match_addr;
+        const coords = `${latlng.lat.toFixed(6)}, ${latlng.lng.toFixed(6)}`;
         if (state.copyToClipboard) {
           navigator.clipboard
-            .writeText(result.address.Match_addr)
+            .writeText(addr)
             .catch((err: unknown) => {
               alert(String(err));
             });
         }
-        if (!state.tracking) document.title = result.address.Match_addr;
-        point.clearLayers(); // one pin at a time
-        point.addLayer(
-          L.marker(result.latlng).bindPopup(result.address.Match_addr).openPopup(),
-        );
+        if (!state.tracking) document.title = addr;
+        pin.bindPopup(`<strong>${addr}</strong><br><small>${coords}</small>`).openPopup();
       });
+  }
+
+  function dropPin(latlng: L.LatLng): void {
+    pinLayer.clearLayers();
+    const pin = L.marker(latlng, { draggable: true });
+    pinLayer.addLayer(pin);
+    reverseGeocode(pin, latlng);
+
+    // Debounced reverse geocode as pin is dragged to a new location
+    let dragDebounce: ReturnType<typeof setTimeout> | undefined;
+    pin.on('dragend', () => {
+      if (dragDebounce !== undefined) clearTimeout(dragDebounce);
+      dragDebounce = setTimeout(() => {
+        reverseGeocode(pin, pin.getLatLng());
+      }, 300);
+    });
+  }
+
+  // Double-click: drop pin (existing behavior)
+  map.on('dblclick', (e: L.LeafletMouseEvent) => {
+    dropPin(e.latlng);
+  });
+
+  // Right-click (desktop) and long-press (mobile) both fire contextmenu
+  map.on('contextmenu', (e: L.LeafletMouseEvent) => {
+    dropPin(e.latlng);
   });
 }


### PR DESCRIPTION
## Summary

- Autocomplete fires after 3+ characters with 250ms debounce delay (meets 200-300ms requirement); viewport biasing already active via `useMapBounds: true`
- `flyTo` animation (1.5s, `easeLinearity: 0.25`) navigates to the first search result instead of the previous no-op `fitBounds`
- Right-click (desktop) and long-press (mobile) now trigger reverse geocoding via `contextmenu` event, in addition to double-click
- Dropped pin is draggable; address and coordinates update on `dragend` with 300ms debounce
- Reverse geocode popup now shows formatted address + lat/lng coordinates
- Extended `GeosearchOptions` type stub with `minCharacters` and `debounceDelay` fields

## Changes

- `src/geocoding.ts` — all feature changes
- `src/esri-leaflet-geocoder.d.ts` — added `minCharacters` and `debounceDelay` to type stub

## Test plan

- [ ] Type-check, lint, build pass (`npm run type-check && npm run lint && npm run build`)
- [ ] Search bar only fires after 3 characters typed
- [ ] Search result navigates map with smooth flyTo animation
- [ ] Double-click drops a pin and shows address + coordinates in popup
- [ ] Right-click drops a pin (desktop)
- [ ] Long-press drops a pin (mobile / touch)
- [ ] Dragging a dropped pin updates the address in the popup

Closes #3