### PR TITLE
fix(location): request GPS within user gesture for iOS permission prompt

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,9 @@ addClipboardControl(map, () => {
 
 function startLocating(): void {
   state.locateState = 'active';
+  // Request location immediately within the user gesture so iOS Safari
+  // shows the permission prompt (the gesture expires before the 500ms polling timer fires)
+  map.locate({ setView: false, maxZoom: map.getZoom() });
   activatePolling();
   updateLocateIcon('active');
 }


### PR DESCRIPTION
## Summary

- Fixes iOS Safari not showing the location permission prompt when the user taps the centering or tracking button
- The root cause: `map.locate()` was only called after a 500ms polling timer, by which point the user gesture had expired and iOS silently denied the request
- Adds an immediate `map.locate()` call within the click handler so the browser recognizes it as a user-initiated action

## Changes

- `src/main.ts`: Call `map.locate()` synchronously when centering is enabled (before starting the polling loop)
- `src/main.ts`: Same fix in the tracking handler when it auto-enables centering on first activation

## Test plan

- [ ] On iOS Safari: tap centering button — location permission prompt should appear
- [ ] On iOS Safari: tap tracking button (first time) — location permission prompt should appear
- [ ] On desktop browsers: verify centering/tracking still work as before
- [ ] Verify toggling centering off and back on re-prompts correctly

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)