### PR TITLE
feat(search): show richer detail per search result

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -90,7 +90,7 @@ export function addSearchControl(map: L.Map, state: AppState): void {
     collapseAfterResult: false,
     minCharacters: MIN_CHARS,
     debounceDelay: 250,
-    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey }))],
+    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey, outFields: 'Addr_type,City,Region,Postal,Country' }))],
   });
   searchControl.addTo(map);
 
@@ -182,10 +182,20 @@ export function addSearchControl(map: L.Map, state: AppState): void {
                               [r.bounds.getNorth(), r.bounds.getEast()]])
             : '';
           const addrType = escapeHtml((r.properties?.Addr_type as string) ?? '');
+          const props = (r.properties ?? {}) as Record<string, string>;
+          const subtitle = ['City', 'Region', 'Postal']
+            .map((k) => props[k] ?? '')
+            .filter(Boolean)
+            .map(escapeHtml)
+            .join(', ');
           return (
             `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}"` +
             ` data-bounds="${escapeHtml(boundsJson)}" data-addr-type="${addrType}">` +
-            `  <span class="sheet-result__name">${name}</span>` +
+            `  <div class="sheet-result__main">` +
+            `    <span class="sheet-result__name">${name}</span>` +
+            (subtitle ? `    <span class="sheet-result__subtitle">${subtitle}</span>` : '') +
+            `  </div>` +
+            (addrType ? `  <span class="sheet-result__badge">${addrType}</span>` : '') +
             `  <span class="sheet-result__arrow">&#x203A;</span>` +
             `</li>`
           );

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -188,6 +188,7 @@ export function addSearchControl(map: L.Map, state: AppState): void {
             .filter(Boolean)
             .map(escapeHtml)
             .join(', ');
+          // data-index is 0-based; the visible marker number is i+1 (see createNumberedIcon)
           return (
             `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}"` +
             ` data-bounds="${escapeHtml(boundsJson)}" data-addr-type="${addrType}">` +

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -181,10 +181,10 @@ export function addSearchControl(map: L.Map, state: AppState): void {
             ? JSON.stringify([[r.bounds.getSouth(), r.bounds.getWest()],
                               [r.bounds.getNorth(), r.bounds.getEast()]])
             : '';
-          const addrType = escapeHtml((r.properties?.Addr_type as string) ?? '');
-          const props = (r.properties ?? {}) as Record<string, string>;
+          const strProp = (v: unknown): string => (typeof v === 'string' ? v : '');
+          const addrType = escapeHtml(strProp(r.properties?.Addr_type));
           const subtitle = ['City', 'Region', 'Postal']
-            .map((k) => props[k] ?? '')
+            .map((k) => strProp(r.properties?.[k]))
             .filter(Boolean)
             .map(escapeHtml)
             .join(', ');

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -90,7 +90,7 @@ export function addSearchControl(map: L.Map, state: AppState): void {
     collapseAfterResult: false,
     minCharacters: MIN_CHARS,
     debounceDelay: 250,
-    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey, outFields: 'Addr_type,City,Region,Postal,Country' }))],
+    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey, outFields: 'Addr_type,City,Region,Postal' }))],
   });
   searchControl.addTo(map);
 

--- a/src/style.css
+++ b/src/style.css
@@ -331,7 +331,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .sheet-result {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: 12px 4px;
   border-bottom: 1px solid #f0f0f0;
@@ -349,10 +349,35 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   background: #f5f5f5;
 }
 
+.sheet-result__main {
+  flex: 1;
+  min-width: 0;
+}
+
 .sheet-result__name {
   font-size: 14px;
   color: #333;
-  flex: 1;
+}
+
+.sheet-result__subtitle {
+  display: block;
+  font-size: 12px;
+  color: #666;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sheet-result__badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #e8f0fe;
+  color: #4a90d9;
+  margin-left: 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .sheet-result__arrow {

--- a/src/style.css
+++ b/src/style.css
@@ -378,12 +378,14 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   margin-left: 8px;
   white-space: nowrap;
   flex-shrink: 0;
+  align-self: center;
 }
 
 .sheet-result__arrow {
   color: #bbb;
   font-size: 18px;
   margin-left: 8px;
+  align-self: center;
 }
 
 /* ── Reverse geocode address view ── */


### PR DESCRIPTION
## Summary
- Adds `outFields: 'Addr_type,City,Region,Postal'` to `arcgisOnlineProvider` so geocoding results include address metadata
- Each search result `<li>` now shows a subtitle (City, Region, Postal joined with ", ", blanks omitted) and an `Addr_type` badge pill
- Adds `data-index` attribute (0-based) to each result item — visible marker numbers are 1-based (see `createNumberedIcon`)
- New CSS classes: `.sheet-result__main` (flex wrapper), `.sheet-result__subtitle`, `.sheet-result__badge`

## Test plan
- [ ] Search for an address — results should show place name, city/region/postal subtitle, and Addr_type badge
- [ ] Results with missing City/Region/Postal should omit those fields gracefully
- [ ] Badge only renders when Addr_type is present
- [ ] `escapeHtml()` applied to all injected property values
- [ ] Badge and arrow are vertically centered relative to multi-line result rows

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)