### PR TITLE
feat(search): numbered markers matching result list order

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -19,6 +19,15 @@ function escapeHtml(str: string): string {
     .replace(/"/g, '&quot;');
 }
 
+function createNumberedIcon(n: number): L.DivIcon {
+  return L.divIcon({
+    html: `<div>${n}</div>`,
+    className: 'numbered-marker',
+    iconSize: [24, 24],
+    iconAnchor: [12, 12],
+  });
+}
+
 export function addSearchControl(map: L.Map, state: AppState): void {
   // state is read in the results callback (for future extensibility)
   void state;
@@ -148,24 +157,28 @@ export function addSearchControl(map: L.Map, state: AppState): void {
     if (data.results.length) {
       document.title = data.text;
 
-      // Add markers (no popup — info panel handles the UI)
+      // Add numbered markers (reverse iteration preserves z-order: #1 on top)
+      // markerRefs is populated here; issue #65 will wire up click handlers
+      const markerRefs: L.Marker[] = [];
       for (let i = data.results.length - 1; i >= 0; i--) {
         const result = data.results[i];
         if (result) {
-          results.addLayer(L.marker(result.latlng));
+          const marker = L.marker(result.latlng, { icon: createNumberedIcon(i + 1) });
+          markerRefs[i] = marker;
+          results.addLayer(marker);
         }
       }
 
       // Build results list for the info panel
       const itemsHtml = data.results
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((r: any) => {
+        .map((r: any, i: number) => {
           if (!r) return '';
           const name = escapeHtml(r.text);
           const lat = r.latlng.lat.toFixed(6);
           const lng = r.latlng.lng.toFixed(6);
           return (
-            `<li class="sheet-result" data-lat="${lat}" data-lng="${lng}">` +
+            `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}">` +
             `  <span class="sheet-result__name">${name}</span>` +
             `  <span class="sheet-result__arrow">&#x203A;</span>` +
             `</li>`

--- a/src/style.css
+++ b/src/style.css
@@ -534,6 +534,16 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   }
 }
 
+/* ── Numbered search result markers ─────────────────────────────────────────── */
+.numbered-marker { background: transparent !important; border: none !important; }
+.numbered-marker div {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: #4a90d9; color: white;
+  font-size: 12px; font-weight: bold;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+}
+
 /* ── Version badge ───────────────────────────────────────────────────────────── */
 
 #version-badge {


### PR DESCRIPTION
## Summary
- Add `createNumberedIcon(n)` factory in `src/geocoding.ts` that produces a `L.DivIcon` with the result number inside
- Replace default blue pins with numbered markers in the results loop; populate `markerRefs[]` array at handler scope (needed by #65)
- Add `data-index` attribute to each `<li>` in the results list (needed by #65)
- Add `.numbered-marker` CSS styles in `src/style.css`

## Test plan
- [ ] Search for a query with multiple results — each map marker should show a number (1, 2, 3...) matching the panel list order
- [ ] Marker #1 should appear on top (correct z-order from reverse iteration)
- [ ] Numbered markers should be circular blue badges, no default Leaflet pin chrome
- [ ] `npm run type-check && npm run lint` pass clean

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)