### PR TITLE
fix(pwa): user-visible warnings and canvas fallback for offline tile misses

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import './style.css';
 import changelogRaw from '../CHANGELOG.md?raw';
 
 import { createInitialState } from './types';
-import { createMap } from './map';
+import { createMap, initOfflineTileFallback } from './map';
 import { addLocateControl, updateLocateIcon } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
@@ -260,6 +260,8 @@ function updateOfflineBanner(): void {
 window.addEventListener('online', updateOfflineBanner);
 window.addEventListener('offline', updateOfflineBanner);
 updateOfflineBanner();
+
+initOfflineTileFallback(showToast);
 
 let pendingSwUpdate: (() => void) | null = null;
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -5,6 +5,7 @@
  * Future: Tile layer config (tokens, URLs, zoom limits) is hardcoded; no runtime layer switching beyond the built-in layer control
  */
 import L from 'leaflet';
+import { OSM_TILE_CACHE_NAME } from './sw-constants';
 
 // Module-level tile layer refs — set during createMap(), read by initOfflineTileFallback()
 let osmTileLayer: L.TileLayer | null = null;
@@ -49,11 +50,10 @@ async function handleTileError(
 ): Promise<void> {
   if (!navigator.onLine && !tileWarnCooldown) {
     tileWarnCooldown = true;
-    showToast(
-      'Some map tiles aren\u2019t cached for this area \u2014 zoom out for cached coverage. ' +
-        '(Safari limits offline cache to ~50\u00a0MB.)',
-      7000,
-    );
+    const msg = isOsmLayer
+      ? 'Some map tiles aren\u2019t cached for this area \u2014 zoom out for cached coverage. (Safari limits offline cache to ~50\u00a0MB.)'
+      : 'Tiles unavailable offline \u2014 switch to Structures layer for offline coverage.';
+    showToast(msg, 7000);
     setTimeout(() => {
       tileWarnCooldown = false;
     }, 10000);
@@ -63,7 +63,7 @@ async function handleTileError(
 
   const tile = e.tile;
   const coords = e.coords;
-  const cache = await caches.open('osm-tiles');
+  const cache = await caches.open(OSM_TILE_CACHE_NAME);
 
   for (let dz = 1; dz <= 3; dz++) {
     const parentZ = coords.z - dz;

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,10 +1,115 @@
 /**
  * Intent: Map initialization — creates the Leaflet map, tile layers, and controls
  * Context: Called once from main.ts on startup; returns the configured L.Map instance used everywhere
- * Pattern: All tile layer refs stay local to this module — callers only need the map, not the layers
+ * Pattern: Tile layer refs are module-level so initOfflineTileFallback can attach error handlers
  * Future: Tile layer config (tokens, URLs, zoom limits) is hardcoded; no runtime layer switching beyond the built-in layer control
  */
 import L from 'leaflet';
+
+// Module-level tile layer refs — set during createMap(), read by initOfflineTileFallback()
+let osmTileLayer: L.TileLayer | null = null;
+let mapboxTileLayer: L.TileLayer | null = null;
+let googleTileLayer: L.TileLayer | null = null;
+
+// Tile error event shape (Leaflet fires this on tileerror but @types/leaflet may not expose it fully)
+interface TileErrorEvent extends L.LeafletEvent {
+  tile: HTMLImageElement;
+  coords: { x: number; y: number; z: number };
+  error: Error;
+}
+
+let tileWarnCooldown = false;
+
+/** Wire up offline tile warnings and canvas-based lower-zoom fallback.
+ *  Must be called after createMap(). Attaches tileerror handlers to all tile layers.
+ *  Only the OSM layer (cached by the service worker) attempts canvas fallback;
+ *  Mapbox/Google layers show the warning but serve no fallback (not SW-cached).
+ */
+export function initOfflineTileFallback(
+  showToast: (msg: string, durationMs?: number) => void,
+): void {
+  const layers = [osmTileLayer, mapboxTileLayer, googleTileLayer].filter(
+    (l): l is L.TileLayer => l !== null,
+  );
+  for (const layer of layers) {
+    layer.on('tileerror', (e: L.LeafletEvent) => {
+      void handleTileError(e as TileErrorEvent, layer === osmTileLayer, showToast);
+    });
+  }
+}
+
+async function handleTileError(
+  e: TileErrorEvent,
+  isOsmLayer: boolean,
+  showToast: (msg: string, durationMs?: number) => void,
+): Promise<void> {
+  if (!navigator.onLine && !tileWarnCooldown) {
+    tileWarnCooldown = true;
+    showToast(
+      'Some map tiles aren\u2019t cached for this area \u2014 zoom out for cached coverage. ' +
+        '(Safari limits offline cache to ~50\u00a0MB.)',
+      7000,
+    );
+    setTimeout(() => {
+      tileWarnCooldown = false;
+    }, 10000);
+  }
+
+  if (!isOsmLayer || !('caches' in window) || e.tile.src.startsWith('data:')) return;
+
+  const tile = e.tile;
+  const coords = e.coords;
+
+  for (let dz = 1; dz <= 3; dz++) {
+    const parentZ = coords.z - dz;
+    if (parentZ < 1) break;
+    const scale = Math.pow(2, dz);
+    const parentX = Math.floor(coords.x / scale);
+    const parentY = Math.floor(coords.y / scale);
+
+    for (const sub of ['a', 'b', 'c']) {
+      const url = `https://${sub}.tile.openstreetmap.org/${parentZ}/${parentX}/${parentY}.png`;
+      try {
+        const cache = await caches.open('osm-tiles');
+        const response = await cache.match(url);
+        if (!response) continue;
+
+        const blob = await response.blob();
+        const objectUrl = URL.createObjectURL(blob);
+
+        await new Promise<void>((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 256;
+            canvas.height = 256;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+              URL.revokeObjectURL(objectUrl);
+              reject(new Error('no 2d context'));
+              return;
+            }
+            const subX = coords.x % scale;
+            const subY = coords.y % scale;
+            const srcSize = 256 / scale;
+            ctx.drawImage(img, subX * srcSize, subY * srcSize, srcSize, srcSize, 0, 0, 256, 256);
+            tile.src = canvas.toDataURL('image/png');
+            URL.revokeObjectURL(objectUrl);
+            resolve();
+          };
+          img.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error('img load failed'));
+          };
+          img.src = objectUrl;
+        });
+        return; // success — stop searching
+      } catch {
+        // try next subdomain / zoom level
+      }
+    }
+  }
+}
 
 export function createMap(): L.Map {
   const map = L.map('map', {
@@ -81,7 +186,7 @@ export function createMap(): L.Map {
   // updateWhenZooming: false defers tile loads during pinch-zoom animation
   const tilePerf = { keepBuffer: 3, updateWhenZooming: false } as const;
 
-  const elevationWithTrails = L.tileLayer(
+  mapboxTileLayer = L.tileLayer(
     `https://api.mapbox.com/styles/v1/mapbox/outdoors-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`,
     {
       tileSize: 512,
@@ -94,7 +199,7 @@ export function createMap(): L.Map {
     },
   );
 
-  const osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  osmTileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     tileSize: 512,
     zoomOffset: -1,
     maxZoom: 18,
@@ -104,7 +209,7 @@ export function createMap(): L.Map {
     ...tilePerf,
   }).addTo(map);
 
-  const gsi = L.tileLayer('https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+  googleTileLayer = L.tileLayer('https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
     subdomains: ['mt0', 'mt1', 'mt2', 'mt3'],
     tileSize: 512,
     zoomOffset: -1,
@@ -115,7 +220,7 @@ export function createMap(): L.Map {
     ...tilePerf,
   });
 
-  const baseMaps = { Imagery: gsi, Structures: osm, Topo: elevationWithTrails };
+  const baseMaps = { Imagery: googleTileLayer, Structures: osmTileLayer, Topo: mapboxTileLayer };
   L.control.layers(baseMaps, undefined, { position: 'topleft' }).addTo(map);
 
   return map;

--- a/src/map.ts
+++ b/src/map.ts
@@ -19,7 +19,13 @@ interface TileErrorEvent extends L.LeafletEvent {
   error: Error;
 }
 
+// Single cooldown shared across all layers — intentional: one toast per 10 s regardless
+// of which layer fired, so a Mapbox error followed immediately by an OSM error doesn't
+// show two toasts. The per-layer message is set when the cooldown first trips.
 let tileWarnCooldown = false;
+
+// Opened once on first use; reused for every subsequent tile error lookup.
+let osmCachePromise: Promise<Cache> | null = null;
 
 /** Wire up offline tile warnings and canvas-based lower-zoom fallback.
  *  Must be called after createMap(). Attaches tileerror handlers to all tile layers.
@@ -35,6 +41,9 @@ export function initOfflineTileFallback(
   if (layers.length === 0) {
     console.warn('initOfflineTileFallback: no tile layers found — call createMap() first');
     return;
+  }
+  if ('caches' in window) {
+    osmCachePromise = caches.open(OSM_TILE_CACHE_NAME);
   }
   for (const layer of layers) {
     layer.on('tileerror', (e: L.LeafletEvent) => {
@@ -59,11 +68,11 @@ async function handleTileError(
     }, 10000);
   }
 
-  if (!isOsmLayer || navigator.onLine || !('caches' in window) || e.tile.src.startsWith('data:')) return;
+  if (!isOsmLayer || navigator.onLine || osmCachePromise === null || e.tile.src.startsWith('data:')) return;
 
   const tile = e.tile;
   const coords = e.coords;
-  const cache = await caches.open(OSM_TILE_CACHE_NAME);
+  const cache = await osmCachePromise;
 
   for (let dz = 1; dz <= 3; dz++) {
     const parentZ = coords.z - dz;
@@ -72,11 +81,14 @@ async function handleTileError(
     const parentX = Math.floor(coords.x / scale);
     const parentY = Math.floor(coords.y / scale);
 
-    for (const sub of ['a', 'b', 'c']) {
-      const url = `https://${sub}.tile.openstreetmap.org/${parentZ}/${parentX}/${parentY}.png`;
+    // Check all three subdomains in parallel — parent tile is on exactly one of them
+    const subUrls = ['a', 'b', 'c'].map(
+      sub => `https://${sub}.tile.openstreetmap.org/${parentZ}/${parentX}/${parentY}.png`,
+    );
+    const responses = await Promise.all(subUrls.map(url => cache.match(url)));
+    const response = responses.find(Boolean);
+    if (response !== undefined) {
       try {
-        const response = await cache.match(url);
-        if (!response) continue;
 
         const blob = await response.blob();
         const objectUrl = URL.createObjectURL(blob);
@@ -85,6 +97,9 @@ async function handleTileError(
           const img = new Image();
           img.onload = () => {
             const canvas = document.createElement('canvas');
+            // OSM tiles are 256×256; the layer uses tileSize:512 so Leaflet stretches
+            // the img element to 512 CSS px — fallback tiles will look blurrier than
+            // normal tiles, which is expected and acceptable for degraded offline UX.
             canvas.width = 256;
             canvas.height = 256;
             const ctx = canvas.getContext('2d');
@@ -109,7 +124,7 @@ async function handleTileError(
         });
         return; // success — stop searching
       } catch {
-        // try next subdomain / zoom level
+        // blob or canvas failed — try next zoom level
       }
     }
   }

--- a/src/map.ts
+++ b/src/map.ts
@@ -31,6 +31,10 @@ export function initOfflineTileFallback(
   const layers = [osmTileLayer, mapboxTileLayer, googleTileLayer].filter(
     (l): l is L.TileLayer => l !== null,
   );
+  if (layers.length === 0) {
+    console.warn('initOfflineTileFallback: no tile layers found — call createMap() first');
+    return;
+  }
   for (const layer of layers) {
     layer.on('tileerror', (e: L.LeafletEvent) => {
       void handleTileError(e as TileErrorEvent, layer === osmTileLayer, showToast);
@@ -55,10 +59,11 @@ async function handleTileError(
     }, 10000);
   }
 
-  if (!isOsmLayer || !('caches' in window) || e.tile.src.startsWith('data:')) return;
+  if (!isOsmLayer || navigator.onLine || !('caches' in window) || e.tile.src.startsWith('data:')) return;
 
   const tile = e.tile;
   const coords = e.coords;
+  const cache = await caches.open('osm-tiles');
 
   for (let dz = 1; dz <= 3; dz++) {
     const parentZ = coords.z - dz;
@@ -70,7 +75,6 @@ async function handleTileError(
     for (const sub of ['a', 'b', 'c']) {
       const url = `https://${sub}.tile.openstreetmap.org/${parentZ}/${parentX}/${parentY}.png`;
       try {
-        const cache = await caches.open('osm-tiles');
         const response = await cache.match(url);
         if (!response) continue;
 

--- a/src/sw-constants.ts
+++ b/src/sw-constants.ts
@@ -1,0 +1,5 @@
+/** Shared service worker constants — imported by both vite.config.ts and app code.
+ *  Centralising the cache name ensures a refactor in the SW config is caught
+ *  at the import site rather than silently breaking the canvas tile fallback.
+ */
+export const OSM_TILE_CACHE_NAME = 'osm-tiles' as const;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { readFileSync } from 'fs';
+import { OSM_TILE_CACHE_NAME } from './src/sw-constants';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
@@ -46,7 +47,7 @@ export default defineConfig({
             urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
             handler: 'StaleWhileRevalidate',
             options: {
-              cacheName: 'osm-tiles',
+              cacheName: OSM_TILE_CACHE_NAME,
               expiration: {
                 maxEntries: 500,
                 maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
## Summary

Fixes #76. Addresses the two prioritized mitigations from the issue:

- **Toast on uncached zoom** — when `!navigator.onLine` and a tile fails, a debounced toast fires (max once per 10 s) explaining the constraint and mentioning Safari's ~50 MB quota.
- **Canvas fallback** — for the OSM tile layer (the only one cached by the SW), the error handler walks up to 3 parent zoom levels, checks all three OSM subdomains (`a`/`b`/`c`) in the `osm-tiles` Cache API entry, and scales the matching quadrant onto a 256×256 canvas, setting it as the tile's `src` — degraded but not blank.

## Changes

- `src/map.ts` — promotes tile layer locals to module-level refs; adds `initOfflineTileFallback(showToast)` export with `handleTileError` async helper
- `src/main.ts` — imports and calls `initOfflineTileFallback(showToast)` after the offline-banner wiring

## Test plan

- [ ] Go offline (DevTools → Network → Offline or airplane mode)
- [ ] Navigate to a zoom level that was never loaded — confirm toast appears
- [ ] Zoom to an area previously viewed at z=12, then zoom to z=15 offline — confirm scaled parent tile renders instead of blank
- [ ] Return online — confirm no spurious toasts
- [ ] `npm run type-check && npm run lint` both pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)