### PR TITLE
feat(ui): display version badge overlay in upper-right corner

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,6 +138,12 @@ initInfoPanel(map);
 addSearchControl(map, state);
 addReverseGeocoding(map, state);
 
+// ── Version badge ─────────────────────────────────────────────────────────────
+const versionBadge = document.createElement('div');
+versionBadge.id = 'version-badge';
+versionBadge.textContent = `v${__APP_VERSION__}`;
+document.getElementById('map')?.appendChild(versionBadge);
+
 // Focus map for keyboard zoom shortcuts
 document.getElementById('map')?.focus();
 document.body.style.zoom = '100%';

--- a/src/style.css
+++ b/src/style.css
@@ -520,3 +520,20 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
     font-size: 11px;
   }
 }
+
+/* ── Version badge ───────────────────────────────────────────────────────────── */
+
+#version-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 500;
+  background: rgba(255, 255, 255, 0.65);
+  color: #333;
+  font-size: 10px;
+  font-family: monospace;
+  padding: 2px 6px;
+  border-radius: 3px;
+  pointer-events: none;
+  user-select: none;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string;
+
 interface ImportMetaEnv {
   readonly VITE_MAPBOX_TOKEN: string;
   readonly VITE_ESRI_API_KEY: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
## Summary

- Adds a small version badge (e.g. `v0.3.0-beta`) in the upper-right corner of the map
- Version is injected at build time via Vite `define` — always reflects the current `package.json` version, no runtime fetch needed
- Badge is unobtrusive: 10px monospace, semi-transparent white background, `pointer-events: none`

## Changes

- `vite.config.ts` — adds `define: { __APP_VERSION__ }` to expose version at build time
- `src/vite-env.d.ts` — adds `declare const __APP_VERSION__: string`
- `src/main.ts` — creates and appends the badge element
- `src/style.css` — adds `#version-badge` styles

## Test plan

- [ ] `npm run type-check && npm run lint && npm run build` passes
- [ ] `v0.3.0-beta` badge visible in upper-right corner of the map
- [ ] Badge does not block map tiles or interactive controls
- [ ] Badge updates automatically when `package.json` version changes (rebuild to verify)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)