### PR TITLE
fix(location): replace GPS polling with watchPosition

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -40,6 +40,12 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
   const R = 6371000; // Earth's radius in meters
   const dist = 2 * R * Math.asin(Math.sqrt(f));
 
+  // On first GPS fix, zoom to street level
+  if (state.initialZoom) {
+    map.setZoom(16);
+    state.initialZoom = false;
+  }
+
   // Accept update if accuracy improved OR we've moved meaningfully
   if (e.accuracy < state.prior || dist > e.accuracy / 2) {
     state.prior = e.accuracy;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 // Intent: Application entry point — wires all modules together
 // Pattern: Single AppState object threaded through all modules by reference.
 //          updateCallback is a refcount so locate and recording can independently
-//          request/release the GPS polling loop without stepping on each other.
+//          request/release the GPS watch without stepping on each other.
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
@@ -20,7 +20,7 @@ import { addClipboardControl, addLocateControl, updateLocateIcon } from './contr
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
-import { scheduleUpdateCallback, cancelUpdateCallback } from './timer';
+import { startWatching, stopWatching } from './timer';
 import { createStatsBar, addRecordingControl, updateRecordingButtons } from './recording';
 import { registerSW } from 'virtual:pwa-register';
 
@@ -36,11 +36,11 @@ map.on('locationerror', (e: L.ErrorEvent) => {
   if (e.code === 1 && state.locateState !== 'off') {
     showToast('Location access is denied. Enable it in browser settings.');
     state.locateState = 'off';
-    // Force-stop ALL polling regardless of refcount. Without this, an active
-    // recording (refcount > 1) keeps the timer alive — timer fires map.locate()
-    // every 500 ms, which re-triggers this error handler in an infinite loop.
+    // Force-stop ALL watching regardless of refcount. Without this, an active
+    // recording (refcount > 1) keeps the watch alive, which re-triggers this
+    // error handler in an infinite loop.
     state.updateCallback = 0;
-    cancelUpdateCallback(state, map);
+    stopWatching(map);
     clearLocationMarkers(state, map);
     updateLocateIcon('off');
     updateRecordingButtons();
@@ -53,18 +53,13 @@ map.on('locationerror', (e: L.ErrorEvent) => {
 // Polling refcount helpers — shared by locate and recording
 function activatePolling(): void {
   state.updateCallback += 1;
-  // Use a longer initial delay (3 s) so the immediate map.locate() call in
-  // startLocating has time to resolve before the first poll cycle fires and
-  // cancels it with map.stopLocate().  Subsequent activations (recording while
-  // locate is already running) don't reach this branch, so their poll interval
-  // is unaffected.
-  if (state.updateCallback === 1) scheduleUpdateCallback(state, map, 3000);
+  if (state.updateCallback === 1) startWatching(map);
 }
 
 function deactivatePolling(): void {
   state.prior = 1000;
   state.updateCallback -= 1;
-  if (state.updateCallback === 0) cancelUpdateCallback(state, map);
+  if (state.updateCallback === 0) stopWatching(map);
 }
 
 // ── Toast ────────────────────────────────────────────────────────────────────
@@ -108,9 +103,6 @@ addClipboardControl(map, () => {
 
 function startLocating(): void {
   state.locateState = 'active';
-  // Request location immediately within the user gesture so iOS Safari
-  // shows the permission prompt (the gesture expires before the 500ms polling timer fires)
-  map.locate({ setView: false, maxZoom: map.getZoom() });
   activatePolling();
   updateLocateIcon('active');
 }

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,31 +1,13 @@
-// Intent: GPS polling loop — schedules repeated location requests at 500ms intervals
-// Context: Leaflet's map.locate() is one-shot; we reschedule after each result.
-//          updateCallback is a refcount: 0=stopped, 1+=running (centering and/or tracking).
-// Pattern: cancelUpdateCallback → scheduleUpdateCallback → updateLocation → repeat
+// Intent: GPS watch management — start/stop continuous location tracking
+// Context: Uses Leaflet's map.locate({ watch: true }) which wraps the browser's
+//          watchPosition API. A single call starts streaming locationfound events;
+//          no polling timer needed.
 import type L from 'leaflet';
-import type { AppState } from './types';
 
-export function cancelUpdateCallback(state: AppState, map: L.Map): void {
-  if (state.timer !== undefined) {
-    clearTimeout(state.timer);
-    state.timer = undefined;
-  }
-  map.stopLocate();
+export function startWatching(map: L.Map): void {
+  map.locate({ watch: true, setView: false });
 }
 
-export function scheduleUpdateCallback(state: AppState, map: L.Map, delayMs = 500): void {
-  if (state.timer !== undefined) {
-    clearTimeout(state.timer);
-  }
-  state.timer = setTimeout(() => updateLocation(state, map), delayMs);
-}
-
-function updateLocation(state: AppState, map: L.Map): void {
+export function stopWatching(map: L.Map): void {
   map.stopLocate();
-  if (state.initialZoom) {
-    map.setZoom(16);
-    state.initialZoom = false;
-  }
-  map.locate({ setView: false, maxZoom: map.getZoom() });
-  scheduleUpdateCallback(state, map);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,8 @@ export interface AppState {
   copyToClipboard: boolean;
   locateState: LocateState; // three-state location button (replaces centering boolean)
 
-  // Timer/polling state
+  // Watch/polling state
   updateCallback: number; // refcount: 0=stopped; each consumer (locate, recording) adds 1
-  timer: ReturnType<typeof setTimeout> | undefined;
   initialZoom: boolean; // true until first GPS fix; zooms to level 16 on first fix
 
   // Persistent location marker refs (updated in place instead of adding new layers)
@@ -54,7 +53,6 @@ export function createInitialState(): AppState {
     copyToClipboard: false,
     locateState: 'off',
     updateCallback: 0,
-    timer: undefined,
     initialZoom: true,
     locationMarker: null,
     accuracyCircle: null,


### PR DESCRIPTION
## Summary
- Replace 500ms `setTimeout` → `map.locate()` polling loop with `map.locate({ watch: true })` (`watchPosition`) — eliminates `[Violation] Only request geolocation information in response to a user gesture` console spam
- Remove `timer` field from AppState — no longer needed
- Move `initialZoom` logic from deleted `updateLocation` to `onLocationFound`

Closes #59

## Test plan
- [ ] Tap locate button → blue dot appears, map follows GPS
- [ ] Pan while following → drops to passive (dot stays, map stops following)
- [ ] Tap again → re-centers
- [ ] Start recording → GPS continues streaming
- [ ] Stop locate while recording → GPS continues (refcount > 0)
- [ ] Stop recording → GPS stops
- [ ] Chrome DevTools console shows no geolocation violation warnings
- [ ] iOS Safari still shows permission prompt on first locate tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)