### PR TITLE
fix(ux): tap-to-expand long address on mobile geocode bar

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -408,6 +408,33 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   const barCopyBtn = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__copy')!;
   const barHandle  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__handle')!;
 
+  // Tap-to-expand: tapping a truncated address shows the full text for 3s
+  // (or until a second tap). This makes long addresses readable on mobile
+  // where title-attr tooltips don't render.
+  let addrCollapseTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function collapseAddr(): void {
+    barAddrEl.classList.remove('geocode-bar__addr--expanded');
+    if (addrCollapseTimer !== undefined) {
+      clearTimeout(addrCollapseTimer);
+      addrCollapseTimer = undefined;
+    }
+  }
+
+  barAddrEl.addEventListener('click', (e: MouseEvent) => {
+    // Don't interfere with the copy button or close button
+    if ((e.target as HTMLElement).closest('.geocode-bar__copy, .geocode-bar__close')) return;
+
+    if (barAddrEl.classList.contains('geocode-bar__addr--expanded')) {
+      collapseAddr();
+      return;
+    }
+
+    barAddrEl.classList.add('geocode-bar__addr--expanded');
+    if (addrCollapseTimer !== undefined) clearTimeout(addrCollapseTimer);
+    addrCollapseTimer = setTimeout(collapseAddr, 3000);
+  });
+
   // Height of the sheet visible in peek state (px), augmented by safe-area-inset-bottom
   // so the handle + action row remain fully above the home-indicator on notched phones.
   const PEEK_HEIGHT_BASE = 130;
@@ -475,6 +502,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   }
 
   function showGeocodeBar(label: string, copyText: string): void {
+    collapseAddr();
     barAddrEl.textContent = label;
     barAddrEl.title = label;
     barCopyBtn.dataset['copy'] = copyText;

--- a/src/style.css
+++ b/src/style.css
@@ -493,7 +493,8 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .geocode-bar--peek .geocode-bar__handle,
 .geocode-bar--peek .geocode-bar__copy,
-.geocode-bar--peek .geocode-bar__close {
+.geocode-bar--peek .geocode-bar__close,
+.geocode-bar--peek .geocode-bar__addr {
   pointer-events: auto;
 }
 
@@ -568,6 +569,15 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   white-space: nowrap;
   color: #222;
   min-width: 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Tap-to-expand: show full address as multi-line text */
+.geocode-bar__addr--expanded {
+  white-space: normal;
+  text-overflow: clip;
+  word-break: break-word;
 }
 
 .geocode-bar__close {


### PR DESCRIPTION
## Summary

- Adds tap-to-expand behavior on `.geocode-bar__addr` so truncated long addresses are readable on mobile without expanding the sheet
- Tapping the address text expands it to multi-line for 3 seconds; a second tap collapses immediately
- Adds `pointer-events: auto` to the address element in peek state so taps register through the overlay

## Problem

PR #90 added `title` attr for long address accessibility, but `title` tooltips are desktop-only (hover). Mobile users — the primary target — still couldn't read truncated addresses without changing sheet state.

## Test plan

- [ ] Drop pin on a location with a long address (e.g. reverse geocode a rural intersection)
- [ ] In peek state, verify the address is truncated with ellipsis
- [ ] Tap the address text — it should expand to show full multi-line text
- [ ] After 3 seconds, verify it auto-collapses back to single-line
- [ ] Tap again while expanded — verify immediate collapse
- [ ] Verify desktop hover tooltip (`title` attr) still works
- [ ] Verify Copy and Close buttons are unaffected

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)