### PR TITLE
fix(gps): discard fixes with accuracy > 30m during trail recording

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -9,6 +9,9 @@ import type { AppState } from './types';
 import { updateLocateIcon } from './controls';
 import { appendTrailPoint } from './recording';
 
+/** Discard GPS fixes coarser than this threshold for trail recording (metres). */
+const TRAIL_MAX_ACCURACY_M = 30;
+
 // divIcon HTML for the blue pulsing dot — styled via .blue-dot CSS in style.css
 const BLUE_DOT_ICON = L.divIcon({
   className: 'blue-dot',
@@ -89,7 +92,7 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
 
     // Append to the recording trail when actively recording.
     // Discard fixes with accuracy > 30m — noisy fixes inflate trail distance and create zigzag artifacts.
-    if (state.recordingState === 'recording' && e.accuracy <= 30) {
+    if (state.recordingState === 'recording' && e.accuracy <= TRAIL_MAX_ACCURACY_M) {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
       appendTrailPoint(e.latlng, speedMs, state, map);
     }

--- a/src/location.ts
+++ b/src/location.ts
@@ -87,8 +87,9 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
       state.accuracyCircle.setStyle({ fillOpacity });
     }
 
-    // Append to the recording trail when actively recording
-    if (state.recordingState === 'recording') {
+    // Append to the recording trail when actively recording.
+    // Discard fixes with accuracy > 30m — noisy fixes inflate trail distance and create zigzag artifacts.
+    if (state.recordingState === 'recording' && e.accuracy <= 30) {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
       appendTrailPoint(e.latlng, speedMs, state, map);
     }


### PR DESCRIPTION
## Summary

- Adds an accuracy gate (`e.accuracy <= 30m`) before calling `appendTrailPoint` in `location.ts`, discarding inherently noisy fixes from the trail recording pipeline
- The 5m minimum-distance threshold already present in `recording.ts` handles per-point jitter; this completes the two-layer filtering strategy described in #74
- Blue dot and accuracy circle still update for all accepted fixes — the accuracy gate only applies to trail recording

## Test plan

- [ ] Record a trail indoors or under heavy canopy — verify no zigzag artifacts appear in the polyline or exported GPX
- [ ] Walk outdoors with clear sky — verify trail records normally (accuracy typically < 5m)
- [ ] Confirm distance stats are not inflated compared to known route distances

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)