### PR TITLE
fix(gps): address polling refcount leaks and state machine edge cases

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -99,8 +99,12 @@ export function onLocationError(state: AppState): void {
   if (state.locationMarker !== null) {
     state.locationMarker.setIcon(createGrayDotIcon());
   }
-  // Reset prior so next fix is accepted regardless of accuracy change
-  state.prior = 1000;
+  // Only reset prior when we have no position yet; if we already have a fix,
+  // preserve prior so the haversine filter doesn't accept a degraded-accuracy
+  // position that would make the dot jump on signal recovery.
+  if (state.locationMarker === null) {
+    state.prior = 1000;
+  }
 }
 
 // Remove blue dot and accuracy circle from the map (called when locate is turned off)

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,11 @@ map.on('locationerror', (e: L.ErrorEvent) => {
   if (e.code === 1 && state.locateState !== 'off') {
     showToast('Location access is denied. Enable it in browser settings.');
     state.locateState = 'off';
-    deactivatePolling();
+    // Force-stop ALL polling regardless of refcount. Without this, an active
+    // recording (refcount > 1) keeps the timer alive — timer fires map.locate()
+    // every 500 ms, which re-triggers this error handler in an infinite loop.
+    state.updateCallback = 0;
+    cancelUpdateCallback(state, map);
     clearLocationMarkers(state, map);
     updateLocateIcon('off');
     updateRecordingButtons();
@@ -48,7 +52,12 @@ map.on('locationerror', (e: L.ErrorEvent) => {
 // Polling refcount helpers — shared by locate and recording
 function activatePolling(): void {
   state.updateCallback += 1;
-  if (state.updateCallback === 1) scheduleUpdateCallback(state, map);
+  // Use a longer initial delay (3 s) so the immediate map.locate() call in
+  // startLocating has time to resolve before the first poll cycle fires and
+  // cancels it with map.stopLocate().  Subsequent activations (recording while
+  // locate is already running) don't reach this branch, so their poll interval
+  // is unaffected.
+  if (state.updateCallback === 1) scheduleUpdateCallback(state, map, 3000);
 }
 
 function deactivatePolling(): void {

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -13,11 +13,11 @@ export function cancelUpdateCallback(state: AppState, map: L.Map): void {
   map.stopLocate();
 }
 
-export function scheduleUpdateCallback(state: AppState, map: L.Map): void {
+export function scheduleUpdateCallback(state: AppState, map: L.Map, delayMs = 500): void {
   if (state.timer !== undefined) {
     clearTimeout(state.timer);
   }
-  state.timer = setTimeout(() => updateLocation(state, map), 500);
+  state.timer = setTimeout(() => updateLocation(state, map), delayMs);
 }
 
 function updateLocation(state: AppState, map: L.Map): void {


### PR DESCRIPTION
## Summary

- **Bug 4**: `onLocationError` was unconditionally resetting `state.prior = 1000`, discarding valid accuracy data and causing the haversine filter to accept low-accuracy fixes after transient signal loss. Now only resets when no location marker exists yet.
- **Bug 2**: The permission-denied `locationerror` handler called `deactivatePolling()` once, but if recording was also active the refcount stayed above 0 — the timer kept firing `map.locate()` every 500 ms, immediately re-triggering the same error in an infinite loop. Now forces `updateCallback = 0` + `cancelUpdateCallback` to hard-stop all polling.
- **Bug 5**: `startLocating()` fires `map.locate()` immediately (required for iOS Safari gesture context), but `activatePolling()` scheduled the first poll cycle at 500 ms. That cycle called `map.stopLocate()` first, cancelling the in-flight request. Fixed by using a 3 s initial delay for the first poll cycle via a new optional `delayMs` parameter on `scheduleUpdateCallback`.

Closes #43

## Test plan

- [ ] Tap Locate → blue dot appears, map follows (no double-locate artefact on first fix)
- [ ] Deny location permission → toast shown, no infinite error spam in console
- [ ] Start recording → start locate → deny permission → timer stops, no console loop
- [ ] GPS signal lost (airplane mode briefly) → dot grays out, position does not jump on recovery
- [ ] Resume locate after signal recovery → haversine filter still rejects jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)