### PR TITLE
feat(offline): persist GPS trail to localStorage for page-reload resilience

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
 import { startWatching, stopWatching } from './timer';
-import { createStatsBar, addRecordingControl, updateRecordingButtons } from './recording';
+import { createStatsBar, addRecordingControl, updateRecordingButtons, maybeRestoreTrailBackup } from './recording';
 import { registerSW } from 'virtual:pwa-register';
 
 const state = createInitialState();
@@ -181,6 +181,11 @@ map.on('dragstart', () => {
 
 createStatsBar();
 addRecordingControl(map, state, activatePolling, deactivatePolling);
+
+// Offer to restore an interrupted trail if a backup exists in localStorage
+if (maybeRestoreTrailBackup(state, map, activatePolling)) {
+  updateRecordingButtons();
+}
 
 initInfoPanel(map);
 addSearchControl(map, state, showToast);

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -6,6 +6,7 @@
  */
 import L from 'leaflet';
 import type { AppState } from './types';
+import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup } from './trail-backup';
 
 // tradeoff: 5m minimum distance filters GPS jitter at walking pace without skipping real movement; lower values add noise, higher values miss tight turns
 const MIN_TRAIL_DIST_M = 5;
@@ -340,6 +341,8 @@ function stopRecording(state: AppState, deactivatePolling: () => void): void {
   state.recordingState = 'idle';
   deactivatePolling(); // recording refcount
 
+  clearTrailBackup();
+
   if (state.statsTimer !== null) {
     clearInterval(state.statsTimer);
     state.statsTimer = null;
@@ -444,6 +447,9 @@ export function appendTrailPoint(
   state.lastTrailPoint = latlng;
   state.trailPoints.push({ latlng, t: performance.now(), speedMs });
 
+  // Persist to localStorage so a page reload doesn't lose the in-progress trail
+  saveTrailBackup(state);
+
   // Direction arrow: add between lastArrowPoint and current point when far enough apart
   if (state.lastArrowPoint !== null) {
     const arrowDist = haversineM(state.lastArrowPoint, latlng);
@@ -472,4 +478,58 @@ function addArrowMarker(
   const mid = L.latLng((from.lat + to.lat) / 2, (from.lng + to.lng) / 2);
   const marker = L.marker(mid, { icon, interactive: false }).addTo(map);
   state.arrowMarkers.push(marker);
+}
+
+// ── Trail backup restore (called from main.ts on startup) ─────────────────────
+
+/**
+ * Check for a persisted trail backup and, if found, prompt the user to restore it.
+ * Restores recording state and redraws the trail on the map; starts the stats bar timer.
+ * Returns true if a backup was applied, false otherwise.
+ */
+export function maybeRestoreTrailBackup(
+  state: AppState,
+  map: L.Map,
+  activatePolling: () => void,
+): boolean {
+  const backup = loadTrailBackup();
+  if (!backup) return false;
+
+  const totalPoints =
+    backup.trailPoints.length +
+    backup.trailSegments.reduce((n, s) => n + s.length, 0);
+  if (totalPoints === 0) {
+    clearTrailBackup();
+    return false;
+  }
+
+  if (!confirm(`Restore interrupted recording? (${totalPoints} GPS points recovered)`)) {
+    clearTrailBackup();
+    return false;
+  }
+
+  // Recreate polylines so applyTrailBackup can populate them
+  state.trailGlow = L.polyline([], {
+    color: 'rgba(66,135,245,0.25)',
+    weight: 14,
+    smoothFactor: 2,
+    interactive: false,
+  }).addTo(map);
+  state.trail = L.polyline([], {
+    color: '#4287f5',
+    weight: 4,
+    smoothFactor: 2,
+    interactive: false,
+  }).addTo(map);
+
+  applyTrailBackup(backup, state);
+  state.recordingState = 'recording';
+
+  activatePolling(); // recording refcount
+
+  setStatsBarVisible(true);
+  if (state.statsTimer !== null) clearInterval(state.statsTimer);
+  state.statsTimer = setInterval(() => updateStatsBar(state), 1000);
+
+  return true;
 }

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -12,6 +12,11 @@ import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup } 
 const MIN_TRAIL_DIST_M = 5;
 const MIN_ARROW_DIST_M = 50;  // minimum metres between direction-arrow markers
 
+// Shared polyline options — used in both startRecording and maybeRestoreTrailBackup
+// to avoid style drift between the two code paths.
+const TRAIL_LINE_OPTS: L.PolylineOptions = { color: '#4287f5', weight: 4, smoothFactor: 2, interactive: false };
+const TRAIL_GLOW_OPTS: L.PolylineOptions = { color: 'rgba(66,135,245,0.25)', weight: 14, smoothFactor: 2, interactive: false };
+
 // ── Geometry helpers ─────────────────────────────────────────────────────────
 
 function haversineM(a: L.LatLng, b: L.LatLng): number {
@@ -286,20 +291,10 @@ function startRecording(
   state.trailSegments = [];
 
   // Glow layer beneath the main trail line
-  state.trailGlow = L.polyline([], {
-    color: 'rgba(66,135,245,0.25)',
-    weight: 14,
-    smoothFactor: 2,
-    interactive: false,
-  }).addTo(map);
+  state.trailGlow = L.polyline([], TRAIL_GLOW_OPTS).addTo(map);
 
   // Main trail line
-  state.trail = L.polyline([], {
-    color: '#4287f5',
-    weight: 4,
-    smoothFactor: 2,
-    interactive: false,
-  }).addTo(map);
+  state.trail = L.polyline([], TRAIL_LINE_OPTS).addTo(map);
 
   activatePolling(); // recording refcount
 
@@ -514,18 +509,8 @@ export function maybeRestoreTrailBackup(
   }
 
   // Recreate polylines so applyTrailBackup can populate them
-  state.trailGlow = L.polyline([], {
-    color: 'rgba(66,135,245,0.25)',
-    weight: 14,
-    smoothFactor: 2,
-    interactive: false,
-  }).addTo(map);
-  state.trail = L.polyline([], {
-    color: '#4287f5',
-    weight: 4,
-    smoothFactor: 2,
-    interactive: false,
-  }).addTo(map);
+  state.trailGlow = L.polyline([], TRAIL_GLOW_OPTS).addTo(map);
+  state.trail = L.polyline([], TRAIL_LINE_OPTS).addTo(map);
 
   applyTrailBackup(backup, state);
   state.recordingState = 'recording';

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -503,6 +503,11 @@ export function maybeRestoreTrailBackup(
     return false;
   }
 
+  // window.confirm() is intentional here: it fires synchronously at app startup
+  // before any recording state is live, so blocking the event loop is harmless.
+  // The rest of the app uses showToast() for non-blocking feedback, but a restore
+  // prompt must block initialization until the user decides — a toast action button
+  // would require async startup machinery that isn't worth the complexity.
   if (!confirm(`Restore interrupted recording? (${totalPoints} GPS points recovered)`)) {
     clearTrailBackup();
     return false;

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -503,8 +503,15 @@ export function maybeRestoreTrailBackup(
   // The rest of the app uses showToast() for non-blocking feedback, but a restore
   // prompt must block initialization until the user decides — a toast action button
   // would require async startup machinery that isn't worth the complexity.
+  //
+  // Known limitation: some browsers (Firefox on Android, certain PWA installations on
+  // Chromium) suppress confirm() without user interaction and silently return false.
+  // To prevent silent discard in these cases, we intentionally do NOT call
+  // clearTrailBackup() here — the backup persists and will be offered again on the next
+  // page load. If the user genuinely cancels, the backup remains until recording stops
+  // normally (which calls clearTrailBackup()). This is a minor annoyance vs. the
+  // alternative of silently losing a hike's worth of GPS data.
   if (!confirm(`Restore interrupted recording? (${totalPoints} GPS points recovered)`)) {
-    clearTrailBackup();
     return false;
   }
 

--- a/src/trail-backup.ts
+++ b/src/trail-backup.ts
@@ -23,7 +23,14 @@ interface TrailBackup {
   version: 1;
   /** Wall-clock epoch ms when recording started */
   recordingStartWallMs: number;
-  /** Accumulated pause duration in ms */
+  /**
+   * Accumulated pause duration in ms.
+   * Known limitation: recordingState ('recording' | 'paused') is not serialized.
+   * If the page reloads while recording is paused, the in-progress pause duration
+   * (performance.now() - recordingPauseStart) is lost and will not be subtracted
+   * from the elapsed time, slightly inflating the displayed time. This is a low-
+   * probability corner case (crash during pause) and acceptable for now.
+   */
   recordingPauseMs: number;
   trailSegments: SerializedPoint[][];
   /** Current (active) segment points */
@@ -104,18 +111,41 @@ export function loadTrailBackup(): TrailBackup | null {
     const parsed: unknown = JSON.parse(raw);
     // Runtime shape guard: discard stale/partial data from schema changes or other apps
     const p = parsed as Record<string, unknown>;
+    const trailPoints = p['trailPoints'];
+    const trailSegments = p['trailSegments'];
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
       p['version'] !== CURRENT_VERSION ||
-      !Array.isArray(p['trailPoints']) ||
-      !Array.isArray(p['trailSegments']) ||
+      !Array.isArray(trailPoints) ||
+      !Array.isArray(trailSegments) ||
       typeof p['totalDistance'] !== 'number' ||
       typeof p['recordingStartWallMs'] !== 'number' ||
       typeof p['recordingPauseMs'] !== 'number'
     ) {
       localStorage.removeItem(BACKUP_KEY);
       return null;
+    }
+    // Per-point spot check: validate first element of each array to catch truncated/corrupt data
+    function isValidPoint(pt: unknown): boolean {
+      return (
+        typeof pt === 'object' && pt !== null &&
+        typeof (pt as Record<string, unknown>)['lat'] === 'number' &&
+        typeof (pt as Record<string, unknown>)['lng'] === 'number'
+      );
+    }
+    const firstPoint = trailPoints[0];
+    if (firstPoint !== undefined && !isValidPoint(firstPoint)) {
+      localStorage.removeItem(BACKUP_KEY);
+      return null;
+    }
+    for (const seg of trailSegments) {
+      if (!Array.isArray(seg)) { localStorage.removeItem(BACKUP_KEY); return null; }
+      const firstSeg = seg[0];
+      if (firstSeg !== undefined && !isValidPoint(firstSeg)) {
+        localStorage.removeItem(BACKUP_KEY);
+        return null;
+      }
     }
     return parsed as TrailBackup;
   } catch {

--- a/src/trail-backup.ts
+++ b/src/trail-backup.ts
@@ -1,0 +1,134 @@
+/**
+ * Intent: Persist in-progress trail data to localStorage so a page reload during recording doesn't lose the track
+ * Context: Called by recording.ts on each trail point append; cleared when recording stops; checked on startup in main.ts
+ * Pattern: Convert performance.now() timestamps to wall-clock milliseconds before serializing; reverse on restore
+ * Future: If trail grows beyond localStorage quota (~5MB), silently degrade to memory-only (no data loss during the session)
+ */
+import L from 'leaflet';
+import type { AppState } from './types';
+
+const BACKUP_KEY = 'webmap-trail-backup';
+
+interface SerializedPoint {
+  lat: number;
+  lng: number;
+  /** Wall-clock epoch ms (Date.now() equivalent at the time the point was recorded) */
+  wallMs: number;
+  speedMs: number;
+}
+
+interface TrailBackup {
+  /** Wall-clock epoch ms when recording started */
+  recordingStartWallMs: number;
+  /** Accumulated pause duration in ms */
+  recordingPauseMs: number;
+  trailSegments: SerializedPoint[][];
+  /** Current (active) segment points */
+  trailPoints: SerializedPoint[];
+  totalDistance: number;
+}
+
+function toSerializedPoint(
+  p: { latlng: L.LatLng; t: number; speedMs: number },
+  epochOffset: number,
+): SerializedPoint {
+  return {
+    lat: p.latlng.lat,
+    lng: p.latlng.lng,
+    wallMs: epochOffset + p.t,
+    speedMs: p.speedMs,
+  };
+}
+
+function serializeSegment(
+  seg: Array<{ latlng: L.LatLng; t: number; speedMs: number }>,
+  epochOffset: number,
+): SerializedPoint[] {
+  return seg.map((p) => toSerializedPoint(p, epochOffset));
+}
+
+/** Write the current recording state to localStorage. Silently ignores quota errors. */
+export function saveTrailBackup(state: AppState): void {
+  // epochOffset = wall-clock equivalent of performance.now() == 0
+  const epochOffset = Date.now() - performance.now();
+  const backup: TrailBackup = {
+    recordingStartWallMs: epochOffset + state.recordingStartMs,
+    recordingPauseMs: state.recordingPauseMs,
+    trailSegments: state.trailSegments.map((seg) => serializeSegment(seg, epochOffset)),
+    trailPoints: serializeSegment(state.trailPoints, epochOffset),
+    totalDistance: state.totalDistance,
+  };
+  try {
+    localStorage.setItem(BACKUP_KEY, JSON.stringify(backup));
+  } catch {
+    // Quota exceeded — silently degrade; in-memory recording continues unaffected
+  }
+}
+
+/** Read a previously persisted trail backup, or null if none exists. */
+export function loadTrailBackup(): TrailBackup | null {
+  try {
+    const raw = localStorage.getItem(BACKUP_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as TrailBackup;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the trail backup from localStorage (call after recording stops). */
+export function clearTrailBackup(): void {
+  try {
+    localStorage.removeItem(BACKUP_KEY);
+  } catch { /* ignore */ }
+}
+
+/**
+ * Restore a persisted trail backup into AppState and redraw the trail on the map.
+ * Returns the number of total points restored, or 0 if backup was empty/unusable.
+ */
+export function applyTrailBackup(
+  backup: TrailBackup,
+  state: AppState,
+): number {
+  // Convert wall-clock timestamps back to performance.now()-relative offsets
+  const epochOffset = Date.now() - performance.now();
+
+  function restorePoints(
+    pts: SerializedPoint[],
+  ): Array<{ latlng: L.LatLng; t: number; speedMs: number }> {
+    return pts.map((p) => ({
+      latlng: L.latLng(p.lat, p.lng),
+      t: p.wallMs - epochOffset,
+      speedMs: p.speedMs,
+    }));
+  }
+
+  const allSegs = backup.trailSegments.map(restorePoints);
+  const activeSeg = restorePoints(backup.trailPoints);
+
+  // Merge into state
+  state.recordingStartMs = backup.recordingStartWallMs - epochOffset;
+  state.recordingPauseMs = backup.recordingPauseMs;
+  state.totalDistance = backup.totalDistance;
+  state.trailSegments = allSegs;
+  state.trailPoints = activeSeg;
+
+  // Rebuild polyline from all points
+  const allLatLngs: L.LatLng[] = [
+    ...allSegs.flatMap((s) => s.map((p) => p.latlng)),
+    ...activeSeg.map((p) => p.latlng),
+  ];
+
+  if (allLatLngs.length > 0) {
+    if (state.trail) state.trail.setLatLngs(allLatLngs);
+    if (state.trailGlow) state.trailGlow.setLatLngs(allLatLngs);
+    const last = allLatLngs[allLatLngs.length - 1];
+    if (last) {
+      state.lastTrailPoint = last;
+      state.lastArrowPoint = last;
+    }
+  }
+
+  return allLatLngs.length;
+}

--- a/src/trail-backup.ts
+++ b/src/trail-backup.ts
@@ -1,6 +1,6 @@
 /**
  * Intent: Persist in-progress trail data to localStorage so a page reload during recording doesn't lose the track
- * Context: Called by recording.ts on each trail point append; cleared when recording stops; checked on startup in main.ts
+ * Context: Called by recording.ts on each trail point append (debounced); cleared when recording stops; checked on startup in main.ts
  * Pattern: Convert performance.now() timestamps to wall-clock milliseconds before serializing; reverse on restore
  * Future: If trail grows beyond localStorage quota (~5MB), silently degrade to memory-only (no data loss during the session)
  */
@@ -8,6 +8,7 @@ import L from 'leaflet';
 import type { AppState } from './types';
 
 const BACKUP_KEY = 'webmap-trail-backup';
+const CURRENT_VERSION = 1;
 
 interface SerializedPoint {
   lat: number;
@@ -18,6 +19,8 @@ interface SerializedPoint {
 }
 
 interface TrailBackup {
+  /** Schema version — bump when fields change so stale backups can be discarded cleanly */
+  version: 1;
   /** Wall-clock epoch ms when recording started */
   recordingStartWallMs: number;
   /** Accumulated pause duration in ms */
@@ -47,11 +50,17 @@ function serializeSegment(
   return seg.map((p) => toSerializedPoint(p, epochOffset));
 }
 
-/** Write the current recording state to localStorage. Silently ignores quota errors. */
-export function saveTrailBackup(state: AppState): void {
-  // epochOffset = wall-clock equivalent of performance.now() == 0
+// ── Debounced write ───────────────────────────────────────────────────────────
+// Serialize the whole trail on the first point of a burst, then at most once
+// every 5 seconds. This avoids O(n²) total serialization work on long hikes.
+
+let _backupDirty = false;
+let _backupTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushBackup(state: AppState): void {
   const epochOffset = Date.now() - performance.now();
   const backup: TrailBackup = {
+    version: CURRENT_VERSION,
     recordingStartWallMs: epochOffset + state.recordingStartMs,
     recordingPauseMs: state.recordingPauseMs,
     trailSegments: state.trailSegments.map((seg) => serializeSegment(seg, epochOffset)),
@@ -65,12 +74,42 @@ export function saveTrailBackup(state: AppState): void {
   }
 }
 
-/** Read a previously persisted trail backup, or null if none exists. */
+/** Write the current recording state to localStorage, debounced to at most once per 5s. */
+export function saveTrailBackup(state: AppState): void {
+  if (_backupTimer === null) {
+    // First call of a burst — write immediately for fast initial persistence
+    flushBackup(state);
+    _backupDirty = false;
+  } else {
+    _backupDirty = true;
+  }
+  if (_backupTimer !== null) clearTimeout(_backupTimer);
+  _backupTimer = setTimeout(() => {
+    if (_backupDirty) flushBackup(state);
+    _backupDirty = false;
+    _backupTimer = null;
+  }, 5000);
+}
+
+/** Read a previously persisted trail backup, or null if none exists or shape is invalid. */
 export function loadTrailBackup(): TrailBackup | null {
   try {
     const raw = localStorage.getItem(BACKUP_KEY);
     if (!raw) return null;
-    return JSON.parse(raw) as TrailBackup;
+    const parsed: unknown = JSON.parse(raw);
+    // Runtime shape guard: discard stale/partial data from schema changes or other apps
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      (parsed as Record<string, unknown>)['version'] !== CURRENT_VERSION ||
+      !Array.isArray((parsed as Record<string, unknown>)['trailPoints']) ||
+      !Array.isArray((parsed as Record<string, unknown>)['trailSegments']) ||
+      typeof (parsed as Record<string, unknown>)['totalDistance'] !== 'number'
+    ) {
+      localStorage.removeItem(BACKUP_KEY);
+      return null;
+    }
+    return parsed as TrailBackup;
   } catch {
     return null;
   }
@@ -78,6 +117,11 @@ export function loadTrailBackup(): TrailBackup | null {
 
 /** Remove the trail backup from localStorage (call after recording stops). */
 export function clearTrailBackup(): void {
+  if (_backupTimer !== null) {
+    clearTimeout(_backupTimer);
+    _backupTimer = null;
+  }
+  _backupDirty = false;
   try {
     localStorage.removeItem(BACKUP_KEY);
   } catch { /* ignore */ }
@@ -86,6 +130,15 @@ export function clearTrailBackup(): void {
 /**
  * Restore a persisted trail backup into AppState and redraw the trail on the map.
  * Returns the number of total points restored, or 0 if backup was empty/unusable.
+ *
+ * Known limitation: direction-arrow markers are NOT restored — the trail line appears
+ * correct but has no chevrons for the pre-reload portion. Arrow markers are cheap to
+ * lose (purely decorative) and expensive to reconstruct without re-running the full
+ * append loop. Acceptable trade-off for now.
+ *
+ * Known limitation: pause-segment boundaries are merged into a single flat polyline
+ * for the restored visual. The per-segment data is preserved in state.trailSegments,
+ * so GPX export will still emit correct <trkseg> splits.
  */
 export function applyTrailBackup(
   backup: TrailBackup,
@@ -114,7 +167,8 @@ export function applyTrailBackup(
   state.trailSegments = allSegs;
   state.trailPoints = activeSeg;
 
-  // Rebuild polyline from all points
+  // Rebuild polyline from all points (segments merged into one visual line —
+  // see "Known limitation" above for why segment gaps are not preserved visually)
   const allLatLngs: L.LatLng[] = [
     ...allSegs.flatMap((s) => s.map((p) => p.latlng)),
     ...activeSeg.map((p) => p.latlng),

--- a/src/trail-backup.ts
+++ b/src/trail-backup.ts
@@ -74,21 +74,26 @@ function flushBackup(state: AppState): void {
   }
 }
 
-/** Write the current recording state to localStorage, debounced to at most once per 5s. */
+/**
+ * Write the current recording state to localStorage, throttled to at most once per 5s.
+ * Leading-edge write fires immediately on the first call; trailing flush catches any
+ * points that arrived during the 5s window. Timer is NOT reset on each call — that
+ * would make it a debounce and the trailing flush would never fire under continuous GPS input.
+ */
 export function saveTrailBackup(state: AppState): void {
   if (_backupTimer === null) {
     // First call of a burst — write immediately for fast initial persistence
     flushBackup(state);
     _backupDirty = false;
+    _backupTimer = setTimeout(() => {
+      if (_backupDirty) flushBackup(state);
+      _backupDirty = false;
+      _backupTimer = null;
+    }, 5000);
   } else {
+    // Timer already running — mark dirty so the trailing flush picks up the latest points
     _backupDirty = true;
   }
-  if (_backupTimer !== null) clearTimeout(_backupTimer);
-  _backupTimer = setTimeout(() => {
-    if (_backupDirty) flushBackup(state);
-    _backupDirty = false;
-    _backupTimer = null;
-  }, 5000);
 }
 
 /** Read a previously persisted trail backup, or null if none exists or shape is invalid. */
@@ -98,13 +103,16 @@ export function loadTrailBackup(): TrailBackup | null {
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     // Runtime shape guard: discard stale/partial data from schema changes or other apps
+    const p = parsed as Record<string, unknown>;
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
-      (parsed as Record<string, unknown>)['version'] !== CURRENT_VERSION ||
-      !Array.isArray((parsed as Record<string, unknown>)['trailPoints']) ||
-      !Array.isArray((parsed as Record<string, unknown>)['trailSegments']) ||
-      typeof (parsed as Record<string, unknown>)['totalDistance'] !== 'number'
+      p['version'] !== CURRENT_VERSION ||
+      !Array.isArray(p['trailPoints']) ||
+      !Array.isArray(p['trailSegments']) ||
+      typeof p['totalDistance'] !== 'number' ||
+      typeof p['recordingStartWallMs'] !== 'number' ||
+      typeof p['recordingPauseMs'] !== 'number'
     ) {
       localStorage.removeItem(BACKUP_KEY);
       return null;


### PR DESCRIPTION
Closes #78

## Summary

- GPS recording already works without network (browser native `watchPosition` API + client-side GPX export). The offline banner was already wired up.
- The missing piece was **localStorage persistence**: if the page reloads mid-hike (browser crash, accidental tab close), the trail was lost.
- New `src/trail-backup.ts` saves trail state to `localStorage` on every accepted GPS point. On next page load, `maybeRestoreTrailBackup()` detects the backup and prompts the user to restore.

## Changes

- **`src/trail-backup.ts`** (new): `saveTrailBackup`, `loadTrailBackup`, `clearTrailBackup`, `applyTrailBackup` — converts `performance.now()` timestamps to wall-clock ms before serializing so timestamps survive a page reload
- **`src/recording.ts`**: call `saveTrailBackup()` on every trail point append; `clearTrailBackup()` on recording stop; export `maybeRestoreTrailBackup()` for main.ts startup
- **`src/main.ts`**: call `maybeRestoreTrailBackup()` after recording controls mount; re-renders buttons if a recording was restored

## Test plan

- [ ] Start recording, reload the page — confirm restore prompt appears and trail redraws
- [ ] Start recording, let it run, stop normally — confirm no restore prompt on next load
- [ ] Go offline mid-recording — confirm trail continues accumulating points and banner shows
- [ ] Export GPX while offline — confirm download completes locally
- [ ] Restore backup, then stop recording — confirm GPX includes all pre-reload points

🤖 Generated with [Claude Code](https://claude.com/claude-code)