### PR TITLE
feat(search): smart zoom using result bounds on click

### DIFF
--- a/src/bottom-sheet.ts
+++ b/src/bottom-sheet.ts
@@ -141,6 +141,33 @@ function onDocTouchEnd(e: TouchEvent): void {
   snapTo(target);
 }
 
+// ── Zoom heuristics ──────────────────────────────────────────────────────────
+
+function zoomForAddrType(addrType: string): number {
+  switch (addrType) {
+    case 'PointAddress':
+    case 'StreetAddress':
+    case 'SubAddress':
+    case 'StreetInt':
+      return 17;
+    case 'Locality':
+    case 'Neighborhood':
+    case 'Sublocality':
+      return 14;
+    case 'City':
+    case 'Municipal':
+      return 12;
+    case 'Region':
+    case 'State':
+    case 'Province':
+      return 8;
+    case 'Country':
+      return 5;
+    default:
+      return 15;
+  }
+}
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 export function initInfoPanel(map: L.Map): void {
@@ -203,10 +230,19 @@ export function initInfoPanel(map: L.Map): void {
     if (target === null || _map === null) return;
     const lat = parseFloat(target.dataset['lat'] ?? '');
     const lng = parseFloat(target.dataset['lng'] ?? '');
-    if (!isNaN(lat) && !isNaN(lng)) {
-      _map.flyTo(L.latLng(lat, lng), _map.getZoom());
-      snapTo('peek');
+    if (isNaN(lat) || isNaN(lng)) return;
+    const boundsRaw = target.dataset['bounds'] ?? '';
+    if (boundsRaw !== '') {
+      try {
+        const parsed = JSON.parse(boundsRaw) as [[number, number], [number, number]];
+        _map.flyToBounds(L.latLngBounds(parsed), { padding: [50, 50], maxZoom: 17 });
+      } catch {
+        _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+      }
+    } else {
+      _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
     }
+    snapTo('peek');
   });
 
   // Event delegation: click a copy button → write to clipboard

--- a/src/bottom-sheet.ts
+++ b/src/bottom-sheet.ts
@@ -234,8 +234,12 @@ export function initInfoPanel(map: L.Map): void {
     const boundsRaw = target.dataset['bounds'] ?? '';
     if (boundsRaw !== '') {
       try {
-        const parsed = JSON.parse(boundsRaw) as [[number, number], [number, number]];
-        _map.flyToBounds(L.latLngBounds(parsed), { padding: [50, 50], maxZoom: 17 });
+        const parsed = JSON.parse(boundsRaw) as unknown;
+        if (Array.isArray(parsed) && parsed.length === 2) {
+          _map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), { padding: [50, 50], maxZoom: 17 });
+        } else {
+          _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+        }
       } catch {
         _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
       }

--- a/src/bottom-sheet.ts
+++ b/src/bottom-sheet.ts
@@ -235,7 +235,8 @@ export function initInfoPanel(map: L.Map): void {
     if (boundsRaw !== '') {
       try {
         const parsed = JSON.parse(boundsRaw) as unknown;
-        if (Array.isArray(parsed) && parsed.length === 2) {
+        if (Array.isArray(parsed) && parsed.length === 2 &&
+            Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
           _map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), { padding: [50, 50], maxZoom: 17 });
         } else {
           _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -177,8 +177,14 @@ export function addSearchControl(map: L.Map, state: AppState): void {
           const name = escapeHtml(r.text);
           const lat = r.latlng.lat.toFixed(6);
           const lng = r.latlng.lng.toFixed(6);
+          const boundsJson = r.bounds
+            ? JSON.stringify([[r.bounds.getSouth(), r.bounds.getWest()],
+                              [r.bounds.getNorth(), r.bounds.getEast()]])
+            : '';
+          const addrType = escapeHtml((r.properties?.Addr_type as string) ?? '');
           return (
-            `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}">` +
+            `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}"` +
+            ` data-bounds="${escapeHtml(boundsJson)}" data-addr-type="${addrType}">` +
             `  <span class="sheet-result__name">${name}</span>` +
             `  <span class="sheet-result__arrow">&#x203A;</span>` +
             `</li>`


### PR DESCRIPTION
## Summary
- Serializes `bounds` and `Addr_type` onto each result `<li>` as `data-bounds` / `data-addr-type` in `geocoding.ts`
- Updates the click handler in `bottom-sheet.ts` to use `flyToBounds` when bounds are available, falling back to `Addr_type`-based zoom heuristics (PointAddress/StreetAddress → 17, City/Municipal → 12, Country → 5, etc.)
- Eliminates the previous behavior of flying at whatever zoom the user happened to be at

## Test plan
- [ ] Search for a street address — should zoom to level 17
- [ ] Search for a city — should zoom to level 12
- [ ] Search for a country — should zoom to level 5
- [ ] Search for a result that has bounds — should use flyToBounds with padding
- [ ] Verify sheet snaps to peek after flying

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)