### PR TITLE
feat(ux): add mouse drag support to reverse geocode bottom sheet handle

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/jplumb/webmap.dev/node_modules

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -536,6 +536,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   let dragStartY = 0;
   let dragStartOffset = 0;
   let isDragging = false;
+  let dragMoved = false; // suppresses click-toggle after a mouse drag
 
   barHandle.addEventListener('touchstart', (e: TouchEvent) => {
     const touch = e.touches[0];
@@ -577,6 +578,48 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     snapTo(currentOffset < peekOffset / 2 ? 'full' : 'peek');
   }, { passive: true });
 
+  // ── Mouse drag-to-snap on handle (mirrors touch handlers for desktop) ──
+  barHandle.addEventListener('mousedown', (e: MouseEvent) => {
+    if (e.button !== 0) return; // only primary button
+    isDragging = true;
+    dragMoved = false;
+    dragStartY = e.clientY;
+    dragStartOffset = getCurrentOffset();
+    geocodeBar.style.willChange = 'transform';
+    geocodeBar.style.transition = 'none';
+    e.preventDefault(); // prevent text selection during drag
+  });
+
+  document.addEventListener('mousemove', (e: MouseEvent) => {
+    if (!isDragging) return;
+    if (e.buttons !== 1) {
+      // Button was released outside the window — end drag gracefully
+      isDragging = false;
+      geocodeBar.style.willChange = '';
+      return;
+    }
+    const delta = e.clientY - dragStartY;
+    if (Math.abs(delta) > 3) dragMoved = true;
+    const clamped = Math.max(-20, Math.min(geocodeBar.offsetHeight + 20, dragStartOffset + delta));
+    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (!isDragging) return;
+    isDragging = false;
+    geocodeBar.style.willChange = '';
+    const currentOffset = getCurrentOffset();
+    const peekOffset = getPeekOffset();
+    // Dragged more than 80px below peek → dismiss
+    if (currentOffset > peekOffset + 80) {
+      hideGeocodeBar();
+      pinLayer.clearLayers();
+      return;
+    }
+    // Snap to nearest: below midpoint between full(0) and peek → full; above → peek
+    snapTo(currentOffset < peekOffset / 2 ? 'full' : 'peek');
+  });
+
   // Click and keyboard (Enter / Space) on handle bar toggle peek ↔ full.
   // Both are required: click fires from pointer devices; keydown covers
   // keyboard and assistive-technology users (role="button" + tabindex="0").
@@ -585,7 +628,10 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     else if (sheetState === 'full') snapTo('peek');
   }
 
-  barHandle.addEventListener('click', handleToggle);
+  barHandle.addEventListener('click', () => {
+    if (dragMoved) { dragMoved = false; return; }
+    handleToggle();
+  });
   barHandle.addEventListener('keydown', (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -595,7 +595,16 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     if (e.buttons !== 1) {
       // Button was released outside the window — end drag gracefully
       isDragging = false;
+      dragMoved = false;
       geocodeBar.style.willChange = '';
+      const earlyOffset = getCurrentOffset();
+      const earlyPeek = getPeekOffset();
+      if (earlyOffset > earlyPeek + 80) {
+        hideGeocodeBar();
+        pinLayer.clearLayers();
+      } else {
+        snapTo(earlyOffset < earlyPeek / 2 ? 'full' : 'peek');
+      }
       return;
     }
     const delta = e.clientY - dragStartY;
@@ -608,6 +617,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
     if (!isDragging) return;
     isDragging = false;
     geocodeBar.style.willChange = '';
+    setTimeout(() => { dragMoved = false; }, 0); // let click fire first, then reset
     const currentOffset = getCurrentOffset();
     const peekOffset = getPeekOffset();
     // Dragged more than 80px below peek → dismiss
@@ -629,7 +639,7 @@ export function addReverseGeocoding(map: L.Map, state: AppState): void {
   }
 
   barHandle.addEventListener('click', () => {
-    if (dragMoved) { dragMoved = false; return; }
+    if (dragMoved) return; // mouseup's setTimeout resets the flag
     handleToggle();
   });
   barHandle.addEventListener('keydown', (e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- Add `mousedown`/`mousemove`/`mouseup` listeners to the bottom sheet handle, mirroring the existing touch handlers for desktop mouse drag support
- `mousemove`/`mouseup` are on `document` to avoid losing events when cursor exits the handle mid-drag; `e.buttons === 1` guard catches missed button-up outside the window
- `dragMoved` flag suppresses the click-to-toggle handler after a genuine drag, preventing accidental peek/full toggling on mouseup

## Test plan
- [ ] Right-click map to drop a pin → geocode bar appears in peek state
- [ ] Mouse-drag the handle upward → sheet expands to full
- [ ] Mouse-drag the handle downward from full → snaps back to peek
- [ ] Mouse-drag far below peek (>80px) → sheet dismisses
- [ ] Click (no drag) on handle → toggles peek ↔ full as before
- [ ] Mouse-drag does not cause map panning underneath
- [ ] Touch drag still works on mobile/touch devices

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)