### PR TITLE
feat(trail): add trail recording with pause/resume and GPX 1.1 export

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -94,8 +94,8 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     // Discard fixes with accuracy > 30m — noisy fixes inflate trail distance and create zigzag artifacts.
     if (state.recordingState === 'recording' && e.accuracy <= TRAIL_MAX_ACCURACY_M) {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
-      // e.altitude is null when the device doesn't report elevation
-      const altM = e.altitude !== null ? e.altitude : undefined;
+      // e.altitude is typed as number by Leaflet but is null at runtime when the device doesn't report elevation
+      const altM = (e.altitude as number | null) !== null ? e.altitude : undefined;
       appendTrailPoint(e.latlng, speedMs, state, map, altM);
     }
   }

--- a/src/location.ts
+++ b/src/location.ts
@@ -94,7 +94,9 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     // Discard fixes with accuracy > 30m — noisy fixes inflate trail distance and create zigzag artifacts.
     if (state.recordingState === 'recording' && e.accuracy <= TRAIL_MAX_ACCURACY_M) {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
-      appendTrailPoint(e.latlng, speedMs, state, map);
+      // e.altitude is null when the device doesn't report elevation
+      const altM = e.altitude !== null ? e.altitude : undefined;
+      appendTrailPoint(e.latlng, speedMs, state, map, altM);
     }
   }
 

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -367,8 +367,9 @@ function buildGpx(state: AppState): string {
     allSegments.push(state.trailPoints);
   }
 
-  const formatPoint = ({ latlng, t, speedMs }: { latlng: L.LatLng; t: number; speedMs: number }): string => {
+  const formatPoint = ({ latlng, t, speedMs, altM }: { latlng: L.LatLng; t: number; speedMs: number; altM?: number }): string => {
     const pointTime = new Date(epochOffset + t).toISOString();
+    const eleTag = altM !== undefined ? `<ele>${altM.toFixed(1)}</ele>` : '';
     const timeTag = `<time>${pointTime}</time>`;
     const speedTag =
       speedMs > 0
@@ -376,7 +377,7 @@ function buildGpx(state: AppState): string {
         : '';
     return (
       `      <trkpt lat="${latlng.lat.toFixed(7)}" lon="${latlng.lng.toFixed(7)}">` +
-      `${timeTag}${speedTag}</trkpt>`
+      `${eleTag}${timeTag}${speedTag}</trkpt>`
     );
   };
 
@@ -428,6 +429,7 @@ export function appendTrailPoint(
   speedMs: number,
   state: AppState,
   map: L.Map,
+  altM?: number,
 ): void {
   if (state.recordingState !== 'recording') return;
 
@@ -442,7 +444,7 @@ export function appendTrailPoint(
   state.trail?.addLatLng(latlng);
   state.trailGlow?.addLatLng(latlng);
   state.lastTrailPoint = latlng;
-  state.trailPoints.push({ latlng, t: performance.now(), speedMs });
+  state.trailPoints.push({ latlng, t: performance.now(), speedMs, altM });
 
   // Direction arrow: add between lastArrowPoint and current point when far enough apart
   if (state.lastArrowPoint !== null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,8 @@ export interface AppState {
   lastSpeedMs: number;
   trail: L.Polyline | null;
   trailGlow: L.Polyline | null;
-  trailPoints: Array<{ latlng: L.LatLng; t: number; speedMs: number }>;
-  trailSegments: Array<Array<{ latlng: L.LatLng; t: number; speedMs: number }>>;
+  trailPoints: Array<{ latlng: L.LatLng; t: number; speedMs: number; altM?: number }>;
+  trailSegments: Array<Array<{ latlng: L.LatLng; t: number; speedMs: number; altM?: number }>>;
   arrowMarkers: L.Marker[];
   statsTimer: ReturnType<typeof setInterval> | null;
 }


### PR DESCRIPTION
Closes #77

## Summary

- Trail recording state machine (idle → recording → paused → idle) with real-time polyline rendered on the map
- Start, pause, resume, stop controls in the bottom-right recording panel; record button disabled until location is active
- GPS accuracy filter (>30m discard) and distance threshold (<5m skip) on every fix
- GPX 1.1 auto-download on stop: multi-segment support preserves pause gaps as separate `<trkseg>` elements; `<ele>` tag now populated from device altitude when available
- Stats bar shows elapsed time, distance, and speed during recording

## Test plan

- [ ] Enable location, tap Record — polyline appears and stats bar shows
- [ ] Tap Pause — dot turns amber, stats freeze; tap Resume — new segment begins (no straight-line gap artifact)
- [ ] Tap Stop → confirm dialog → GPX file downloads as `track-YYYY-MM-DD-HHmm.gpx`
- [ ] Import GPX into Strava or AllTrails — track renders correctly
- [ ] On a device with barometric altitude, verify `<ele>` values appear in GPX

🤖 Generated with [Claude Code](https://claude.com/claude-code)