### PR TITLE
feat(locate): three-state location button with blue dot and accuracy circle

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -4,6 +4,7 @@
 // Pattern: Factory function creates a fresh L.Control subclass per control instance,
 //          capturing config in a closure to avoid shared state between controls.
 import L from 'leaflet';
+import type { LocateState } from './types';
 
 interface ToggleControlConfig {
   id: string;
@@ -45,7 +46,6 @@ function makeToggleControl(config: ToggleControlConfig): L.Control {
     },
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   return new (Ctrl as new (opts: L.ControlOptions) => L.Control)({
     position: config.position,
   });
@@ -61,14 +61,36 @@ export function addClipboardControl(map: L.Map, onClick: (e: Event) => void): vo
   }).addTo(map);
 }
 
-export function addCenteringControl(map: L.Map, onClick: (e: Event) => void): void {
+// Three-state locate button: Off → Active (following) → Passive (dot only)
+// Icon mapping: off=lines, active=color, passive=bw
+export function addLocateControl(map: L.Map, onClick: (e: Event) => void): void {
   makeToggleControl({
-    id: 'centering',
+    id: 'locate',
     disabledSrc: '/centering-lines-v1.1.svg',
-    disabledTitle: 'Centering Toggle (Disabled)',
+    disabledTitle: 'Locate (Off)',
     position: 'bottomright',
     onClick,
   }).addTo(map);
+}
+
+// Updates the locate button icon to reflect current state
+export function updateLocateIcon(locateState: LocateState): void {
+  const img = document.getElementById('locate') as HTMLImageElement | null;
+  if (!img) return;
+  switch (locateState) {
+    case 'off':
+      img.alt = img.title = 'Locate (Off)';
+      img.src = '/centering-lines-v1.1.svg';
+      break;
+    case 'active':
+      img.alt = img.title = 'Locate (Following)';
+      img.src = '/centering-color-v1.1.svg';
+      break;
+    case 'passive':
+      img.alt = img.title = 'Locate (Passive — tap to re-center)';
+      img.src = '/centering-bw-v1.1.svg';
+      break;
+  }
 }
 
 export function addTrackingControl(map: L.Map, onClick: (e: Event) => void): void {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -109,7 +109,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
             alert(String(err));
           });
         }
-        if (!state.tracking) document.title = addr;
+        if (state.recordingState === 'idle') document.title = addr;
 
         // Format coordinates for display
         const lat = latlng.lat;

--- a/src/location.ts
+++ b/src/location.ts
@@ -1,11 +1,33 @@
-// Intent: Handle GPS location events — apply haversine distance filter, update icon
-//         states, recenter the map, and append points to the active recording trail
+// Intent: Handle GPS location events — apply haversine distance filter, draw/update
+//         blue dot marker and accuracy circle, recenter the map when in active state,
+//         and append points to the active recording trail
 // Context: map.locate() fires 'locationfound' for every GPS fix. The haversine filter
 //          ignores updates where we haven't moved more than half the accuracy radius
 //          AND accuracy hasn't improved — reduces jitter when standing still.
 import L from 'leaflet';
 import type { AppState } from './types';
+import { updateLocateIcon } from './controls';
 import { appendTrailPoint } from './recording';
+
+// divIcon HTML for the blue pulsing dot — styled via .blue-dot CSS in style.css
+function createBlueDotIcon(): L.DivIcon {
+  return L.divIcon({
+    className: 'blue-dot',
+    html: '<div class="blue-dot__inner"></div>',
+    iconSize: [16, 16],
+    iconAnchor: [8, 8],
+  });
+}
+
+// Gray dot shown on GPS signal loss
+function createGrayDotIcon(): L.DivIcon {
+  return L.divIcon({
+    className: 'blue-dot blue-dot--gray',
+    html: '<div class="blue-dot__inner"></div>',
+    iconSize: [16, 16],
+    iconAnchor: [8, 8],
+  });
+}
 
 export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map): void {
   // Haversine formula: great-circle distance between previous and current position
@@ -27,20 +49,56 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     state.youAreHereLocationlng = e.latlng.lng;
     state.youAreHereLocation = e.latlng;
 
+    // Blue dot: create on first fix, update position on subsequent fixes
+    if (state.locationMarker === null) {
+      state.locationMarker = L.marker(e.latlng, {
+        icon: createBlueDotIcon(),
+        zIndexOffset: 1000,
+        interactive: false,
+      }).addTo(map);
+    } else {
+      state.locationMarker.setLatLng(e.latlng);
+      // Restore blue icon in case it was grayed out from a prior signal loss
+      state.locationMarker.setIcon(createBlueDotIcon());
+    }
+
+    // Accuracy circle: translucent blue, no stroke, opacity fades as accuracy improves
+    // Opacity: full (0.35) at 100m+ accuracy, fades to 0.1 at 5m or better
+    const fillOpacity = Math.max(0.1, Math.min(0.35, e.accuracy / 300));
+    if (state.accuracyCircle === null) {
+      state.accuracyCircle = L.circle(e.latlng, {
+        radius: e.accuracy,
+        weight: 0,
+        fillColor: '#4285F4',
+        fillOpacity,
+      }).addTo(map);
+    } else {
+      state.accuracyCircle.setLatLng(e.latlng);
+      state.accuracyCircle.setRadius(e.accuracy);
+      state.accuracyCircle.setStyle({ fillOpacity });
+    }
+
+    // Append to the recording trail when actively recording
     if (state.recordingState === 'recording') {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
       appendTrailPoint(e.latlng, speedMs, state, map);
     }
   }
 
-  if (state.centering) {
-    const cnt_img = document.getElementById('centering') as HTMLImageElement | null;
-    if (cnt_img) {
-      cnt_img.alt = cnt_img.title = 'Centering Toggle (Enabled)';
-      cnt_img.src = '/centering-color-v1.1.svg';
-    }
-    if (state.youAreHereLocation !== null) {
-      map.panTo(state.youAreHereLocation);
-    }
+  // Update locate button icon to reflect current state
+  updateLocateIcon(state.locateState);
+
+  // Follow GPS position when in active (following) state
+  if (state.locateState === 'active' && state.youAreHereLocation !== null) {
+    map.panTo(state.youAreHereLocation);
   }
+}
+
+// Handle GPS signal loss — gray out the dot and reset accuracy filter
+export function onLocationError(state: AppState): void {
+  if (state.locationMarker !== null) {
+    state.locationMarker.setIcon(createGrayDotIcon());
+  }
+  // Reset prior so next fix is accepted regardless of accuracy change
+  state.prior = 1000;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 // Intent: Application entry point — wires all modules together
 // Pattern: Single AppState object threaded through all modules by reference.
-//          updateCallback is a refcount so centering and recording can independently
+//          updateCallback is a refcount so locate and recording can independently
 //          request/release the GPS polling loop without stepping on each other.
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -9,20 +9,24 @@ import './style.css';
 
 import { createInitialState } from './types';
 import { createMap } from './map';
-import { addClipboardControl, addCenteringControl } from './controls';
+import { addClipboardControl, addLocateControl, updateLocateIcon } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
-import { onLocationFound } from './location';
+import { onLocationFound, onLocationError } from './location';
 import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
 import { createStatsBar, addRecordingControl } from './recording';
 
 const state = createInitialState();
 const map = createMap();
 
-// Wire GPS location callback
+// Wire GPS location callbacks
 map.on('locationfound', (e: L.LocationEvent) => onLocationFound(e, state, map));
+map.on('locationerror', () => {
+  onLocationError(state);
+  showToast('GPS signal lost');
+});
 
-// Polling refcount helpers — shared by centering and recording
+// Polling refcount helpers — shared by locate and recording
 function activatePolling(): void {
   state.updateCallback += 1;
   if (state.updateCallback === 1) scheduleUpdateCallback(state, map);
@@ -34,7 +38,28 @@ function deactivatePolling(): void {
   if (state.updateCallback === 0) cancelUpdateCallback(state, map);
 }
 
-// Clipboard: copy reverse-geocoded address to clipboard on pin drop
+// ── Toast ────────────────────────────────────────────────────────────────────
+
+let toastTimer: ReturnType<typeof setTimeout> | undefined;
+
+function showToast(message: string, durationMs = 3000): void {
+  let toast = document.getElementById('locate-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'locate-toast';
+    document.getElementById('map')?.appendChild(toast);
+  }
+  toast.textContent = message;
+  toast.classList.add('visible');
+  if (toastTimer !== undefined) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast?.classList.remove('visible');
+    toastTimer = undefined;
+  }, durationMs);
+}
+
+// ── Clipboard ────────────────────────────────────────────────────────────────
+
 addClipboardControl(map, () => {
   state.copyToClipboard = !state.copyToClipboard;
   const img = document.getElementById('clip') as HTMLImageElement | null;
@@ -48,22 +73,64 @@ addClipboardControl(map, () => {
   }
 });
 
-// Centering: keep map panned to current GPS position
-addCenteringControl(map, () => {
-  state.centering = !state.centering;
-  if (state.centering) {
-    activatePolling();
-  } else {
-    deactivatePolling();
-    const img = document.getElementById('centering') as HTMLImageElement | null;
-    if (img) {
-      img.alt = img.title = 'Centering Toggle (Disabled)';
-      img.src = '/centering-lines-v1.1.svg';
-    }
+// ── Three-state locate button ─────────────────────────────────────────────────
+// States: off → active (following) → passive (dot visible, not following)
+// Pan while active automatically drops to passive.
+
+function startLocating(): void {
+  state.locateState = 'active';
+  activatePolling();
+  updateLocateIcon('active');
+}
+
+addLocateControl(map, () => {
+  switch (state.locateState) {
+    case 'off':
+      // Check permission before prompting — gracefully degrade if denied
+      if ('permissions' in navigator) {
+        navigator.permissions
+          .query({ name: 'geolocation' })
+          .then((result) => {
+            if (result.state === 'denied') {
+              showToast('Location access is denied. Enable it in browser settings.');
+            } else {
+              startLocating();
+            }
+          })
+          .catch(() => startLocating()); // permissions API unavailable — just try
+      } else {
+        startLocating();
+      }
+      break;
+
+    case 'active':
+      // Turn off: release locate's polling refcount
+      state.locateState = 'off';
+      deactivatePolling();
+      updateLocateIcon('off');
+      break;
+
+    case 'passive':
+      // Re-center: fly to current position and resume following
+      state.locateState = 'active';
+      if (state.youAreHereLocation !== null) {
+        map.flyTo(state.youAreHereLocation, map.getZoom(), { animate: true, duration: 0.8 });
+      }
+      updateLocateIcon('active');
+      break;
   }
 });
 
-// Recording: Start/Pause/Resume/Stop state machine with real-time stats and styled trail
+// Pan while following → drop to passive (map stays on user's panned position)
+map.on('dragstart', () => {
+  if (state.locateState === 'active') {
+    state.locateState = 'passive';
+    updateLocateIcon('passive');
+  }
+});
+
+// ── Recording (trail with stats) ──────────────────────────────────────────────
+
 createStatsBar();
 addRecordingControl(map, state, activatePolling, deactivatePolling);
 

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -3,6 +3,7 @@
 //          appendTrailPoint for location.ts to call on each GPS fix.
 import L from 'leaflet';
 import type { AppState } from './types';
+import { updateLocateIcon } from './controls';
 
 const MIN_TRAIL_DIST_M = 5;   // minimum metres between trail points (GPS jitter filter)
 const MIN_ARROW_DIST_M = 50;  // minimum metres between direction-arrow markers
@@ -244,16 +245,14 @@ function startRecording(
     interactive: false,
   }).addTo(map);
 
-  // Auto-enable centering on first recording activation (mirrors prior tracking behavior)
-  if (state.initiateTracking) {
-    state.initiateTracking = false;
-    document.title = 'You are here';
-    state.centering = true;
-    activatePolling(); // centering refcount
+  // Auto-enable locate on first recording if locate is off — ensures the blue dot appears
+  if (state.locateState === 'off') {
+    state.locateState = 'active';
+    activatePolling(); // locate refcount
+    updateLocateIcon('active');
   }
 
-  state.tracking = true;
-  activatePolling(); // tracking refcount
+  activatePolling(); // recording refcount
 
   setStatsBarVisible(true);
   if (state.statsTimer !== null) clearInterval(state.statsTimer);
@@ -280,8 +279,7 @@ function resumeRecording(state: AppState): void {
 function stopRecording(state: AppState, deactivatePolling: () => void): void {
   if (state.recordingState === 'idle') return;
   state.recordingState = 'idle';
-  state.tracking = false;
-  deactivatePolling(); // tracking refcount
+  deactivatePolling(); // recording refcount
 
   if (state.statsTimer !== null) {
     clearInterval(state.statsTimer);

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,76 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   filter: none;
 }
 
+/* ── Blue dot location marker ─────────────────────────────────────────────── */
+
+/* Clear Leaflet's default divIcon styles */
+.blue-dot {
+  background: transparent !important;
+  border: none !important;
+}
+
+.blue-dot__inner {
+  width: 16px;
+  height: 16px;
+  background-color: #4285F4;
+  border: 2px solid white;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  position: relative;
+}
+
+/* Pulsing ring on the blue dot */
+.blue-dot__inner::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  background-color: rgba(66, 133, 244, 0.35);
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(1);
+  animation: blue-dot-pulse 2s ease-out infinite;
+}
+
+@keyframes blue-dot-pulse {
+  0%   { transform: translate(-50%, -50%) scale(1);   opacity: 0.8; }
+  100% { transform: translate(-50%, -50%) scale(3.5); opacity: 0;   }
+}
+
+/* Gray dot on GPS signal loss — overrides background color, suppresses pulse */
+.blue-dot--gray .blue-dot__inner {
+  background-color: #9e9e9e;
+  border-color: #e0e0e0;
+}
+.blue-dot--gray .blue-dot__inner::before {
+  display: none;
+}
+
+/* ── Toast notification ───────────────────────────────────────────────────── */
+
+#locate-toast {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(30, 30, 30, 0.85);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: sans-serif;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  white-space: nowrap;
+}
+
+#locate-toast.visible {
+  opacity: 1;
+}
+
 /* ── Recording stats bar ──────────────────────────────────────────────────── */
 #recording-stats {
   position: absolute;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,9 @@
 //          modules mutate it directly (no event bus needed for this size app)
 import type L from 'leaflet';
 
+// Three-state location button: off → active (following) → passive (dot visible, not following)
+export type LocateState = 'off' | 'active' | 'passive';
+
 export type RecordingState = 'idle' | 'recording' | 'paused';
 
 export interface AppState {
@@ -14,24 +17,26 @@ export interface AppState {
 
   // Control toggle states
   copyToClipboard: boolean;
-  centering: boolean;
-  tracking: boolean;
-  initiateTracking: boolean; // true until first recording activation (triggers auto-centering)
+  locateState: LocateState; // three-state location button (replaces centering boolean)
 
   // Timer/polling state
-  updateCallback: number; // refcount: 0=stopped, 1=centering, 2=centering+tracking
+  updateCallback: number; // refcount: 0=stopped; each consumer (locate, recording) adds 1
   timer: ReturnType<typeof setTimeout> | undefined;
   initialZoom: boolean; // true until first GPS fix; zooms to level 16 on first fix
 
+  // Persistent location marker refs (updated in place instead of adding new layers)
+  locationMarker: L.Marker | null;
+  accuracyCircle: L.Circle | null;
+
   // Recording state machine
   recordingState: RecordingState;
-  recordingStartMs: number;        // performance.now() when recording began
-  recordingPauseMs: number;        // total accumulated pause duration in ms
-  recordingPauseStart: number | null; // performance.now() when current pause began
-  totalDistance: number;           // total meters traveled during recording
-  lastTrailPoint: L.LatLng | null; // last appended trail point (distance filter)
-  lastArrowPoint: L.LatLng | null; // last arrow marker point (spacing filter)
-  lastSpeedMs: number;             // m/s from most recent GPS fix
+  recordingStartMs: number;
+  recordingPauseMs: number;
+  recordingPauseStart: number | null;
+  totalDistance: number;
+  lastTrailPoint: L.LatLng | null;
+  lastArrowPoint: L.LatLng | null;
+  lastSpeedMs: number;
   trail: L.Polyline | null;
   trailGlow: L.Polyline | null;
   arrowMarkers: L.Marker[];
@@ -45,12 +50,12 @@ export function createInitialState(): AppState {
     youAreHereLocationlng: 0,
     prior: 1000,
     copyToClipboard: false,
-    centering: false,
-    tracking: false,
-    initiateTracking: true,
+    locateState: 'off',
     updateCallback: 0,
     timer: undefined,
     initialZoom: true,
+    locationMarker: null,
+    accuracyCircle: null,
     recordingState: 'idle',
     recordingStartMs: 0,
     recordingPauseMs: 0,


### PR DESCRIPTION
## Summary

Closes #2

Replaces the binary centering toggle with a three-state locate button following the Google Maps/Mapbox UX pattern, and upgrades the location marker to a persistent blue dot with pulsing animation and an accuracy circle.

- **Off → Active**: starts GPS polling; map follows position
- **Active → Passive**: triggered automatically when user pans; dot stays visible but camera doesn't follow
- **Passive → Active**: button tap flies back to current position with smooth animation
- **Blue dot**: `L.divIcon` with CSS `@keyframes` pulse ring, white border, drop shadow
- **Accuracy circle**: translucent `#4285F4` fill, no stroke; opacity fades as accuracy improves
- **Signal loss**: dot turns gray (pulse suppressed), toast notification shown
- **Permission check**: `navigator.permissions.query({ name: 'geolocation' })` before prompting; graceful fallback if denied

## Changes

| File | What changed |
|------|-------------|
| `src/types.ts` | Added `LocateState` type; replaced `centering: boolean` with `locateState: LocateState`; added `locationMarker` and `accuracyCircle` refs; removed `initiateTracking` |
| `src/controls.ts` | Replaced `addCenteringControl` with `addLocateControl`; exported `updateLocateIcon(state)` for use in main.ts and location.ts |
| `src/location.ts` | Creates/updates persistent blue dot marker and accuracy circle in-place; calls `updateLocateIcon`; added `onLocationError` for signal-loss handling |
| `src/style.css` | Blue dot + pulse animation; gray dot variant; toast notification styles |
| `src/main.ts` | Three-state click handler with permission check; `dragstart` listener for active→passive transition; `locationerror` wired to signal-loss handler + toast |

## Test plan

- [ ] Tap locate button → activates (blue icon), GPS polling starts, map follows position
- [ ] Pan map while following → button dims to passive (bw icon), panning works freely
- [ ] Tap button in passive state → flyTo animation re-centers, icon returns to active
- [ ] Tap button in active state → turns off, polling stops (unless tracking is also on)
- [ ] Tracking toggle remains independent of locate state
- [ ] Blue dot appears on first GPS fix with pulsing ring; updates position on subsequent fixes
- [ ] Accuracy circle scales and its opacity decreases as accuracy improves
- [ ] GPS signal loss → dot turns gray, toast "GPS signal lost" appears briefly
- [ ] Geolocation denied in browser → toast "Location access is denied..." shown, state stays off
- [ ] `npm run type-check && npm run lint && npm run build` all pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)