### PR TITLE
feat(ui): mobile bottom sheet / desktop side panel for location info

### DIFF
--- a/src/bottom-sheet.ts
+++ b/src/bottom-sheet.ts
@@ -1,0 +1,227 @@
+// Intent: Mobile bottom sheet / desktop side panel for displaying location info.
+// Pattern: Module-level state; call initInfoPanel(map) once from main.ts before
+//          showSheet() can be used. On mobile (≤768px), renders as a three-snap-point
+//          bottom sheet with drag gesture support. On desktop (>768px), renders as a
+//          left-side slide-in panel.
+import L from 'leaflet';
+
+export type SnapPoint = 'hidden' | 'peek' | 'half' | 'full';
+
+export interface SheetContent {
+  title: string;
+  subtitle?: string;
+  bodyHtml: string;
+}
+
+const MOBILE_BREAKPOINT = 768;
+// Sheet occupies 90vh on mobile (partially revealed via translateY)
+const SHEET_VH = 0.9;
+const HALF_VH = 0.45;
+const PEEK_PX = 72; // visible px at peek snap
+
+// Module state
+let _map: L.Map | null = null;
+let _el: HTMLElement | null = null;
+let _snap: SnapPoint = 'hidden';
+let _mapOffsetPx = 0; // accumulated panBy offset so we can reverse it
+
+// Drag state (mobile only)
+let _isDragging = false;
+let _dragStartY = 0;
+let _dragStartSnap: SnapPoint = 'hidden';
+
+function isMobile(): boolean {
+  return window.innerWidth <= MOBILE_BREAKPOINT;
+}
+
+function fullHeightPx(): number {
+  return Math.round(window.innerHeight * SHEET_VH);
+}
+
+// Returns translateY value (px) for each snap point.
+// 0 = fully visible; fullHeightPx()+8 = fully off-screen below.
+function snapToPx(snap: SnapPoint): number {
+  const h = fullHeightPx();
+  switch (snap) {
+    case 'hidden':
+      return h + 8;
+    case 'peek':
+      return h - PEEK_PX;
+    case 'half':
+      return h - Math.round(window.innerHeight * HALF_VH);
+    case 'full':
+      return 0;
+  }
+}
+
+// Pan map to compensate for sheet height, then track the accumulated offset
+// so we can undo it when the sheet snaps to a different position.
+function setMapOffset(targetPx: number): void {
+  if (_map === null) return;
+  const delta = targetPx - _mapOffsetPx;
+  if (delta !== 0) {
+    _map.panBy(L.point(0, delta), { animate: true, duration: 0.3 });
+    _mapOffsetPx = targetPx;
+  }
+}
+
+function snapTo(snap: SnapPoint, animated = true): void {
+  if (_el === null) return;
+  _snap = snap;
+
+  if (isMobile()) {
+    const px = snapToPx(snap);
+    _el.style.transition = animated ? 'transform 0.3s ease' : 'none';
+    _el.style.transform = `translateY(${px}px)`;
+    // Shift map center upward when sheet is at half height so the POI stays visible
+    const offset = snap === 'half' ? Math.round(window.innerHeight * HALF_VH / 3) : 0;
+    setMapOffset(offset);
+  } else {
+    _el.classList.toggle('info-panel--visible', snap !== 'hidden');
+    setMapOffset(0);
+  }
+
+  _el.setAttribute('aria-hidden', String(snap === 'hidden'));
+}
+
+// ── Touch / drag handlers ────────────────────────────────────────────────────
+
+function onHandleTouchStart(e: TouchEvent): void {
+  if (!isMobile()) return;
+  const touch = e.touches[0];
+  if (touch === undefined) return;
+  _isDragging = true;
+  _dragStartY = touch.clientY;
+  _dragStartSnap = _snap;
+  if (_el) _el.style.transition = 'none';
+}
+
+function onDocTouchMove(e: TouchEvent): void {
+  if (!_isDragging || _snap === 'hidden' || _el === null) return;
+  const touch = e.touches[0];
+  if (touch === undefined) return;
+  const delta = touch.clientY - _dragStartY;
+  const basePx = snapToPx(_dragStartSnap);
+  const maxPx = fullHeightPx() + 8;
+  const newPx = Math.max(0, Math.min(maxPx, basePx + delta));
+  _el.style.transform = `translateY(${newPx}px)`;
+  e.preventDefault(); // passive: false on listener — prevents page scroll during drag
+}
+
+function onDocTouchEnd(e: TouchEvent): void {
+  if (!_isDragging) return;
+  _isDragging = false;
+  const touch = e.changedTouches[0];
+  if (touch === undefined) {
+    snapTo(_dragStartSnap);
+    return;
+  }
+
+  const delta = touch.clientY - _dragStartY;
+  const downOrder: SnapPoint[] = ['full', 'half', 'peek', 'hidden'];
+  const upOrder: SnapPoint[] = ['hidden', 'peek', 'half', 'full'];
+  let target: SnapPoint;
+
+  if (delta > 60) {
+    // Swipe down → next lower snap
+    const idx = downOrder.indexOf(_dragStartSnap);
+    target = downOrder[idx + 1] ?? 'hidden';
+  } else if (delta < -60) {
+    // Swipe up → next higher snap
+    const idx = upOrder.indexOf(_dragStartSnap);
+    target = upOrder[idx + 1] ?? 'full';
+  } else {
+    target = _dragStartSnap;
+  }
+
+  snapTo(target);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export function initInfoPanel(map: L.Map): void {
+  _map = map;
+
+  const el = document.createElement('div');
+  el.id = 'info-panel';
+  el.className = 'info-panel';
+  el.setAttribute('role', 'complementary');
+  el.setAttribute('aria-label', 'Location information');
+  el.setAttribute('aria-hidden', 'true');
+
+  el.innerHTML =
+    '<div class="info-panel__handle-area">' +
+    '  <div class="info-panel__handle" aria-hidden="true"></div>' +
+    '</div>' +
+    '<div class="info-panel__header">' +
+    '  <div>' +
+    '    <div class="info-panel__title"></div>' +
+    '    <div class="info-panel__subtitle"></div>' +
+    '  </div>' +
+    '  <button class="info-panel__close" aria-label="Close">&#x2715;</button>' +
+    '</div>' +
+    '<div class="info-panel__body"></div>';
+
+  // Set initial off-screen position before appending (prevents flash)
+  el.style.transition = 'none';
+  el.style.transform = `translateY(${fullHeightPx() + 8}px)`;
+
+  document.body.appendChild(el);
+  _el = el;
+
+  // Close button
+  const closeBtn = el.querySelector('.info-panel__close') as HTMLButtonElement;
+  closeBtn.addEventListener('click', () => snapTo('hidden'));
+
+  // Drag handle (mobile)
+  const handleArea = el.querySelector('.info-panel__handle-area') as HTMLElement;
+  handleArea.addEventListener('touchstart', onHandleTouchStart, { passive: true });
+  document.addEventListener('touchmove', onDocTouchMove, { passive: false });
+  document.addEventListener('touchend', onDocTouchEnd, { passive: true });
+
+  // Keyboard dismiss
+  document.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && _snap !== 'hidden') snapTo('hidden');
+  });
+
+  const bodyEl = el.querySelector('.info-panel__body') as HTMLElement;
+
+  // Event delegation: click a result item → fly to its location
+  bodyEl.addEventListener('click', (e: MouseEvent) => {
+    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-lat]');
+    if (target === null || _map === null) return;
+    const lat = parseFloat(target.dataset['lat'] ?? '');
+    const lng = parseFloat(target.dataset['lng'] ?? '');
+    if (!isNaN(lat) && !isNaN(lng)) {
+      _map.flyTo(L.latLng(lat, lng), _map.getZoom());
+      snapTo('peek');
+    }
+  });
+
+  // Event delegation: click a copy button → write to clipboard
+  bodyEl.addEventListener('click', (e: MouseEvent) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-copy]');
+    if (btn === null) return;
+    const text = btn.dataset['copy'] ?? '';
+    navigator.clipboard.writeText(text).catch((err: unknown) => {
+      alert(String(err));
+    });
+  });
+}
+
+// Show the panel with new content. If already open, keeps the current snap point.
+// If hidden, opens to `initialSnap` (defaults to 'half').
+export function showSheet(content: SheetContent, initialSnap: SnapPoint = 'half'): void {
+  if (_el === null) return;
+  const titleEl = _el.querySelector('.info-panel__title');
+  const subtitleEl = _el.querySelector('.info-panel__subtitle');
+  const bodyEl = _el.querySelector('.info-panel__body');
+  if (titleEl) titleEl.textContent = content.title;
+  if (subtitleEl) subtitleEl.textContent = content.subtitle ?? '';
+  if (bodyEl) bodyEl.innerHTML = content.bodyHtml;
+  snapTo(_snap === 'hidden' ? initialSnap : _snap);
+}
+
+export function hideSheet(): void {
+  snapTo('hidden');
+}

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -3,9 +3,21 @@
 // Context: geosearch provides the search UI; geocodeService powers reverse geocode.
 //          Both use the VITE_ESRI_API_KEY env var for authentication.
 //          contextmenu fires on right-click (desktop) and long-press (most mobile browsers).
+//          Results are displayed in the bottom sheet (mobile) / side panel (desktop)
+//          rather than Leaflet popups.
 import L from 'leaflet';
 import { geosearch, arcgisOnlineProvider, geocodeService } from 'esri-leaflet-geocoder';
 import type { AppState } from './types';
+import { showSheet } from './bottom-sheet';
+
+// Escape text for safe insertion into innerHTML
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 export function addSearchControl(map: L.Map, state: AppState): void {
   // state is read in the results callback (for future extensibility)
@@ -30,12 +42,38 @@ export function addSearchControl(map: L.Map, state: AppState): void {
     results.clearLayers();
     if (data.results.length) {
       document.title = data.text;
+
+      // Add markers (no popup — info panel handles the UI)
       for (let i = data.results.length - 1; i >= 0; i--) {
         const result = data.results[i];
         if (result) {
-          results.addLayer(L.marker(result.latlng).bindPopup(result.text).openPopup());
+          results.addLayer(L.marker(result.latlng));
         }
       }
+
+      // Build results list for the info panel
+      const itemsHtml = data.results
+        .map((r) => {
+          if (!r) return '';
+          const name = escapeHtml(r.text);
+          const lat = r.latlng.lat.toFixed(6);
+          const lng = r.latlng.lng.toFixed(6);
+          return (
+            `<li class="sheet-result" data-lat="${lat}" data-lng="${lng}">` +
+            `  <span class="sheet-result__name">${name}</span>` +
+            `  <span class="sheet-result__arrow">&#x203A;</span>` +
+            `</li>`
+          );
+        })
+        .join('');
+
+      const count = data.results.length;
+      showSheet({
+        title: escapeHtml(data.text),
+        subtitle: count === 1 ? '1 result' : `${count} results`,
+        bodyHtml: `<ul class="sheet-results">${itemsHtml}</ul>`,
+      });
+
       // Smooth flyTo animation to the first result
       const firstResult = data.results[0];
       if (firstResult) {
@@ -57,23 +95,41 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   // Disable double-click zoom so dblclick can drop a pin instead
   map.doubleClickZoom.disable();
 
-  function reverseGeocode(pin: L.Marker, latlng: L.LatLng): void {
+  function reverseGeocode(latlng: L.LatLng): void {
     geocoder
       .reverse()
       .latlng(latlng)
       .run((error, result) => {
         if (error || !result) return;
         const addr = result.address.Match_addr;
-        const coords = `${latlng.lat.toFixed(6)}, ${latlng.lng.toFixed(6)}`;
+
+        // Auto-copy if clipboard toggle is enabled
         if (state.copyToClipboard) {
-          navigator.clipboard
-            .writeText(addr)
-            .catch((err: unknown) => {
-              alert(String(err));
-            });
+          navigator.clipboard.writeText(addr).catch((err: unknown) => {
+            alert(String(err));
+          });
         }
         if (!state.tracking) document.title = addr;
-        pin.bindPopup(`<strong>${addr}</strong><br><small>${coords}</small>`).openPopup();
+
+        // Format coordinates for display
+        const lat = latlng.lat;
+        const lng = latlng.lng;
+        const latStr = `${Math.abs(lat).toFixed(6)}\u00b0\u00a0${lat >= 0 ? 'N' : 'S'}`;
+        const lngStr = `${Math.abs(lng).toFixed(6)}\u00b0\u00a0${lng >= 0 ? 'E' : 'W'}`;
+        const addrEsc = escapeHtml(addr);
+
+        showSheet({
+          title: addrEsc,
+          subtitle: `${latStr},  ${lngStr}`,
+          bodyHtml:
+            `<div class="sheet-address">` +
+            `  <div class="sheet-address__line">${addrEsc}</div>` +
+            `  <div class="sheet-address__coords">${latStr} &nbsp; ${lngStr}</div>` +
+            `</div>` +
+            `<div class="sheet-actions">` +
+            `  <button class="sheet-btn" data-copy="${escapeHtml(addr)}">Copy address</button>` +
+            `</div>`,
+        });
       });
   }
 
@@ -81,14 +137,14 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     pinLayer.clearLayers();
     const pin = L.marker(latlng, { draggable: true });
     pinLayer.addLayer(pin);
-    reverseGeocode(pin, latlng);
+    reverseGeocode(latlng);
 
     // Debounced reverse geocode as pin is dragged to a new location
     let dragDebounce: ReturnType<typeof setTimeout> | undefined;
     pin.on('dragend', () => {
       if (dragDebounce !== undefined) clearTimeout(dragDebounce);
       dragDebounce = setTimeout(() => {
-        reverseGeocode(pin, pin.getLatLng());
+        reverseGeocode(pin.getLatLng());
       }, 300);
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { createInitialState } from './types';
 import { createMap } from './map';
 import { addClipboardControl, addCenteringControl } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
+import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound } from './location';
 import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
 import { createStatsBar, addRecordingControl } from './recording';
@@ -66,6 +67,7 @@ addCenteringControl(map, () => {
 createStatsBar();
 addRecordingControl(map, state, activatePolling, deactivatePolling);
 
+initInfoPanel(map);
 addSearchControl(map, state);
 addReverseGeocoding(map, state);
 

--- a/src/style.css
+++ b/src/style.css
@@ -123,3 +123,196 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   height: 16px;
   text-shadow: 0 0 3px #fff, 0 0 3px #fff;
 }
+
+/* ===== Info Panel ===== */
+/* Mobile (≤768px): bottom sheet with three snap points (peek / half / full).  */
+/* Desktop (>768px): left-side slide-in panel (Google Maps desktop pattern).   */
+
+.info-panel {
+  position: fixed;
+  z-index: 1000;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  /* will-change: transform enables GPU compositing for smooth animation */
+  will-change: transform;
+}
+
+/* ── Mobile bottom sheet ── */
+@media (max-width: 768px) {
+  .info-panel {
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 90vh;
+    border-radius: 12px 12px 0 0;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
+    /* JS sets transform directly; this is just a safe CSS fallback */
+    transform: translateY(110%);
+    overflow: hidden;
+  }
+}
+
+/* ── Desktop side panel ── */
+@media (min-width: 769px) {
+  .info-panel {
+    top: 0;
+    left: -380px;
+    bottom: 0;
+    width: 360px;
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.15);
+    transition: left 0.3s ease;
+    overflow-y: auto;
+  }
+
+  .info-panel--visible {
+    left: 0;
+  }
+}
+
+/* ── Drag handle (mobile only) ── */
+.info-panel__handle-area {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 6px;
+  cursor: grab;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+@media (min-width: 769px) {
+  .info-panel__handle-area {
+    display: none;
+  }
+}
+
+.info-panel__handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: #ccc;
+}
+
+/* ── Header ── */
+.info-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 8px 16px 12px;
+  border-bottom: 1px solid #eee;
+  flex-shrink: 0;
+}
+
+.info-panel__title {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #222;
+}
+
+.info-panel__subtitle {
+  font-size: 13px;
+  color: #666;
+  margin-top: 2px;
+}
+
+.info-panel__close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #888;
+  padding: 0 0 0 10px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.info-panel__close:hover {
+  color: #333;
+}
+
+/* ── Scrollable body ── */
+.info-panel__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Search results list ── */
+.sheet-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sheet-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 4px;
+  border-bottom: 1px solid #f0f0f0;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 6px;
+}
+
+.sheet-result:last-child {
+  border-bottom: none;
+}
+
+.sheet-result:hover,
+.sheet-result:active {
+  background: #f5f5f5;
+}
+
+.sheet-result__name {
+  font-size: 14px;
+  color: #333;
+  flex: 1;
+}
+
+.sheet-result__arrow {
+  color: #bbb;
+  font-size: 18px;
+  margin-left: 8px;
+}
+
+/* ── Reverse geocode address view ── */
+.sheet-address {
+  margin-bottom: 16px;
+}
+
+.sheet-address__line {
+  font-size: 15px;
+  color: #222;
+  line-height: 1.4;
+  margin-bottom: 6px;
+}
+
+.sheet-address__coords {
+  font-size: 12px;
+  color: #888;
+  font-family: monospace;
+}
+
+.sheet-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sheet-btn {
+  background: #007aff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.sheet-btn:hover {
+  background: #0066dd;
+}


### PR DESCRIPTION
## Summary

Implements a responsive info panel that replaces Leaflet popups for search results and reverse geocoding:

- **Mobile (≤768px)**: Three-snap-point bottom sheet (peek 72px / half 45vh / full 90vh) with drag handle and swipe gestures
- **Desktop (>768px)**: Left-side slide-in panel (Google Maps desktop pattern)

## Changes

- `src/bottom-sheet.ts` (new): Full info panel module — snap logic, touch drag gesture, map center offset via `map.panBy()`, event delegation for result clicks and address copy, keyboard Escape dismiss
- `src/style.css`: Panel styles — mobile bottom sheet with `border-radius` and `box-shadow`, desktop slide-in, handle bar, results list, address view, copy button
- `src/geocoding.ts`: Replace `bindPopup().openPopup()` with `showSheet()`; keep draggable pin, contextmenu, flyTo, and debounce from mainline; add `escapeHtml` for XSS safety
- `src/main.ts`: Add `initInfoPanel(map)` call before geocoding setup

## Test plan

- [ ] Mobile: search for a place → bottom sheet opens at half height with results list; tap result → flies to location, sheet snaps to peek
- [ ] Mobile: double-tap or long-press map → draggable pin dropped, sheet shows address and coords; drag pin → sheet updates (debounced)
- [ ] Mobile: swipe sheet up/down → snaps between peek / half / full
- [ ] Mobile: map center shifts upward when sheet is at half height
- [ ] Mobile: Escape key or ✕ button dismisses sheet
- [ ] Desktop: search or pin drop → left panel slides in; ✕ closes it
- [ ] Quality gate: `npm run type-check && npm run lint && npm run build` all pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)