### PR TITLE
fix(recording): GPX export data correctness issues

### DIFF
--- a/src/recording.ts
+++ b/src/recording.ts
@@ -249,6 +249,7 @@ function startRecording(
   state.lastArrowPoint = null;
   state.lastSpeedMs = 0;
   state.trailPoints = [];
+  state.trailSegments = [];
 
   // Glow layer beneath the main trail line
   state.trailGlow = L.polyline([], {
@@ -287,8 +288,11 @@ function resumeRecording(state: AppState): void {
   }
   state.recordingPauseStart = null;
   state.recordingState = 'recording';
-  // Start a new GPX segment after pause by clearing trail points.
-  // This prevents a straight-line artifact across the pause in the exported GPX.
+  // Save current segment and start a new one to avoid straight-line artifact
+  // across the pause gap in the exported GPX (each segment becomes a <trkseg>).
+  if (state.trailPoints.length > 0) {
+    state.trailSegments.push(state.trailPoints);
+  }
   state.trailPoints = [];
   updateStatsBar(state);
 }
@@ -296,7 +300,7 @@ function resumeRecording(state: AppState): void {
 function stopRecording(state: AppState, deactivatePolling: () => void): void {
   if (state.recordingState === 'idle') return;
 
-  if (state.trailPoints.length > 0) {
+  if (state.trailPoints.length > 0 || state.trailSegments.length > 0) {
     downloadGpx(state);
   }
 
@@ -317,24 +321,30 @@ function buildGpx(state: AppState): string {
   // This ensures each point's wall-clock time is derived from the same epoch.
   const epochOffset = Date.now() - performance.now();
   const startDate = new Date(epochOffset + state.recordingStartMs);
-  const trackName = startDate
-    .toLocaleString()
-    .replace(/,/, '')
-    .substring(0, 16);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const trackName = `${startDate.getFullYear()}-${pad(startDate.getMonth() + 1)}-${pad(startDate.getDate())} ${pad(startDate.getHours())}:${pad(startDate.getMinutes())}`;
 
-  const trkpts = state.trailPoints
-    .map(({ latlng, t, speedMs }) => {
-      const pointTime = new Date(epochOffset + t).toISOString();
-      const timeTag = `<time>${pointTime}</time>`;
-      const speedTag =
-        speedMs > 0
-          ? `<extensions><speed>${speedMs.toFixed(4)}</speed></extensions>`
-          : '';
-      return (
-        `      <trkpt lat="${latlng.lat.toFixed(7)}" lon="${latlng.lng.toFixed(7)}">` +
-        `${timeTag}${speedTag}</trkpt>`
-      );
-    })
+  // Collect all segments: completed segments from pause/resume + current active segment
+  const allSegments = [...state.trailSegments];
+  if (state.trailPoints.length > 0) {
+    allSegments.push(state.trailPoints);
+  }
+
+  const formatPoint = ({ latlng, t, speedMs }: { latlng: L.LatLng; t: number; speedMs: number }): string => {
+    const pointTime = new Date(epochOffset + t).toISOString();
+    const timeTag = `<time>${pointTime}</time>`;
+    const speedTag =
+      speedMs > 0
+        ? `<extensions><speed>${speedMs.toFixed(4)}</speed></extensions>`
+        : '';
+    return (
+      `      <trkpt lat="${latlng.lat.toFixed(7)}" lon="${latlng.lng.toFixed(7)}">` +
+      `${timeTag}${speedTag}</trkpt>`
+    );
+  };
+
+  const trksegs = allSegments
+    .map((seg) => '    <trkseg>\n' + seg.map(formatPoint).join('\n') + '\n    </trkseg>')
     .join('\n');
 
   return (
@@ -343,9 +353,7 @@ function buildGpx(state: AppState): string {
     '     xmlns="http://www.topografix.com/GPX/1/1">\n' +
     '  <trk>\n' +
     `    <name>${trackName}</name>\n` +
-    '    <trkseg>\n' +
-    trkpts +
-    '\n    </trkseg>\n' +
+    trksegs + '\n' +
     '  </trk>\n' +
     '</gpx>'
   );

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -287,6 +287,9 @@ function resumeRecording(state: AppState): void {
   }
   state.recordingPauseStart = null;
   state.recordingState = 'recording';
+  // Start a new GPX segment after pause by clearing trail points.
+  // This prevents a straight-line artifact across the pause in the exported GPX.
+  state.trailPoints = [];
   updateStatsBar(state);
 }
 
@@ -309,20 +312,20 @@ function stopRecording(state: AppState, deactivatePolling: () => void): void {
 
 // ── GPX export ────────────────────────────────────────────────────────────────
 
-function perfToIso(t: number): string {
-  return new Date(Date.now() - (performance.now() - t)).toISOString();
-}
-
 function buildGpx(state: AppState): string {
-  const startDate = new Date(Date.now() - (performance.now() - state.recordingStartMs));
+  // Capture epoch offset once to avoid timing drift in GPX timestamps.
+  // This ensures each point's wall-clock time is derived from the same epoch.
+  const epochOffset = Date.now() - performance.now();
+  const startDate = new Date(epochOffset + state.recordingStartMs);
   const trackName = startDate
-    .toISOString()
-    .replace('T', ' ')
-    .replace(/:\d{2}\.\d{3}Z$/, '');
+    .toLocaleString()
+    .replace(/,/, '')
+    .substring(0, 16);
 
   const trkpts = state.trailPoints
     .map(({ latlng, t, speedMs }) => {
-      const timeTag = `<time>${perfToIso(t)}</time>`;
+      const pointTime = new Date(epochOffset + t).toISOString();
+      const timeTag = `<time>${pointTime}</time>`;
       const speedTag =
         speedMs > 0
           ? `<extensions><speed>${speedMs.toFixed(4)}</speed></extensions>`
@@ -369,7 +372,8 @@ function downloadGpx(state: AppState): void {
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  // Defer revokeObjectURL to avoid race condition; download is initiated asynchronously
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 // ── Trail point appending (called from location.ts) ───────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface AppState {
   trail: L.Polyline | null;
   trailGlow: L.Polyline | null;
   trailPoints: Array<{ latlng: L.LatLng; t: number; speedMs: number }>;
+  trailSegments: Array<Array<{ latlng: L.LatLng; t: number; speedMs: number }>>;
   arrowMarkers: L.Marker[];
   statsTimer: ReturnType<typeof setInterval> | null;
 }
@@ -68,6 +69,7 @@ export function createInitialState(): AppState {
     trail: null,
     trailGlow: null,
     trailPoints: [],
+    trailSegments: [],
     arrowMarkers: [],
     statsTimer: null,
   };


### PR DESCRIPTION
## Summary

Fixed four data correctness bugs in GPX export affecting pause/resume tracking, timestamp consistency, download safety, and timezone handling.

- **Clear trailPoints on resume** — start a new GPX segment after pause to avoid straight-line artifact across pause gap
- **Fix timing drift** — capture epoch offset once before loop to ensure consistent wall-clock timestamps
- **Defer URL.revokeObjectURL** — avoid race condition where download is initiated asynchronously
- **Use local time for track name** — show user's local time instead of UTC

## Test plan

- [ ] `npm run type-check && npm run lint && npm run build` passes
- [ ] Record a track, pause, resume — exported GPX should not have straight line across pause
- [ ] Verify GPX timestamps are consistent (no drift between points)
- [ ] Export GPX and verify download completes without errors
- [ ] In a non-UTC timezone, verify track name shows local time, not UTC

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)