### PR TITLE
fix(ux): add hysteresis to GPS weak-signal badge

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -39,6 +39,22 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
   // Always track the latest GPS accuracy so the stats bar can show a weak-signal indicator
   state.lastGpsAccuracy = e.accuracy;
 
+  // Update hysteresis counters for GPS weak-signal badge (show after 2+ weak fixes,
+  // hide after 2+ strong fixes, hold state in the 25-30m deadband)
+  if (e.accuracy > TRAIL_MAX_ACCURACY_M) {
+    state.gpsWeakStreak++;
+    state.gpsStrongStreak = 0;
+    if (state.gpsWeakStreak >= 2) state.gpsWeakBadgeVisible = true;
+  } else if (e.accuracy < TRAIL_MAX_ACCURACY_M - 5) {
+    state.gpsStrongStreak++;
+    state.gpsWeakStreak = 0;
+    if (state.gpsStrongStreak >= 2) state.gpsWeakBadgeVisible = false;
+  } else {
+    // Deadband (25–30m): reset streaks, keep current badge state
+    state.gpsWeakStreak = 0;
+    state.gpsStrongStreak = 0;
+  }
+
   // Haversine formula: great-circle distance between previous and current position
   const p = Math.PI / 180;
   const f =

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -6,7 +6,6 @@
  */
 import L from 'leaflet';
 import type { AppState } from './types';
-import { TRAIL_MAX_ACCURACY_M } from './location';
 import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup, dismissTrailBackup, isTrailBackupDismissed } from './trail-backup';
 
 // tradeoff: 5m minimum distance filters GPS jitter at walking pace without skipping real movement; lower values add noise, higher values miss tight turns
@@ -142,17 +141,14 @@ function updateStatsBar(state: AppState): void {
     }
   }
 
-  // Show GPS weak badge when recording and last fix exceeded accuracy threshold
+  // Show GPS weak badge using hysteresis state (avoids flicker in marginal signal)
   const gpsBadge = document.getElementById('gps-weak-badge');
   const gpsVal = document.getElementById('gps-accuracy-val');
   if (gpsBadge && gpsVal) {
-    const weak =
-      state.recordingState === 'recording' &&
-      state.lastGpsAccuracy !== null &&
-      state.lastGpsAccuracy > TRAIL_MAX_ACCURACY_M;
+    const weak = state.recordingState === 'recording' && state.gpsWeakBadgeVisible;
     gpsBadge.style.display = weak ? 'block' : 'none';
-    if (weak) {
-      gpsVal.textContent = String(Math.round(state.lastGpsAccuracy!));
+    if (weak && state.lastGpsAccuracy !== null) {
+      gpsVal.textContent = String(Math.round(state.lastGpsAccuracy));
     }
   }
 }
@@ -303,6 +299,9 @@ function startRecording(
   state.lastSpeedMs = 0;
   state.trailPoints = [];
   state.trailSegments = [];
+  state.gpsWeakStreak = 0;
+  state.gpsStrongStreak = 0;
+  state.gpsWeakBadgeVisible = false;
 
   // Glow layer beneath the main trail line
   state.trailGlow = L.polyline([], TRAIL_GLOW_OPTS).addTo(map);

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,11 @@ export interface AppState {
   arrowMarkers: L.Marker[];
   statsTimer: ReturnType<typeof setInterval> | null;
   lastGpsAccuracy: number | null; // most recent GPS fix accuracy (metres); used by stats bar to show weak-signal indicator
+
+  // Hysteresis state for GPS weak-signal badge — prevents flicker in marginal signal
+  gpsWeakStreak: number;        // consecutive fixes with accuracy > TRAIL_MAX_ACCURACY_M
+  gpsStrongStreak: number;      // consecutive fixes with accuracy < (TRAIL_MAX_ACCURACY_M - 5)
+  gpsWeakBadgeVisible: boolean; // debounced badge state: true after 2+ weak, false after 2+ strong
 }
 
 export function createInitialState(): AppState {
@@ -77,5 +82,8 @@ export function createInitialState(): AppState {
     arrowMarkers: [],
     statsTimer: null,
     lastGpsAccuracy: null,
+    gpsWeakStreak: 0,
+    gpsStrongStreak: 0,
+    gpsWeakBadgeVisible: false,
   };
 }


### PR DESCRIPTION
## Summary
- Adds hysteresis (deadband) to the GPS weak-signal badge to prevent rapid flicker when accuracy oscillates around the 30m threshold in marginal signal conditions
- Show badge after 2+ consecutive fixes > 30m; hide after 2+ consecutive fixes < 25m; hold state in the 25–30m gap
- Resets hysteresis counters on new recording start to avoid stale state carry-over

## Test plan
- [ ] Start trail recording in an area with marginal GPS signal (~25-35m accuracy)
- [ ] Verify badge does not flicker on/off every GPS cycle
- [ ] Verify badge appears after sustained weak signal (2+ consecutive fixes > 30m)
- [ ] Verify badge disappears after sustained strong signal (2+ consecutive fixes < 25m)
- [ ] Verify badge accuracy readout still updates when visible
- [ ] Stop and restart recording — verify badge starts hidden

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)