### PR TITLE
feat(recording): track recording UX with state machine, trail, and real-time stats

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -1,10 +1,11 @@
-// Intent: Handle GPS location events — apply haversine distance filter, draw accuracy
-//         circles, update icon states, and recenter the map
+// Intent: Handle GPS location events — apply haversine distance filter, update icon
+//         states, recenter the map, and append points to the active recording trail
 // Context: map.locate() fires 'locationfound' for every GPS fix. The haversine filter
 //          ignores updates where we haven't moved more than half the accuracy radius
 //          AND accuracy hasn't improved — reduces jitter when standing still.
 import L from 'leaflet';
 import type { AppState } from './types';
+import { appendTrailPoint } from './recording';
 
 export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map): void {
   // Haversine formula: great-circle distance between previous and current position
@@ -26,25 +27,9 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     state.youAreHereLocationlng = e.latlng.lng;
     state.youAreHereLocation = e.latlng;
 
-    if (state.tracking) {
-      // Blue dot for position, translucent circle for accuracy radius
-      L.circleMarker(e.latlng, { radius: 1, color: 'blue' }).addTo(map);
-      const opacity = Math.min(5 / e.accuracy, 1);
-      L.circle(e.latlng, {
-        radius: e.accuracy / 2,
-        opacity: 0,
-        fillOpacity: opacity,
-        color: 'blue',
-      }).addTo(map);
-    }
-  }
-
-  // Update icon states — icons turn from outline→color when actively working
-  if (state.tracking) {
-    const t_img = document.getElementById('tracking') as HTMLImageElement | null;
-    if (t_img) {
-      t_img.alt = t_img.title = 'Tracking Toggle (Enabled)';
-      t_img.src = '/logging-color-v1.1.svg';
+    if (state.recordingState === 'recording') {
+      const speedMs = isNaN(e.speed) ? 0 : e.speed;
+      appendTrailPoint(e.latlng, speedMs, state, map);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 // Intent: Application entry point — wires all modules together
 // Pattern: Single AppState object threaded through all modules by reference.
-//          updateCallback is a refcount so centering and tracking can independently
+//          updateCallback is a refcount so centering and recording can independently
 //          request/release the GPS polling loop without stepping on each other.
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -9,10 +9,11 @@ import './style.css';
 
 import { createInitialState } from './types';
 import { createMap } from './map';
-import { addClipboardControl, addCenteringControl, addTrackingControl } from './controls';
+import { addClipboardControl, addCenteringControl } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { onLocationFound } from './location';
 import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
+import { createStatsBar, addRecordingControl } from './recording';
 
 const state = createInitialState();
 const map = createMap();
@@ -20,7 +21,7 @@ const map = createMap();
 // Wire GPS location callback
 map.on('locationfound', (e: L.LocationEvent) => onLocationFound(e, state, map));
 
-// Polling refcount helpers — shared by centering and tracking
+// Polling refcount helpers — shared by centering and recording
 function activatePolling(): void {
   state.updateCallback += 1;
   if (state.updateCallback === 1) scheduleUpdateCallback(state, map);
@@ -61,27 +62,9 @@ addCenteringControl(map, () => {
   }
 });
 
-// Tracking: record GPS breadcrumb trail; also auto-enables centering on first activation
-addTrackingControl(map, () => {
-  state.tracking = !state.tracking;
-  if (state.tracking) {
-    if (state.initiateTracking) {
-      // First-ever tracking activation: auto-enable centering too
-      state.initiateTracking = false;
-      document.title = 'You are here';
-      state.centering = true;
-      activatePolling(); // centering's refcount
-    }
-    activatePolling(); // tracking's refcount
-  } else {
-    deactivatePolling(); // tracking's refcount
-    const img = document.getElementById('tracking') as HTMLImageElement | null;
-    if (img) {
-      img.alt = img.title = 'Tracking Toggle (Disabled)';
-      img.src = '/logging-lines-v1.1.svg';
-    }
-  }
-});
+// Recording: Start/Pause/Resume/Stop state machine with real-time stats and styled trail
+createStatsBar();
+addRecordingControl(map, state, activatePolling, deactivatePolling);
 
 addSearchControl(map, state);
 addReverseGeocoding(map, state);

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -1,0 +1,343 @@
+// Intent: Track recording state machine, trail visualization, and real-time stats overlay
+// Pattern: Plugs into AppState; exposes initRecording for main.ts wiring and
+//          appendTrailPoint for location.ts to call on each GPS fix.
+import L from 'leaflet';
+import type { AppState } from './types';
+
+const MIN_TRAIL_DIST_M = 5;   // minimum metres between trail points (GPS jitter filter)
+const MIN_ARROW_DIST_M = 50;  // minimum metres between direction-arrow markers
+
+// ── Geometry helpers ─────────────────────────────────────────────────────────
+
+function haversineM(a: L.LatLng, b: L.LatLng): number {
+  const R = 6371000;
+  const p = Math.PI / 180;
+  const dLat = (b.lat - a.lat) * p;
+  const dLng = (b.lng - a.lng) * p;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(a.lat * p) * Math.cos(b.lat * p) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function bearingDeg(a: L.LatLng, b: L.LatLng): number {
+  const p = Math.PI / 180;
+  const dLng = (b.lng - a.lng) * p;
+  const y = Math.sin(dLng) * Math.cos(b.lat * p);
+  const x =
+    Math.cos(a.lat * p) * Math.sin(b.lat * p) -
+    Math.sin(a.lat * p) * Math.cos(b.lat * p) * Math.cos(dLng);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+// ── Time and formatting helpers ──────────────────────────────────────────────
+
+function elapsedMs(state: AppState): number {
+  const currentPause =
+    state.recordingPauseStart !== null ? performance.now() - state.recordingPauseStart : 0;
+  return performance.now() - state.recordingStartMs - state.recordingPauseMs - currentPause;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${String(h)}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+function formatDistance(m: number): string {
+  return m >= 1000 ? `${(m / 1000).toFixed(2)} km` : `${Math.round(m)} m`;
+}
+
+function formatSpeed(ms: number): string {
+  const kmh = ms * 3.6;
+  return kmh < 0.5 ? '-- km/h' : `${kmh.toFixed(1)} km/h`;
+}
+
+// ── Stats bar DOM ─────────────────────────────────────────────────────────────
+
+export function createStatsBar(): void {
+  if (document.getElementById('recording-stats')) return;
+
+  const bar = document.createElement('div');
+  bar.id = 'recording-stats';
+  bar.style.display = 'none';
+  bar.innerHTML =
+    '<div class="rec-indicator">' +
+    '<span class="rec-dot"></span>' +
+    '<span id="rec-status-label">RECORDING</span>' +
+    '</div>' +
+    '<div class="stat-item">' +
+    '<span class="stat-label">Time</span>' +
+    '<span class="stat-value" id="stat-time">00:00</span>' +
+    '</div>' +
+    '<div class="stat-item">' +
+    '<span class="stat-label">Dist</span>' +
+    '<span class="stat-value" id="stat-dist">0 m</span>' +
+    '</div>' +
+    '<div class="stat-item">' +
+    '<span class="stat-label">Speed</span>' +
+    '<span class="stat-value" id="stat-speed">-- km/h</span>' +
+    '</div>';
+
+  document.getElementById('map')?.appendChild(bar);
+}
+
+function updateStatsBar(state: AppState): void {
+  const timeEl = document.getElementById('stat-time');
+  const distEl = document.getElementById('stat-dist');
+  const speedEl = document.getElementById('stat-speed');
+  const labelEl = document.getElementById('rec-status-label');
+  const dotEl = document.querySelector<HTMLElement>('.rec-dot');
+
+  if (timeEl) timeEl.textContent = formatElapsed(elapsedMs(state));
+  if (distEl) distEl.textContent = formatDistance(state.totalDistance);
+  if (speedEl) speedEl.textContent = formatSpeed(state.lastSpeedMs);
+  if (labelEl) labelEl.textContent = state.recordingState === 'paused' ? 'PAUSED' : 'RECORDING';
+  if (dotEl) {
+    if (state.recordingState === 'paused') {
+      dotEl.classList.add('rec-dot-paused');
+    } else {
+      dotEl.classList.remove('rec-dot-paused');
+    }
+  }
+}
+
+function setStatsBarVisible(visible: boolean): void {
+  const bar = document.getElementById('recording-stats');
+  if (bar) bar.style.display = visible ? 'flex' : 'none';
+}
+
+// ── Recording control panel ───────────────────────────────────────────────────
+
+let recControlContainer: HTMLElement | null = null;
+
+export function addRecordingControl(
+  map: L.Map,
+  state: AppState,
+  activatePolling: () => void,
+  deactivatePolling: () => void,
+): void {
+  const RecCtrl = L.Control.extend({
+    onAdd(): HTMLElement {
+      const container = L.DomUtil.create('div', 'recording-panel');
+      recControlContainer = container;
+      L.DomEvent.disableClickPropagation(container);
+      L.DomEvent.disableScrollPropagation(container);
+      renderButtons(state, activatePolling, deactivatePolling, map);
+      return container;
+    },
+  });
+
+  new (RecCtrl as new (opts: L.ControlOptions) => L.Control)({
+    position: 'bottomright',
+  }).addTo(map);
+}
+
+function renderButtons(
+  state: AppState,
+  activatePolling: () => void,
+  deactivatePolling: () => void,
+  map: L.Map,
+): void {
+  const c = recControlContainer;
+  if (!c) return;
+  c.innerHTML = '';
+
+  if (state.recordingState === 'idle') {
+    c.appendChild(
+      makeBtn('⏺ Record', 'rec-btn rec-btn-start', () => {
+        startRecording(state, map, activatePolling);
+        renderButtons(state, activatePolling, deactivatePolling, map);
+      }),
+    );
+  } else if (state.recordingState === 'recording') {
+    c.appendChild(
+      makeBtn('⏸ Pause', 'rec-btn rec-btn-pause', () => {
+        pauseRecording(state);
+        renderButtons(state, activatePolling, deactivatePolling, map);
+      }),
+    );
+    c.appendChild(
+      makeBtn('⏹ Stop', 'rec-btn rec-btn-stop', () => {
+        if (confirmStop()) {
+          stopRecording(state, deactivatePolling);
+          renderButtons(state, activatePolling, deactivatePolling, map);
+        }
+      }),
+    );
+  } else {
+    // paused
+    c.appendChild(
+      makeBtn('▶ Resume', 'rec-btn rec-btn-resume', () => {
+        resumeRecording(state);
+        renderButtons(state, activatePolling, deactivatePolling, map);
+      }),
+    );
+    c.appendChild(
+      makeBtn('⏹ Stop', 'rec-btn rec-btn-stop', () => {
+        if (confirmStop()) {
+          stopRecording(state, deactivatePolling);
+          renderButtons(state, activatePolling, deactivatePolling, map);
+        }
+      }),
+    );
+  }
+}
+
+function makeBtn(label: string, className: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.className = className;
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function confirmStop(): boolean {
+  return confirm('Stop recording? The track will be finalized.');
+}
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+function startRecording(
+  state: AppState,
+  map: L.Map,
+  activatePolling: () => void,
+): void {
+  // Clear any trail left from a previous session
+  if (state.trail) {
+    map.removeLayer(state.trail);
+    state.trail = null;
+  }
+  if (state.trailGlow) {
+    map.removeLayer(state.trailGlow);
+    state.trailGlow = null;
+  }
+  state.arrowMarkers.forEach((m) => map.removeLayer(m));
+  state.arrowMarkers = [];
+
+  state.recordingState = 'recording';
+  state.recordingStartMs = performance.now();
+  state.recordingPauseMs = 0;
+  state.recordingPauseStart = null;
+  state.totalDistance = 0;
+  state.lastTrailPoint = null;
+  state.lastArrowPoint = null;
+  state.lastSpeedMs = 0;
+
+  // Glow layer beneath the main trail line
+  state.trailGlow = L.polyline([], {
+    color: 'rgba(66,135,245,0.25)',
+    weight: 14,
+    smoothFactor: 2,
+    interactive: false,
+  }).addTo(map);
+
+  // Main trail line
+  state.trail = L.polyline([], {
+    color: '#4287f5',
+    weight: 4,
+    smoothFactor: 2,
+    interactive: false,
+  }).addTo(map);
+
+  // Auto-enable centering on first recording activation (mirrors prior tracking behavior)
+  if (state.initiateTracking) {
+    state.initiateTracking = false;
+    document.title = 'You are here';
+    state.centering = true;
+    activatePolling(); // centering refcount
+  }
+
+  state.tracking = true;
+  activatePolling(); // tracking refcount
+
+  setStatsBarVisible(true);
+  if (state.statsTimer !== null) clearInterval(state.statsTimer);
+  state.statsTimer = setInterval(() => updateStatsBar(state), 1000);
+}
+
+function pauseRecording(state: AppState): void {
+  if (state.recordingState !== 'recording') return;
+  state.recordingState = 'paused';
+  state.recordingPauseStart = performance.now();
+  updateStatsBar(state);
+}
+
+function resumeRecording(state: AppState): void {
+  if (state.recordingState !== 'paused') return;
+  if (state.recordingPauseStart !== null) {
+    state.recordingPauseMs += performance.now() - state.recordingPauseStart;
+  }
+  state.recordingPauseStart = null;
+  state.recordingState = 'recording';
+  updateStatsBar(state);
+}
+
+function stopRecording(state: AppState, deactivatePolling: () => void): void {
+  if (state.recordingState === 'idle') return;
+  state.recordingState = 'idle';
+  state.tracking = false;
+  deactivatePolling(); // tracking refcount
+
+  if (state.statsTimer !== null) {
+    clearInterval(state.statsTimer);
+    state.statsTimer = null;
+  }
+  setStatsBarVisible(false);
+}
+
+// ── Trail point appending (called from location.ts) ───────────────────────────
+
+export function appendTrailPoint(
+  latlng: L.LatLng,
+  speedMs: number,
+  state: AppState,
+  map: L.Map,
+): void {
+  if (state.recordingState !== 'recording') return;
+
+  state.lastSpeedMs = speedMs;
+
+  if (state.lastTrailPoint !== null) {
+    const dist = haversineM(state.lastTrailPoint, latlng);
+    if (dist < MIN_TRAIL_DIST_M) return; // jitter filter
+    state.totalDistance += dist;
+  }
+
+  state.trail?.addLatLng(latlng);
+  state.trailGlow?.addLatLng(latlng);
+  state.lastTrailPoint = latlng;
+
+  // Direction arrow: add between lastArrowPoint and current point when far enough apart
+  if (state.lastArrowPoint !== null) {
+    const arrowDist = haversineM(state.lastArrowPoint, latlng);
+    if (arrowDist >= MIN_ARROW_DIST_M) {
+      addArrowMarker(state.lastArrowPoint, latlng, state, map);
+      state.lastArrowPoint = latlng;
+    }
+  } else {
+    state.lastArrowPoint = latlng;
+  }
+}
+
+function addArrowMarker(
+  from: L.LatLng,
+  to: L.LatLng,
+  state: AppState,
+  map: L.Map,
+): void {
+  const bearing = bearingDeg(from, to);
+  const icon = L.divIcon({
+    html: `<div class="trail-arrow" style="transform:rotate(${String(bearing)}deg)">▲</div>`,
+    className: '',
+    iconSize: [16, 16],
+    iconAnchor: [8, 8],
+  });
+  const mid = L.latLng((from.lat + to.lat) / 2, (from.lng + to.lng) / 2);
+  const marker = L.marker(mid, { icon, interactive: false }).addTo(map);
+  state.arrowMarkers.push(marker);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -11,3 +11,115 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   -webkit-filter: grayscale(0);
   filter: none;
 }
+
+/* ── Recording stats bar ──────────────────────────────────────────────────── */
+#recording-stats {
+  position: absolute;
+  bottom: 110px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  padding: 7px 14px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  z-index: 1000;
+  pointer-events: none;
+  white-space: nowrap;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+}
+
+.rec-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rec-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #ef4444;
+  animation: rec-pulse 1s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+.rec-dot-paused {
+  animation: none;
+  background: #f59e0b;
+}
+
+@keyframes rec-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.25; }
+}
+
+#rec-status-label {
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: #ef4444;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.stat-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.65;
+}
+
+.stat-value {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* ── Recording control panel ─────────────────────────────────────────────── */
+.recording-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.rec-btn {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  transition: opacity 0.15s;
+}
+
+.rec-btn:active {
+  opacity: 0.8;
+}
+
+.rec-btn-start  { background: #22c55e; color: #fff; }
+.rec-btn-pause  { background: #f59e0b; color: #fff; }
+.rec-btn-resume { background: #22c55e; color: #fff; }
+.rec-btn-stop   { background: #ef4444; color: #fff; }
+
+/* ── Trail direction arrows ──────────────────────────────────────────────── */
+.trail-arrow {
+  color: #4287f5;
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+  width: 16px;
+  height: 16px;
+  text-shadow: 0 0 3px #fff, 0 0 3px #fff;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@
 //          modules mutate it directly (no event bus needed for this size app)
 import type L from 'leaflet';
 
+export type RecordingState = 'idle' | 'recording' | 'paused';
+
 export interface AppState {
   // GPS position tracking
   youAreHereLocation: L.LatLng | null;
@@ -14,12 +16,26 @@ export interface AppState {
   copyToClipboard: boolean;
   centering: boolean;
   tracking: boolean;
-  initiateTracking: boolean; // true until first tracking activation (triggers auto-centering)
+  initiateTracking: boolean; // true until first recording activation (triggers auto-centering)
 
   // Timer/polling state
   updateCallback: number; // refcount: 0=stopped, 1=centering, 2=centering+tracking
   timer: ReturnType<typeof setTimeout> | undefined;
   initialZoom: boolean; // true until first GPS fix; zooms to level 16 on first fix
+
+  // Recording state machine
+  recordingState: RecordingState;
+  recordingStartMs: number;        // performance.now() when recording began
+  recordingPauseMs: number;        // total accumulated pause duration in ms
+  recordingPauseStart: number | null; // performance.now() when current pause began
+  totalDistance: number;           // total meters traveled during recording
+  lastTrailPoint: L.LatLng | null; // last appended trail point (distance filter)
+  lastArrowPoint: L.LatLng | null; // last arrow marker point (spacing filter)
+  lastSpeedMs: number;             // m/s from most recent GPS fix
+  trail: L.Polyline | null;
+  trailGlow: L.Polyline | null;
+  arrowMarkers: L.Marker[];
+  statsTimer: ReturnType<typeof setInterval> | null;
 }
 
 export function createInitialState(): AppState {
@@ -35,5 +51,17 @@ export function createInitialState(): AppState {
     updateCallback: 0,
     timer: undefined,
     initialZoom: true,
+    recordingState: 'idle',
+    recordingStartMs: 0,
+    recordingPauseMs: 0,
+    recordingPauseStart: null,
+    totalDistance: 0,
+    lastTrailPoint: null,
+    lastArrowPoint: null,
+    lastSpeedMs: 0,
+    trail: null,
+    trailGlow: null,
+    arrowMarkers: [],
+    statsTimer: null,
   };
 }


### PR DESCRIPTION
## Summary

Upgrades the breadcrumb trail recording from a binary toggle into a proper **Start → Recording → Paused → Stopped** state machine with styled trail visualization and a real-time stats overlay.

## Changes

- **`src/recording.ts`** (new) — isolated recording module: state machine, trail drawing, stats bar, direction arrows
- **`src/types.ts`** — extended `AppState` with `RecordingState`, trail polylines, distance/speed accumulators, stats timer
- **`src/location.ts`** — calls `appendTrailPoint` on each GPS fix when recording; removed individual dot/circle accumulation
- **`src/main.ts`** — replaced tracking toggle with `addRecordingControl`; wires `activatePolling`/`deactivatePolling` to recording module
- **`src/style.css`** — stats bar, pulsing recording indicator, Start/Pause/Resume/Stop button styles, trail arrow styles

### Feature highlights

| Feature | Implementation |
|---|---|
| State machine | `idle → recording → paused → idle` |
| Stop confirmation | `confirm()` dialog prevents accidental data loss |
| Stats overlay | Floating bottom-center bar: elapsed time, distance, speed |
| Pulsing indicator | CSS `@keyframes` red dot (amber when paused) |
| Trail glow | Wider semi-transparent polyline beneath main line |
| Canvas renderer | `preferCanvas: true` already set in `map.ts` |
| Distance filter | 5 m minimum between trail points (GPS jitter) |
| Direction arrows | `L.divIcon` rotated to bearing every 50 m |
| Auto-centering | First recording activation still auto-enables centering |

## Test plan

- [ ] Tap **⏺ Record** — trail starts, stats bar appears with pulsing red dot
- [ ] Tap **⏸ Pause** — pulsing stops (amber dot), PAUSED label, elapsed time freezes
- [ ] Tap **▶ Resume** — recording resumes, elapsed time continues from where it left off
- [ ] Tap **⏹ Stop** — confirmation dialog appears; cancel keeps recording; confirm finalizes
- [ ] Trail displays glow (wide translucent) + solid line; direction arrows appear after 50 m
- [ ] Distance stat increments; speed shows km/h; time ticks every second
- [ ] Start new recording — old trail removed, fresh track begins
- [ ] `npm run type-check && npm run lint && npm run build` all pass

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)