### PR TITLE
fix(mobile): disabled button bypass, iOS long-press fallback, remove location markers on locate off

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -247,7 +247,9 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     dropPin(e.latlng);
   });
 
-  // Right-click (desktop) and long-press (mobile) both fire contextmenu
+  // Right-click (desktop) and long-press (mobile) both fire contextmenu.
+  // A second contextmenu handler below sets contextmenuFired=true so the iOS
+  // touch-fallback doesn't double-drop on browsers that do fire contextmenu.
   map.on('contextmenu', (e: L.LeafletMouseEvent) => {
     dropPin(e.latlng);
   });
@@ -261,6 +263,8 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   let longPressStartY = 0;
   let contextmenuFired = false;
 
+  // Guard: if contextmenu fired natively, cancel the touch fallback timer
+  // so browsers that do support long-press contextmenu don't double-drop.
   map.on('contextmenu', () => {
     contextmenuFired = true;
     if (longPressTimer !== undefined) {
@@ -287,12 +291,17 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     }, 500);
   }, { passive: true });
 
-  mapContainer.addEventListener('touchend', () => {
+  function cancelLongPress(): void {
     if (longPressTimer !== undefined) {
       clearTimeout(longPressTimer);
       longPressTimer = undefined;
     }
-  }, { passive: true });
+  }
+
+  mapContainer.addEventListener('touchend', cancelLongPress, { passive: true });
+  // touchcancel fires when the OS interrupts a touch (e.g. incoming call);
+  // clear the timer to prevent a spurious pin drop after the interruption.
+  mapContainer.addEventListener('touchcancel', cancelLongPress, { passive: true });
 
   mapContainer.addEventListener('touchmove', (e: TouchEvent) => {
     if (longPressTimer === undefined) return;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -275,7 +275,10 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
 
   const mapContainer = map.getContainer();
   mapContainer.addEventListener('touchstart', (e: TouchEvent) => {
-    if (e.touches.length !== 1) return;
+    if (e.touches.length !== 1) {
+      cancelLongPress(); // second finger joined mid-hold — cancel timer
+      return;
+    }
     contextmenuFired = false;
     const touch = e.touches[0];
     if (!touch) return;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -251,4 +251,58 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   map.on('contextmenu', (e: L.LeafletMouseEvent) => {
     dropPin(e.latlng);
   });
+
+  // iOS Safari long-press fallback: contextmenu fires inconsistently on iOS,
+  // so we implement our own long-press via touch events. If the touch holds for
+  // 500ms without moving more than ~10px and contextmenu has not already fired
+  // (to avoid double-drop on browsers that do support it), drop a pin.
+  let longPressTimer: ReturnType<typeof setTimeout> | undefined;
+  let longPressStartX = 0;
+  let longPressStartY = 0;
+  let contextmenuFired = false;
+
+  map.on('contextmenu', () => {
+    contextmenuFired = true;
+    if (longPressTimer !== undefined) {
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+  });
+
+  const mapContainer = map.getContainer();
+  mapContainer.addEventListener('touchstart', (e: TouchEvent) => {
+    if (e.touches.length !== 1) return;
+    contextmenuFired = false;
+    const touch = e.touches[0];
+    if (!touch) return;
+    longPressStartX = touch.clientX;
+    longPressStartY = touch.clientY;
+    longPressTimer = setTimeout(() => {
+      longPressTimer = undefined;
+      if (contextmenuFired) return;
+      const mapRect = mapContainer.getBoundingClientRect();
+      const point = L.point(longPressStartX - mapRect.left, longPressStartY - mapRect.top);
+      const latlng = map.containerPointToLatLng(point);
+      dropPin(latlng);
+    }, 500);
+  }, { passive: true });
+
+  mapContainer.addEventListener('touchend', () => {
+    if (longPressTimer !== undefined) {
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+  }, { passive: true });
+
+  mapContainer.addEventListener('touchmove', (e: TouchEvent) => {
+    if (longPressTimer === undefined) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const dx = touch.clientX - longPressStartX;
+    const dy = touch.clientY - longPressStartY;
+    if (dx * dx + dy * dy > 100) { // moved more than ~10px
+      clearTimeout(longPressTimer);
+      longPressTimer = undefined;
+    }
+  }, { passive: true });
 }

--- a/src/location.ts
+++ b/src/location.ts
@@ -102,3 +102,15 @@ export function onLocationError(state: AppState): void {
   // Reset prior so next fix is accepted regardless of accuracy change
   state.prior = 1000;
 }
+
+// Remove blue dot and accuracy circle from the map (called when locate is turned off)
+export function clearLocationMarkers(state: AppState, map: L.Map): void {
+  if (state.locationMarker !== null) {
+    map.removeLayer(state.locationMarker);
+    state.locationMarker = null;
+  }
+  if (state.accuracyCircle !== null) {
+    map.removeLayer(state.accuracyCircle);
+    state.accuracyCircle = null;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { createMap } from './map';
 import { addClipboardControl, addLocateControl, updateLocateIcon } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
-import { onLocationFound, onLocationError } from './location';
+import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
 import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
 import { createStatsBar, addRecordingControl, updateRecordingButtons } from './recording';
 
@@ -36,6 +36,7 @@ map.on('locationerror', (e: L.ErrorEvent) => {
     showToast('Location access is denied. Enable it in browser settings.');
     state.locateState = 'off';
     deactivatePolling();
+    clearLocationMarkers(state, map);
     updateLocateIcon('off');
     updateRecordingButtons();
     return;
@@ -114,9 +115,10 @@ addLocateControl(map, () => {
       break;
 
     case 'active':
-      // Turn off: release locate's polling refcount
+      // Turn off: release locate's polling refcount and remove location markers
       state.locateState = 'off';
       deactivatePolling();
+      clearLocationMarkers(state, map);
       updateLocateIcon('off');
       updateRecordingButtons();
       break;

--- a/src/style.css
+++ b/src/style.css
@@ -181,7 +181,14 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .rec-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  pointer-events: none;
+}
+
+/* Block touch events on disabled buttons on touch devices.
+   Scoped to touch-primary devices so desktop cursor: not-allowed is preserved. */
+@media (hover: none) and (pointer: coarse) {
+  .rec-btn:disabled {
+    pointer-events: none;
+  }
 }
 
 .rec-btn-start  { background: #22c55e; color: #fff; }

--- a/src/style.css
+++ b/src/style.css
@@ -181,6 +181,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .rec-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .rec-btn-start  { background: #22c55e; color: #fff; }


### PR DESCRIPTION
## Summary

- **Record button touch bypass**: Add `pointer-events: none` to `.rec-btn:disabled` so touch events cannot trigger the grayed-out Record button on mobile (fixes disabled-button bypass introduced in #24)
- **iOS long-press fallback**: Add touchstart/touchend-based 500ms long-press detection in `geocoding.ts` as a fallback for iOS Safari where `contextmenu` fires inconsistently; guards against double-drop on browsers that do fire `contextmenu` (fixes gap introduced in #11)
- **Blue dot/accuracy circle cleanup**: Export `clearLocationMarkers` from `location.ts` and call it when locate turns off (button tap + permission-denied error path) so the marker and circle are removed from the map (fixes leak introduced in #12)

## Test plan

- [ ] Mobile: with locate off, tap Record button — should not start recording (pointer-events blocks touch)
- [ ] iOS Safari: long-press on map for 500ms — pin should drop; short tap should not drop a pin; dragging should cancel the long-press
- [ ] Turn locate on, let blue dot appear, turn locate off — blue dot and accuracy circle should disappear from the map
- [ ] Desktop: right-click still drops a pin; double-click still drops a pin
- [ ] `npm run type-check && npm run lint` passes ✓

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)