### PR TITLE
fix(ux): show GPS weak-signal badge during trail recording

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -10,7 +10,7 @@ import { updateLocateIcon } from './controls';
 import { appendTrailPoint } from './recording';
 
 /** Discard GPS fixes coarser than this threshold for trail recording (metres). */
-const TRAIL_MAX_ACCURACY_M = 30;
+export const TRAIL_MAX_ACCURACY_M = 30;
 
 // divIcon HTML for the blue pulsing dot — styled via .blue-dot CSS in style.css
 const BLUE_DOT_ICON = L.divIcon({
@@ -36,6 +36,9 @@ function createGrayDotIcon(): L.DivIcon {
  * effect: Eliminates stationary GPS jitter without introducing lag when the user actually moves
  */
 export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map): void {
+  // Always track the latest GPS accuracy so the stats bar can show a weak-signal indicator
+  state.lastGpsAccuracy = e.accuracy;
+
   // Haversine formula: great-circle distance between previous and current position
   const p = Math.PI / 180;
   const f =

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -6,6 +6,7 @@
  */
 import L from 'leaflet';
 import type { AppState } from './types';
+import { TRAIL_MAX_ACCURACY_M } from './location';
 import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup, dismissTrailBackup, isTrailBackupDismissed } from './trail-backup';
 
 // tradeoff: 5m minimum distance filters GPS jitter at walking pace without skipping real movement; lower values add noise, higher values miss tight turns
@@ -114,6 +115,9 @@ export function createStatsBar(): void {
     '<div class="rec-indicator">' +
     '<span class="rec-dot"></span>' +
     '<span id="rec-status-label">RECORDING</span>' +
+    '</div>' +
+    '<div class="gps-badge" id="gps-weak-badge">' +
+    'GPS ±<span id="gps-accuracy-val">--</span>m' +
     '</div>';
 
   document.getElementById('map')?.appendChild(bar);
@@ -135,6 +139,20 @@ function updateStatsBar(state: AppState): void {
       dotEl.classList.add('rec-dot-paused');
     } else {
       dotEl.classList.remove('rec-dot-paused');
+    }
+  }
+
+  // Show GPS weak badge when recording and last fix exceeded accuracy threshold
+  const gpsBadge = document.getElementById('gps-weak-badge');
+  const gpsVal = document.getElementById('gps-accuracy-val');
+  if (gpsBadge && gpsVal) {
+    const weak =
+      state.recordingState === 'recording' &&
+      state.lastGpsAccuracy !== null &&
+      state.lastGpsAccuracy > TRAIL_MAX_ACCURACY_M;
+    gpsBadge.style.display = weak ? 'block' : 'none';
+    if (weak) {
+      gpsVal.textContent = String(Math.round(state.lastGpsAccuracy!));
     }
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -184,6 +184,19 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #ff6b6b;
 }
 
+/* GPS weak-signal badge — shown when recording and accuracy exceeds threshold */
+.gps-badge {
+  display: none;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 10px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.2);
+  color: #f59e0b;
+  text-align: center;
+}
+
 .stat-item {
   display: flex;
   flex-direction: column;

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export interface AppState {
   trailSegments: Array<Array<{ latlng: L.LatLng; t: number; speedMs: number; altM?: number }>>;
   arrowMarkers: L.Marker[];
   statsTimer: ReturnType<typeof setInterval> | null;
+  lastGpsAccuracy: number | null; // most recent GPS fix accuracy (metres); used by stats bar to show weak-signal indicator
 }
 
 export function createInitialState(): AppState {
@@ -75,5 +76,6 @@ export function createInitialState(): AppState {
     trailSegments: [],
     arrowMarkers: [],
     statsTimer: null,
+    lastGpsAccuracy: null,
   };
 }


### PR DESCRIPTION
## Summary

- Adds an amber "GPS ±Xm" badge to the recording stats bar when the most recent GPS fix exceeds the 30m accuracy threshold (`TRAIL_MAX_ACCURACY_M`)
- Tracks `lastGpsAccuracy` in AppState from every `locationfound` event (before jitter filtering)
- Badge auto-hides when accuracy improves or recording is paused/stopped

## Test plan

- [ ] Start trail recording in a location with good GPS — badge should not appear
- [ ] Move to an area with poor GPS (indoors, heavy canopy) — amber badge should appear showing accuracy value
- [ ] Return to good signal — badge should disappear within 1s (stats bar update interval)
- [ ] Pause recording while badge is visible — badge should hide
- [ ] Stop recording — badge should hide
- [ ] Verify no layout shift in stats bar when badge toggles

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)