### PR TITLE
fix(recording): disable record button when location is off

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound, onLocationError } from './location';
 import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
-import { createStatsBar, addRecordingControl } from './recording';
+import { createStatsBar, addRecordingControl, updateRecordingButtons } from './recording';
 
 const state = createInitialState();
 const map = createMap();
@@ -95,11 +95,16 @@ addLocateControl(map, () => {
               showToast('Location access is denied. Enable it in browser settings.');
             } else {
               startLocating();
+              updateRecordingButtons();
             }
           })
-          .catch(() => startLocating()); // permissions API unavailable — just try
+          .catch(() => {
+            startLocating(); // permissions API unavailable — just try
+            updateRecordingButtons();
+          });
       } else {
         startLocating();
+        updateRecordingButtons();
       }
       break;
 
@@ -108,6 +113,7 @@ addLocateControl(map, () => {
       state.locateState = 'off';
       deactivatePolling();
       updateLocateIcon('off');
+      updateRecordingButtons();
       break;
 
     case 'passive':

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -3,7 +3,6 @@
 //          appendTrailPoint for location.ts to call on each GPS fix.
 import L from 'leaflet';
 import type { AppState } from './types';
-import { updateLocateIcon } from './controls';
 
 const MIN_TRAIL_DIST_M = 5;   // minimum metres between trail points (GPS jitter filter)
 const MIN_ARROW_DIST_M = 50;  // minimum metres between direction-arrow markers
@@ -116,12 +115,23 @@ function setStatsBarVisible(visible: boolean): void {
 
 let recControlContainer: HTMLElement | null = null;
 
+// Module-level refs so updateRecordingButtons can re-render from outside
+let storedState: AppState | null = null;
+let storedActivatePolling: (() => void) | null = null;
+let storedDeactivatePolling: (() => void) | null = null;
+let storedMap: L.Map | null = null;
+
 export function addRecordingControl(
   map: L.Map,
   state: AppState,
   activatePolling: () => void,
   deactivatePolling: () => void,
 ): void {
+  storedState = state;
+  storedActivatePolling = activatePolling;
+  storedDeactivatePolling = deactivatePolling;
+  storedMap = map;
+
   const RecCtrl = L.Control.extend({
     onAdd(): HTMLElement {
       const container = L.DomUtil.create('div', 'recording-panel');
@@ -138,6 +148,13 @@ export function addRecordingControl(
   }).addTo(map);
 }
 
+/** Re-render recording buttons (call when locate state changes) */
+export function updateRecordingButtons(): void {
+  if (storedState && storedActivatePolling && storedDeactivatePolling && storedMap) {
+    renderButtons(storedState, storedActivatePolling, storedDeactivatePolling, storedMap);
+  }
+}
+
 function renderButtons(
   state: AppState,
   activatePolling: () => void,
@@ -149,12 +166,15 @@ function renderButtons(
   c.innerHTML = '';
 
   if (state.recordingState === 'idle') {
-    c.appendChild(
-      makeBtn('⏺ Record', 'rec-btn rec-btn-start', () => {
-        startRecording(state, map, activatePolling);
-        renderButtons(state, activatePolling, deactivatePolling, map);
-      }),
-    );
+    const btn = makeBtn('⏺ Record', 'rec-btn rec-btn-start', () => {
+      startRecording(state, map, activatePolling);
+      renderButtons(state, activatePolling, deactivatePolling, map);
+    });
+    if (state.locateState === 'off') {
+      btn.disabled = true;
+      btn.title = 'Enable location first';
+    }
+    c.appendChild(btn);
   } else if (state.recordingState === 'recording') {
     c.appendChild(
       makeBtn('⏸ Pause', 'rec-btn rec-btn-pause', () => {
@@ -244,13 +264,6 @@ function startRecording(
     smoothFactor: 2,
     interactive: false,
   }).addTo(map);
-
-  // Auto-enable locate on first recording if locate is off — ensures the blue dot appears
-  if (state.locateState === 'off') {
-    state.locateState = 'active';
-    activatePolling(); // locate refcount
-    updateLocateIcon('active');
-  }
 
   activatePolling(); // recording refcount
 

--- a/src/style.css
+++ b/src/style.css
@@ -178,6 +178,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   opacity: 0.8;
 }
 
+.rec-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .rec-btn-start  { background: #22c55e; color: #fff; }
 .rec-btn-pause  { background: #f59e0b; color: #fff; }
 .rec-btn-resume { background: #22c55e; color: #fff; }


### PR DESCRIPTION
## Summary
- Disables the Record button when location (locate) is off, preventing users from starting a recording without GPS enabled
- Removes the auto-enable locate side-effect from `startRecording` — the button is now gated on locate state
- Adds `.rec-btn:disabled` CSS for visual feedback (reduced opacity, not-allowed cursor)

## Changes
- **`src/recording.ts`**: Exported `updateRecordingButtons()` so `main.ts` can re-render buttons on locate state changes; added `disabled` attribute and title to Record button when `locateState === 'off'`; removed auto-enable locate from `startRecording`
- **`src/main.ts`**: Calls `updateRecordingButtons()` after every locate state transition (off→active, active→off, permission denied path)
- **`src/style.css`**: Added `.rec-btn:disabled` style (opacity 0.4, cursor not-allowed)

## Test plan
- [ ] With location off, verify the Record button appears grayed out and is not clickable
- [ ] Enable location, verify the Record button becomes active and clickable
- [ ] Start recording, verify trail and stats work as before
- [ ] Disable location while recording is idle, verify Record button disables again
- [ ] On mobile: tap behavior matches desktop (touchend handler respects disabled state)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)