### PR TITLE
fix(ui): replace locate crosshair with angled arrow icon

### DIFF
--- a/public/locate-arrow-bw.svg
+++ b/public/locate-arrow-bw.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff"/>
+      <stop offset="100%" stop-color="#bcbec0"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#g)" stroke="#939598" stroke-width="1.5" stroke-linejoin="round" d="M12 2 L22 19 L12 15 L2 19 Z"/>
+</svg>

--- a/public/locate-arrow-color.svg
+++ b/public/locate-arrow-color.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#95f7ff"/>
+      <stop offset="100%" stop-color="#008ece"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#g)" stroke="#040077" stroke-width="1.5" stroke-linejoin="round" d="M12 2 L22 19 L12 15 L2 19 Z"/>
+</svg>

--- a/public/locate-arrow-lines.svg
+++ b/public/locate-arrow-lines.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs><style>.cls-1{fill:none;stroke:#231f20;stroke-width:2;stroke-linejoin:round;}</style></defs>
+  <path class="cls-1" d="M12 2 L22 19 L12 15 L2 19 Z"/>
+</svg>

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -81,7 +81,7 @@ export function addClipboardControl(map: L.Map, onClick: (e: Event) => void): vo
 export function addLocateControl(map: L.Map, onClick: (e: Event) => void): void {
   makeToggleControl({
     id: 'locate',
-    disabledSrc: '/centering-lines-v1.1.svg',
+    disabledSrc: '/locate-arrow-lines.svg',
     disabledTitle: 'Locate (Off)',
     position: 'topleft',
     onClick,
@@ -95,15 +95,15 @@ export function updateLocateIcon(locateState: LocateState): void {
   switch (locateState) {
     case 'off':
       img.alt = img.title = 'Locate (Off)';
-      img.src = '/centering-lines-v1.1.svg';
+      img.src = '/locate-arrow-lines.svg';
       break;
     case 'active':
       img.alt = img.title = 'Locate (Following)';
-      img.src = '/centering-color-v1.1.svg';
+      img.src = '/locate-arrow-color.svg';
       break;
     case 'passive':
       img.alt = img.title = 'Locate (Passive — tap to re-center)';
-      img.src = '/centering-bw-v1.1.svg';
+      img.src = '/locate-arrow-bw.svg';
       break;
   }
 }


### PR DESCRIPTION
## Summary
- Replace the centering/crosshair locate button icons with angled navigation arrow SVGs — the standard location symbol users expect from map apps
- Three icon states preserved: outline (off), color gradient (active/following), grayscale (passive)
- Uses the project's existing color palettes (blue gradient for active, gray gradient for passive)

Closes #61

## Test plan
- [ ] Tap locate button — arrow icon appears in color (active/following state)
- [ ] Pan map while following — arrow changes to grayscale (passive state)
- [ ] Tap locate again to turn off — arrow returns to outline (off state)
- [ ] Verify arrow renders crisply at 30x30px control size
- [ ] Test on mobile (iOS Safari, Android Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)