### PR TITLE
fix(geocoding): search bar not returning results and silent API key failure

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -24,12 +24,25 @@ export function addSearchControl(map: L.Map, state: AppState): void {
   void state;
 
   const apikey = import.meta.env.VITE_ESRI_API_KEY;
+
+  // Warn if API key is missing at startup
+  if (!apikey) {
+    console.warn(
+      'VITE_ESRI_API_KEY is not configured. ' +
+      'Search functionality will not work. ' +
+      'Set VITE_ESRI_API_KEY in your .env file.'
+    );
+  }
+
+  // Disable useMapBounds: at low zoom (initial map view), the visible bbox is the
+  // entire world, causing ESRI to return no results. Instead, rely on ESRI's
+  // location biasing which intelligently prioritizes results near the map center.
   const searchControl = geosearch({
     placeholder: '',
-    title: 'Search for places or addresses within visible region',
+    title: 'Search for places or addresses',
     position: 'topleft',
     expanded: false,
-    useMapBounds: true,
+    useMapBounds: false,
     zoomToResult: false,
     minCharacters: 3,
     debounceDelay: 250,


### PR DESCRIPTION
## Summary

The search bar (ESRI geocoder control) had two critical bugs preventing it from returning results:
1. Missing `VITE_ESRI_API_KEY` caused silent API failures with no user feedback
2. `useMapBounds: true` at initial zoom (level 2, world view) created an oversized bounding box that caused ESRI to return no results

## Root Cause Analysis

**Bug 1 — Silent API key failure:**
The geocoder was passed `apikey = undefined` when `VITE_ESRI_API_KEY` was not set, resulting in silent 401 errors with no visible indication to the user. The geocoder simply returned no results.

**Bug 2 — useMapBounds at low zoom:**
`useMapBounds: true` restricts search results to the visible map region. At the initial zoom level (2), the visible area is the entire world — so large that ESRI's API returns no results or irrelevant ones. This is especially problematic for new users who haven't zoomed in yet.

## Changes

1. **Added API key validation**: Console warning at startup if `VITE_ESRI_API_KEY` is missing or falsy
2. **Disabled useMapBounds**: Removed the restriction to visible bounds; instead rely on ESRI's built-in location biasing, which intelligently prioritizes results near the map center
3. **Updated control title**: Changed from "Search for places or addresses within visible region" to just "Search for places or addresses" to reflect the new behavior

## Test Plan

- [ ] Search works at initial zoom level (world view)
- [ ] Search works at high zoom levels
- [ ] Search results display in bottom sheet
- [ ] Clicking a result flies to that location
- [ ] With `VITE_ESRI_API_KEY` missing, console shows warning and search gracefully fails
- [ ] Type-check, lint, and build all pass

Closes #17