### PR TITLE
fix(ux): bottom sheet drag handle, snap points, haptic feedback, peek pass-through

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -430,18 +430,23 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     return geocodeBar.offsetHeight - getPeekHeight();
   }
 
-  function applyTransform(offsetPx: number, animate: boolean): void {
-    if (animate) {
-      geocodeBar.style.willChange = 'transform';
-      geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
-      geocodeBar.addEventListener('transitionend', () => {
-        geocodeBar.style.willChange = '';
-      }, { once: true });
-    } else {
-      geocodeBar.style.willChange = 'transform';
-      geocodeBar.style.transition = 'none';
-    }
+  // Read the current rendered translateY so drag-start is always correct even
+  // if the user grabs the handle mid-transition (sheetState is set to the
+  // target before the CSS animation completes, so reading state would jump).
+  function getCurrentOffset(): number {
+    const matrix = new DOMMatrix(getComputedStyle(geocodeBar).transform);
+    return matrix.m42; // translateY component
+  }
+
+  // Animate to offsetPx with a CSS transition. willChange is enabled for the
+  // duration of the animation only, then cleared to avoid pinning a GPU layer.
+  function animateTo(offsetPx: number): void {
+    geocodeBar.style.willChange = 'transform';
+    geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
     geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
+    geocodeBar.addEventListener('transitionend', () => {
+      geocodeBar.style.willChange = '';
+    }, { once: true });
   }
 
   function snapTo(target: SheetState): void {
@@ -451,19 +456,21 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
       // during the outgoing transition and having this transitionend listener
       // fire at the end of the NEW transition, hiding the freshly-opened sheet.
       sheetState = 'hidden';
-      applyTransform(geocodeBar.offsetHeight + 20, true);
+      animateTo(geocodeBar.offsetHeight + 20);
       geocodeBar.addEventListener('transitionend', () => {
         if (sheetState !== 'hidden') return; // re-opened before transition ended
         geocodeBar.style.display = 'none';
         geocodeBar.style.transform = '';
       }, { once: true });
       geocodeBar.classList.remove('geocode-bar--peek');
+      barHandle.setAttribute('aria-expanded', 'false');
     } else {
       sheetState = target;
-      applyTransform(target === 'peek' ? getPeekOffset() : 0, true);
+      animateTo(target === 'peek' ? getPeekOffset() : 0);
       // In peek state the sheet overlay is pointer-events:none so map
       // interactions pass through; only handle and buttons remain interactive.
       geocodeBar.classList.toggle('geocode-bar--peek', target === 'peek');
+      barHandle.setAttribute('aria-expanded', target === 'full' ? 'true' : 'false');
     }
   }
 
@@ -474,11 +481,16 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     barCopyBtn.classList.remove('geocode-bar__copy--copied');
 
     if (sheetState === 'hidden') {
-      // Render off-screen first so offsetHeight is available, then animate in.
+      // Render off-screen first so offsetHeight is available, then use double-rAF
+      // to guarantee the browser renders the initial off-screen position before
+      // starting the transition (single-rAF can batch both into one paint frame).
       geocodeBar.style.display = 'flex';
       geocodeBar.style.transition = 'none';
       geocodeBar.style.transform = `translateX(-50%) translateY(${geocodeBar.offsetHeight}px)`;
-      requestAnimationFrame(() => { snapTo('peek'); });
+      barHandle.setAttribute('aria-expanded', 'false');
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => { snapTo('peek'); });
+      });
     } else {
       // Already visible — just refresh content and snap back to peek.
       snapTo('peek');
@@ -501,7 +513,10 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     if (!touch) return;
     isDragging = true;
     dragStartY = touch.clientY;
-    dragStartOffset = sheetState === 'full' ? 0 : getPeekOffset();
+    // Read the actual rendered position so drag start is correct even if the
+    // user grabs mid-transition (sheetState already reflects the target).
+    dragStartOffset = getCurrentOffset();
+    geocodeBar.style.willChange = 'transform';
     geocodeBar.style.transition = 'none';
   }, { passive: true });
 
@@ -517,6 +532,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   barHandle.addEventListener('touchend', (e: TouchEvent) => {
     if (!isDragging) return;
     isDragging = false;
+    geocodeBar.style.willChange = ''; // animateTo will re-enable for transition duration
     const touch = e.changedTouches[0];
     if (!touch) return;
     const delta = touch.clientY - dragStartY;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -388,32 +388,136 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   const pinLayer = L.layerGroup().addTo(map);
   _pinLayer = pinLayer;
 
-  // Compact one-line bar shown below the map when a pin is dropped.
+  // Bottom sheet shown below the map when a pin is dropped.
+  // Supports two snap points (peek / full) and drag-to-dismiss.
   const geocodeBar = document.createElement('div');
   geocodeBar.className = 'geocode-bar';
   geocodeBar.style.display = 'none';
   geocodeBar.innerHTML =
-    '<button class="geocode-bar__copy" aria-label="Copy address">Copy</button>' +
-    '<span class="geocode-bar__addr"></span>' +
-    '<button class="geocode-bar__close" aria-label="Dismiss">\u00d7</button>';
+    '<div class="geocode-bar__handle" role="button" aria-label="Drag to resize sheet" tabindex="0">' +
+    '  <div class="geocode-bar__handle-pill"></div>' +
+    '</div>' +
+    '<div class="geocode-bar__body">' +
+    '  <button class="geocode-bar__copy" aria-label="Copy address">Copy</button>' +
+    '  <span class="geocode-bar__addr"></span>' +
+    '  <button class="geocode-bar__close" aria-label="Dismiss">\u00d7</button>' +
+    '</div>';
   document.body.appendChild(geocodeBar);
 
   const barAddrEl  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__addr')!;
   const barCopyBtn = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__copy')!;
+  const barHandle  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__handle')!;
+
+  // Height of the sheet visible in peek state (px).
+  const PEEK_HEIGHT = 130;
+
+  type SheetState = 'hidden' | 'peek' | 'full';
+  let sheetState: SheetState = 'hidden';
+
+  function getPeekOffset(): number {
+    return geocodeBar.offsetHeight - PEEK_HEIGHT;
+  }
+
+  function applyTransform(offsetPx: number, animate: boolean): void {
+    geocodeBar.style.transition = animate
+      ? 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)'
+      : 'none';
+    geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
+  }
+
+  function setPointerEvents(state: SheetState): void {
+    // In peek state the sheet sits over the map — disable pointer events on the
+    // sheet background so map interactions (pan / zoom) pass through. Only the
+    // handle and action buttons remain interactive.
+    geocodeBar.classList.toggle('geocode-bar--peek', state === 'peek');
+  }
+
+  function snapTo(target: SheetState): void {
+    if (target === 'hidden') {
+      applyTransform(geocodeBar.offsetHeight + 20, true);
+      geocodeBar.addEventListener('transitionend', () => {
+        geocodeBar.style.display = 'none';
+        geocodeBar.style.transform = '';
+        sheetState = 'hidden';
+      }, { once: true });
+      geocodeBar.classList.remove('geocode-bar--peek');
+    } else {
+      sheetState = target;
+      applyTransform(target === 'peek' ? getPeekOffset() : 0, true);
+      setPointerEvents(target);
+    }
+  }
 
   function showGeocodeBar(label: string, copyText: string): void {
     barAddrEl.textContent = label;
     barCopyBtn.dataset['copy'] = copyText;
     barCopyBtn.textContent = 'Copy';
     barCopyBtn.classList.remove('geocode-bar__copy--copied');
-    geocodeBar.style.display = 'flex';
+
+    if (sheetState === 'hidden') {
+      // Render off-screen first so offsetHeight is available, then animate in.
+      geocodeBar.style.display = 'flex';
+      geocodeBar.style.transition = 'none';
+      geocodeBar.style.transform = `translateX(-50%) translateY(${geocodeBar.offsetHeight}px)`;
+      requestAnimationFrame(() => { snapTo('peek'); });
+    } else {
+      // Already visible — just refresh content and snap back to peek.
+      snapTo('peek');
+    }
   }
 
   function hideGeocodeBar(): void {
-    geocodeBar.style.display = 'none';
+    snapTo('hidden');
   }
 
   _showGeocodeBar = showGeocodeBar;
+
+  // ── Drag-to-snap on handle ───────────────────────────────────────────────
+  let dragStartY = 0;
+  let dragStartOffset = 0;
+  let isDragging = false;
+
+  barHandle.addEventListener('touchstart', (e: TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    isDragging = true;
+    dragStartY = touch.clientY;
+    dragStartOffset = sheetState === 'full' ? 0 : getPeekOffset();
+    geocodeBar.style.transition = 'none';
+  }, { passive: true });
+
+  barHandle.addEventListener('touchmove', (e: TouchEvent) => {
+    if (!isDragging) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const delta = touch.clientY - dragStartY;
+    const clamped = Math.max(-20, Math.min(geocodeBar.offsetHeight + 20, dragStartOffset + delta));
+    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+  }, { passive: true });
+
+  barHandle.addEventListener('touchend', (e: TouchEvent) => {
+    if (!isDragging) return;
+    isDragging = false;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const delta = touch.clientY - dragStartY;
+    const currentOffset = dragStartOffset + delta;
+    const peekOffset = getPeekOffset();
+    // Dragged more than 80px below peek → dismiss
+    if (currentOffset > peekOffset + 80) {
+      hideGeocodeBar();
+      pinLayer.clearLayers();
+      return;
+    }
+    // Snap to nearest: below midpoint between full(0) and peek → full; above → peek
+    snapTo(currentOffset < peekOffset / 2 ? 'full' : 'peek');
+  }, { passive: true });
+
+  // Click on handle bar toggles peek ↔ full
+  barHandle.addEventListener('click', () => {
+    if (sheetState === 'peek') snapTo('full');
+    else if (sheetState === 'full') snapTo('peek');
+  });
 
   geocodeBar.addEventListener('click', (e: MouseEvent) => {
     const t = e.target as HTMLElement;
@@ -424,6 +528,8 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     }
     const copyBtn = t.closest<HTMLButtonElement>('.geocode-bar__copy');
     if (copyBtn) {
+      // Haptic feedback on supported devices (Android Chrome)
+      if ('vibrate' in navigator) navigator.vibrate(50);
       const text = copyBtn.dataset['copy'] ?? '';
       navigator.clipboard.writeText(text).then(() => {
         copyBtn.textContent = '✓ Copied';

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -408,14 +408,26 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   const barCopyBtn = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__copy')!;
   const barHandle  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__handle')!;
 
-  // Height of the sheet visible in peek state (px).
-  const PEEK_HEIGHT = 130;
+  // Height of the sheet visible in peek state (px), augmented by safe-area-inset-bottom
+  // so the handle + action row remain fully above the home-indicator on notched phones.
+  const PEEK_HEIGHT_BASE = 130;
+
+  function getSafeAreaBottom(): number {
+    // Read env(safe-area-inset-bottom) via a CSS custom property set in :root.
+    const raw = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sai-bottom').trim();
+    return parseInt(raw, 10) || 0;
+  }
+
+  function getPeekHeight(): number {
+    return PEEK_HEIGHT_BASE + getSafeAreaBottom();
+  }
 
   type SheetState = 'hidden' | 'peek' | 'full';
   let sheetState: SheetState = 'hidden';
 
   function getPeekOffset(): number {
-    return geocodeBar.offsetHeight - PEEK_HEIGHT;
+    return geocodeBar.offsetHeight - getPeekHeight();
   }
 
   function applyTransform(offsetPx: number, animate: boolean): void {
@@ -425,26 +437,26 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
   }
 
-  function setPointerEvents(state: SheetState): void {
-    // In peek state the sheet sits over the map — disable pointer events on the
-    // sheet background so map interactions (pan / zoom) pass through. Only the
-    // handle and action buttons remain interactive.
-    geocodeBar.classList.toggle('geocode-bar--peek', state === 'peek');
-  }
-
   function snapTo(target: SheetState): void {
     if (target === 'hidden') {
+      // Update sheetState immediately so any concurrent showGeocodeBar call
+      // takes the correct 'hidden' branch rather than calling snapTo('peek')
+      // during the outgoing transition and having this transitionend listener
+      // fire at the end of the NEW transition, hiding the freshly-opened sheet.
+      sheetState = 'hidden';
       applyTransform(geocodeBar.offsetHeight + 20, true);
       geocodeBar.addEventListener('transitionend', () => {
+        if (sheetState !== 'hidden') return; // re-opened before transition ended
         geocodeBar.style.display = 'none';
         geocodeBar.style.transform = '';
-        sheetState = 'hidden';
       }, { once: true });
       geocodeBar.classList.remove('geocode-bar--peek');
     } else {
       sheetState = target;
       applyTransform(target === 'peek' ? getPeekOffset() : 0, true);
-      setPointerEvents(target);
+      // In peek state the sheet overlay is pointer-events:none so map
+      // interactions pass through; only handle and buttons remain interactive.
+      geocodeBar.classList.toggle('geocode-bar--peek', target === 'peek');
     }
   }
 

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -431,9 +431,16 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   }
 
   function applyTransform(offsetPx: number, animate: boolean): void {
-    geocodeBar.style.transition = animate
-      ? 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)'
-      : 'none';
+    if (animate) {
+      geocodeBar.style.willChange = 'transform';
+      geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
+      geocodeBar.addEventListener('transitionend', () => {
+        geocodeBar.style.willChange = '';
+      }, { once: true });
+    } else {
+      geocodeBar.style.willChange = 'transform';
+      geocodeBar.style.transition = 'none';
+    }
     geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
   }
 
@@ -525,10 +532,20 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     snapTo(currentOffset < peekOffset / 2 ? 'full' : 'peek');
   }, { passive: true });
 
-  // Click on handle bar toggles peek ↔ full
-  barHandle.addEventListener('click', () => {
+  // Click and keyboard (Enter / Space) on handle bar toggle peek ↔ full.
+  // Both are required: click fires from pointer devices; keydown covers
+  // keyboard and assistive-technology users (role="button" + tabindex="0").
+  function handleToggle(): void {
     if (sheetState === 'peek') snapTo('full');
     else if (sheetState === 'full') snapTo('peek');
+  }
+
+  barHandle.addEventListener('click', handleToggle);
+  barHandle.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggle();
+    }
   });
 
   geocodeBar.addEventListener('click', (e: MouseEvent) => {

--- a/src/style.css
+++ b/src/style.css
@@ -457,7 +457,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   font-size: 13px;
   display: flex;
   flex-direction: column;
-  will-change: transform;
   overflow: hidden;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -434,24 +434,75 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   padding-left: calc(12px - 3px); /* compensate for border */
 }
 
-/* ── Reverse geocode compact bar ── */
+/* ── Reverse geocode bottom sheet ── */
 .geocode-bar {
   position: fixed;
-  bottom: calc(28px + env(safe-area-inset-bottom, 0px));
+  bottom: 0;
   left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  max-width: min(480px, calc(100vw - 24px));
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 6px;
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5);
-  padding: 0 6px 0 4px;
-  height: 36px;
+  transform: translateX(-50%) translateY(0);
+  width: min(480px, 100vw);
+  height: 60vh;
+  min-height: 130px;
+  background: #fff;
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);
   z-index: 1500;
   font-family: system-ui, sans-serif;
   font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  will-change: transform;
+  overflow: hidden;
+}
+
+/* In peek state the sheet sits over the map — let touches pass through to
+   the map for everything except the handle and action buttons. */
+.geocode-bar--peek {
+  pointer-events: none;
+}
+
+.geocode-bar--peek .geocode-bar__handle,
+.geocode-bar--peek .geocode-bar__copy,
+.geocode-bar--peek .geocode-bar__close {
+  pointer-events: auto;
+}
+
+/* Drag handle */
+.geocode-bar__handle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 0 8px;
+  cursor: grab;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+.geocode-bar__handle:active {
+  cursor: grabbing;
+}
+
+.geocode-bar__handle-pill {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.25);
+  transition: background 0.15s;
+}
+
+.geocode-bar__handle:hover .geocode-bar__handle-pill {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+/* Content row */
+.geocode-bar__body {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  padding-bottom: max(8px, env(safe-area-inset-bottom, 8px));
+  min-height: 44px;
+  flex-shrink: 0;
 }
 
 .geocode-bar__copy {

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,9 @@
+:root {
+  /* Expose safe-area-inset-bottom as a custom property so JS can read it
+     via getComputedStyle without injecting a throw-away DOM element. */
+  --sai-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 html { height: 100%; width: 100%; padding: 0; margin: 0; }
 body { height: 100%; width: 100%; padding: 0; margin: 0; }
 #map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
@@ -442,7 +448,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   transform: translateX(-50%) translateY(0);
   width: min(480px, 100vw);
   height: 60vh;
-  min-height: 130px;
+  min-height: calc(130px + var(--sai-bottom, 0px));
   background: #fff;
   border-radius: 12px 12px 0 0;
   box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);

--- a/src/style.css
+++ b/src/style.css
@@ -448,7 +448,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   transform: translateX(-50%) translateY(0);
   width: min(480px, 100vw);
   height: 60vh;
-  min-height: calc(130px + var(--sai-bottom, 0px));
+  min-height: calc(130px + var(--sai-bottom));
   background: #fff;
   border-radius: 12px 12px 0 0;
   box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);


### PR DESCRIPTION
## Summary

Fixes #75 — upgrades the reverse geocode bar from a static compact strip to a proper draggable bottom sheet:

- **Drag handle**: pill affordance at the top; tap to toggle peek ↔ full; drag to any intermediate position, releases snap to nearest
- **Snap points**: peek state shows 130 px from the bottom; full state shows 60 vh; dragging 80 px past peek threshold dismisses the sheet
- **Haptic feedback**: `navigator.vibrate(50)` fires on the Copy action on supported devices (Android Chrome)
- **Peek pass-through**: in peek state the sheet is `pointer-events: none` so map pan/zoom work normally; only the handle, Copy, and Close buttons remain interactive

## Test plan

- [ ] Long-press on map → sheet animates up to peek state
- [ ] Tap handle → sheet expands to full; tap again → snaps back to peek
- [ ] Drag handle up → snaps to full; drag down past threshold → sheet dismisses and pin is cleared
- [ ] While in peek state, drag/zoom the map normally — sheet does not block it
- [ ] Tap Copy on Android Chrome → short vibration fires
- [ ] Close button dismisses sheet and clears pin
- [ ] `npm run type-check && npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)