### PR TITLE
fix(ux): long addresses accessible in geocode bar peek state

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -476,6 +476,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
 
   function showGeocodeBar(label: string, copyText: string): void {
     barAddrEl.textContent = label;
+    barAddrEl.title = label;
     barCopyBtn.dataset['copy'] = copyText;
     barCopyBtn.textContent = 'Copy';
     barCopyBtn.classList.remove('geocode-bar__copy--copied');


### PR DESCRIPTION
## Summary
- Set `title` attribute on `.geocode-bar__addr` so the full address is visible via tooltip when CSS ellipsis truncates it in peek state
- Existing CSS (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0`) already handles overflow correctly — no style changes needed

## Test plan
- [ ] Drop a pin at a location that returns a long ESRI `Match_addr` (e.g. a full street address with suite/unit)
- [ ] Verify ellipsis truncation in peek state on iPhone SE (375px viewport)
- [ ] Hover over the truncated address on desktop — tooltip should show full text
- [ ] Expand sheet to full — address remains single-line with ellipsis (expected; sheet body is a single flex row)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)