### PR TITLE
fix(ios): GPS and clipboard fail due to expired user gestures

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -108,28 +108,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   // Disable double-click zoom so dblclick can drop a pin instead
   map.doubleClickZoom.disable();
 
-  // Initiate a clipboard write within the current user-gesture context.
-  // Browsers gate navigator.clipboard on transient activation — by the time
-  // the async geocode response arrives the gesture has expired, so writeText
-  // fails silently. ClipboardItem accepts a Promise<Blob> that we resolve
-  // once the address is known, capturing the gesture at write() time.
-  function deferClipboardWrite(): ((text: string) => void) | undefined {
-    if (!state.copyToClipboard) return undefined;
-    if (typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) return undefined;
-
-    let resolveBlob: ((blob: Blob) => void) | undefined;
-    const blobPromise = new Promise<Blob>((r) => { resolveBlob = r; });
-
-    navigator.clipboard
-      .write([new ClipboardItem({ 'text/plain': blobPromise })])
-      .catch(() => {});
-
-    return (text: string) => {
-      resolveBlob?.(new Blob([text], { type: 'text/plain' }));
-    };
-  }
-
-  function reverseGeocode(latlng: L.LatLng, resolveClipboard?: (text: string) => void): void {
+  function reverseGeocode(latlng: L.LatLng): void {
     geocoder
       .reverse()
       .latlng(latlng)
@@ -137,13 +116,6 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
         if (error || !result) return;
         const addr = result.address.Match_addr;
 
-        // Prefer the deferred write (initiated during user gesture) if available,
-        // otherwise fall back to direct writeText (works in Chrome on HTTPS).
-        if (resolveClipboard) {
-          resolveClipboard(addr);
-        } else if (state.copyToClipboard) {
-          navigator.clipboard.writeText(addr).catch(() => {});
-        }
         if (state.recordingState === 'idle') document.title = addr;
 
         // Format coordinates for display
@@ -172,7 +144,16 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     pinLayer.clearLayers();
     const pin = L.marker(latlng, { draggable: true });
     pinLayer.addLayer(pin);
-    reverseGeocode(latlng, deferClipboardWrite());
+
+    // Copy coordinates to clipboard immediately within the user gesture.
+    // The address (resolved async via geocode) can be copied from the info
+    // sheet's "Copy address" button which provides its own user gesture.
+    if (state.copyToClipboard) {
+      const coords = `${latlng.lat.toFixed(6)}, ${latlng.lng.toFixed(6)}`;
+      navigator.clipboard.writeText(coords).catch(() => {});
+    }
+
+    reverseGeocode(latlng);
 
     // Debounced reverse geocode as pin is dragged to a new location
     let dragDebounce: ReturnType<typeof setTimeout> | undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,25 +89,23 @@ function startLocating(): void {
 addLocateControl(map, () => {
   switch (state.locateState) {
     case 'off':
-      // Check permission before prompting — gracefully degrade if denied
+      // Start locating synchronously so map.locate() fires within the user
+      // gesture — iOS Safari silently denies the permission prompt otherwise.
+      startLocating();
+      updateRecordingButtons();
+      // If permission was previously denied, show a toast and undo
       if ('permissions' in navigator) {
         navigator.permissions
           .query({ name: 'geolocation' })
           .then((result) => {
             if (result.state === 'denied') {
               showToast('Location access is denied. Enable it in browser settings.');
-            } else {
-              startLocating();
-              updateRecordingButtons();
+              state.locateState = 'off';
+              deactivatePolling();
+              updateLocateIcon('off');
             }
           })
-          .catch(() => {
-            startLocating(); // permissions API unavailable — just try
-            updateRecordingButtons();
-          });
-      } else {
-        startLocating();
-        updateRecordingButtons();
+          .catch(() => { /* permissions API unavailable — locate already in progress */ });
       }
       break;
 


### PR DESCRIPTION
## Summary

- Fixes GPS permission prompt not appearing on iOS Safari — `startLocating()` was called inside a `.then()` callback where the user gesture had expired; now called synchronously in the click handler
- Fixes clipboard copy failing on pin drop — removes the `ClipboardItem`/`Promise<Blob>` deferred pattern (Safari rejects when the promise takes too long to resolve); copies coordinates immediately within the gesture instead
- Both issues share the same root cause: iOS Safari strictly enforces user-gesture context for permission prompts and clipboard access

Closes #25

## Test plan

- [ ] iOS Safari: tap locate button → GPS permission prompt appears
- [ ] iOS Safari: double-tap or long-press to drop pin with clipboard toggle on → coordinates copied to clipboard
- [ ] iOS Safari: "Copy address" button in info sheet copies the resolved address
- [ ] Chrome desktop: same flows still work
- [ ] Previously denied GPS permission → toast shown, locate state rolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)