### PR TITLE
fix(ios): remove racy permissions check that breaks first Locate tap

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,18 @@ const map = createMap();
 
 // Wire GPS location callbacks
 map.on('locationfound', (e: L.LocationEvent) => onLocationFound(e, state, map));
-map.on('locationerror', () => {
+map.on('locationerror', (e: L.ErrorEvent) => {
+  // Leaflet error code 1 = PERMISSION_DENIED (browser or OS blocked access)
+  // On iOS Safari the permissions API is unreliable, so this event is the
+  // only trustworthy signal that location was actually denied.
+  if (e.code === 1 && state.locateState !== 'off') {
+    showToast('Location access is denied. Enable it in browser settings.');
+    state.locateState = 'off';
+    deactivatePolling();
+    updateLocateIcon('off');
+    updateRecordingButtons();
+    return;
+  }
   onLocationError(state);
   showToast('GPS signal lost');
 });
@@ -93,20 +104,6 @@ addLocateControl(map, () => {
       // gesture — iOS Safari silently denies the permission prompt otherwise.
       startLocating();
       updateRecordingButtons();
-      // If permission was previously denied, show a toast and undo
-      if ('permissions' in navigator) {
-        navigator.permissions
-          .query({ name: 'geolocation' })
-          .then((result) => {
-            if (result.state === 'denied') {
-              showToast('Location access is denied. Enable it in browser settings.');
-              state.locateState = 'off';
-              deactivatePolling();
-              updateLocateIcon('off');
-            }
-          })
-          .catch(() => { /* permissions API unavailable — locate already in progress */ });
-      }
       break;
 
     case 'active':


### PR DESCRIPTION
## Summary
- Remove the eager `navigator.permissions.query()` call that races against the iOS permission prompt, causing first-tap "access denied" (#32) and inability to grant location on iPhones where the API is unavailable (#28)
- Detect actual permission denial via Leaflet's `locationerror` event (error code 1 = PERMISSION_DENIED), which fires only after the browser definitively blocks access
- Properly resets locate state and updates recording buttons on denial

## Test plan
- [ ] iOS Safari: tap Locate for the first time — permission prompt appears, granting works on first tap
- [ ] iOS Safari: deny permission, tap Locate again — toast shows "denied" message, button resets to off
- [ ] iOS with Location Services disabled at OS level — tap Locate, verify denial detected and toast shown
- [ ] Desktop Chrome/Firefox: locate still works as before (regression check)
- [ ] GPS signal loss still shows "GPS signal lost" toast (not confused with permission denial)

Closes #28
Closes #32
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)