### PR TITLE
feat(search): expandable result items on mobile

### DIFF
--- a/src/bottom-sheet.ts
+++ b/src/bottom-sheet.ts
@@ -228,39 +228,56 @@ export function initInfoPanel(map: L.Map): void {
 
   const bodyEl = el.querySelector('.info-panel__body') as HTMLElement;
 
-  // Event delegation: click a result item → fly to its location and mark active
+  // Event delegation: expand result on first tap; fly to location on "Go" button
   bodyEl.addEventListener('click', (e: MouseEvent) => {
-    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-lat]');
-    if (target === null || _map === null) return;
-    const lat = parseFloat(target.dataset['lat'] ?? '');
-    const lng = parseFloat(target.dataset['lng'] ?? '');
-    if (isNaN(lat) || isNaN(lng)) return;
-    // Reset all markers and list items, then activate the selected one
-    if (_clearSelectionFn) _clearSelectionFn();
-    target.classList.add('sheet-result--active');
-    const idx = parseInt(target.dataset['index'] ?? '', 10);
-    if (_activateSelectionFn && !isNaN(idx)) _activateSelectionFn(idx);
-    const boundsRaw = target.dataset['bounds'] ?? '';
-    if (boundsRaw !== '') {
-      try {
-        const parsed = JSON.parse(boundsRaw) as unknown;
-        if (Array.isArray(parsed) && parsed.length === 2 &&
-            Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
-          _map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
-              paddingTopLeft: [50, 50],
-              paddingBottomRight: [50, isMobile() ? 300 : 50],
-              maxZoom: 17,
-            });
-        } else {
+    const clicked = e.target as HTMLElement;
+
+    // Let the copy handler (separate listener below) handle data-copy buttons
+    if (clicked.closest('[data-copy]')) return;
+
+    // "Go to location" button — fly to result and mark active
+    const goBtn = clicked.closest<HTMLElement>('.sheet-result__go-btn');
+    if (goBtn) {
+      const target = goBtn.closest<HTMLElement>('[data-lat]');
+      if (target === null || _map === null) return;
+      const lat = parseFloat(target.dataset['lat'] ?? '');
+      const lng = parseFloat(target.dataset['lng'] ?? '');
+      if (isNaN(lat) || isNaN(lng)) return;
+      if (_clearSelectionFn) _clearSelectionFn();
+      target.classList.add('sheet-result--active');
+      target.classList.remove('sheet-result--expanded');
+      const idx = parseInt(target.dataset['index'] ?? '', 10);
+      if (_activateSelectionFn && !isNaN(idx)) _activateSelectionFn(idx);
+      const boundsRaw = target.dataset['bounds'] ?? '';
+      if (boundsRaw !== '') {
+        try {
+          const parsed = JSON.parse(boundsRaw) as unknown;
+          if (Array.isArray(parsed) && parsed.length === 2 &&
+              Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
+            _map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
+                paddingTopLeft: [50, 50],
+                paddingBottomRight: [50, isMobile() ? 300 : 50],
+                maxZoom: 17,
+              });
+          } else {
+            _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+          }
+        } catch {
           _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
         }
-      } catch {
+      } else {
         _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
       }
-    } else {
-      _map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+      snapTo('half');
+      return;
     }
-    snapTo('half');
+
+    // Result item click — toggle expand/collapse
+    const li = clicked.closest<HTMLElement>('.sheet-result');
+    if (li === null) return;
+    const prev = bodyEl.querySelector('.sheet-result--expanded');
+    if (prev && prev !== li) prev.classList.remove('sheet-result--expanded');
+    li.classList.toggle('sheet-result--expanded');
   });
 
   // Event delegation: click a copy button → write to clipboard

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -126,7 +126,7 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
     collapseAfterResult: false,
     minCharacters: MIN_CHARS,
     debounceDelay: 250,
-    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey, outFields: 'Addr_type,City,Region,Postal' }))],
+    providers: [wrapProvider(arcgisOnlineProvider({ maxResults: 15, apikey, outFields: 'Addr_type,City,Region,Postal,LongLabel,Match_addr' }))],
   });
   searchControl.addTo(map);
 
@@ -235,44 +235,70 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
     if (marker) marker.setIcon(createActiveNumberedIcon(index + 1));
   }
 
-  // Event delegation on dropdown — wired once; fires for any result-item click.
+  // Event delegation on dropdown — expand/collapse on item click; navigate on "Go" button.
   dropdownEl.addEventListener('click', (e: MouseEvent) => {
-    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-lat]');
-    if (target === null) return;
-    const lat = parseFloat(target.dataset['lat'] ?? '');
-    const lng = parseFloat(target.dataset['lng'] ?? '');
-    if (isNaN(lat) || isNaN(lng)) return;
-    // Clear dropped pin markers; show geocode bar with the selected result's address and coordinates.
-    _pinLayer?.clearLayers();
-    const resultName = target.dataset['name'] ?? '';
-    const coordText = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
-    const label = resultName !== '' ? resultName : coordText;
-    const copyText = resultName !== '' ? `${resultName}\n${coordText}` : coordText;
-    _showGeocodeBar?.(label, copyText);
-    clearSelection();
-    target.classList.add('sheet-result--active');
-    const idx = parseInt(target.dataset['index'] ?? '', 10);
-    if (!isNaN(idx)) activateSelection(idx);
-    const boundsRaw = target.dataset['bounds'] ?? '';
-    if (boundsRaw !== '') {
-      try {
-        const parsed = JSON.parse(boundsRaw) as unknown;
-        if (Array.isArray(parsed) && parsed.length === 2 &&
-            Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
-          map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
-            paddingTopLeft:     [50, 50],
-            paddingBottomRight: [50, 50],
-            maxZoom: 17,
-          });
-        } else {
-          map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+    const clicked = e.target as HTMLElement;
+
+    // "Go to location" button — fly to the result and show geocode bar
+    const goBtn = clicked.closest<HTMLElement>('.sheet-result__go-btn');
+    if (goBtn) {
+      const li = goBtn.closest<HTMLElement>('.sheet-result[data-lat]');
+      if (li === null) return;
+      const lat = parseFloat(li.dataset['lat'] ?? '');
+      const lng = parseFloat(li.dataset['lng'] ?? '');
+      if (isNaN(lat) || isNaN(lng)) return;
+      _pinLayer?.clearLayers();
+      const resultName = li.dataset['name'] ?? '';
+      const coordText = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+      const label = resultName !== '' ? resultName : coordText;
+      const copyText = resultName !== '' ? `${resultName}\n${coordText}` : coordText;
+      _showGeocodeBar?.(label, copyText);
+      clearSelection();
+      li.classList.add('sheet-result--active');
+      li.classList.remove('sheet-result--expanded');
+      const idx = parseInt(li.dataset['index'] ?? '', 10);
+      if (!isNaN(idx)) activateSelection(idx);
+      const boundsRaw = li.dataset['bounds'] ?? '';
+      if (boundsRaw !== '') {
+        try {
+          const parsed = JSON.parse(boundsRaw) as unknown;
+          if (Array.isArray(parsed) && parsed.length === 2 &&
+              Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
+            map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
+              paddingTopLeft:     [50, 50],
+              paddingBottomRight: [50, 50],
+              maxZoom: 17,
+            });
+          } else {
+            map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
+          }
+        } catch {
+          map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
         }
-      } catch {
-        map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+      } else {
+        map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
       }
-    } else {
-      map.flyTo(L.latLng(lat, lng), zoomForAddrType(target.dataset['addrType'] ?? ''));
+      return;
     }
+
+    // Copy button inside expanded detail
+    const copyBtn = clicked.closest<HTMLElement>('.sheet-result__copy-btn');
+    if (copyBtn) {
+      const text = copyBtn.dataset['copy'] ?? '';
+      const origText = copyBtn.textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        copyBtn.textContent = '\u2713 Copied';
+        setTimeout(() => { copyBtn.textContent = origText; }, 1500);
+      }).catch(() => { /* silent */ });
+      return;
+    }
+
+    // Result item click — toggle expand/collapse
+    const li = clicked.closest<HTMLElement>('.sheet-result');
+    if (li === null) return;
+    const prev = dropdownEl.querySelector('.sheet-result--expanded');
+    if (prev && prev !== li) prev.classList.remove('sheet-result--expanded');
+    li.classList.toggle('sheet-result--expanded');
   });
 
   // Keep marker size in sync with map zoom level via CSS classes.
@@ -336,15 +362,31 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
             .join(', ');
           const tooltipParts = [name, subtitle, addrType, `${lat}, ${lng}`].filter(Boolean);
           const tooltip = escapeHtml(tooltipParts.join(' · '));
+          const longLabel = escapeHtml(strProp(r.properties?.LongLabel) || strProp(r.properties?.Match_addr) || r.text || '');
+          const coordStr = `${lat}, ${lng}`;
           return (
             `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}"` +
             ` data-name="${escapeHtml(name)}" data-bounds="${escapeHtml(boundsJson)}" data-addr-type="${addrType}" title="${tooltip}">` +
-            `  <div class="sheet-result__main">` +
-            `    <span class="sheet-result__name">${name}</span>` +
-            (subtitle ? `    <span class="sheet-result__subtitle">${subtitle}</span>` : '') +
+            `  <div class="sheet-result__summary">` +
+            `    <div class="sheet-result__main">` +
+            `      <span class="sheet-result__name">${name}</span>` +
+            (subtitle ? `      <span class="sheet-result__subtitle">${subtitle}</span>` : '') +
+            `    </div>` +
+            (addrType ? `    <span class="sheet-result__badge">${addrType}</span>` : '') +
+            `    <span class="sheet-result__arrow">&#x203A;</span>` +
             `  </div>` +
-            (addrType ? `  <span class="sheet-result__badge">${addrType}</span>` : '') +
-            `  <span class="sheet-result__arrow">&#x203A;</span>` +
+            `  <div class="sheet-result__detail">` +
+            `    <div class="sheet-result__full-addr">${longLabel}</div>` +
+            `    <div class="sheet-result__detail-meta">` +
+            (addrType ? `      <span class="sheet-result__detail-badge">${addrType}</span>` : '') +
+            `      <span class="sheet-result__detail-coords">${coordStr}</span>` +
+            `    </div>` +
+            `    <div class="sheet-result__detail-actions">` +
+            `      <button class="sheet-result__go-btn">Go to location</button>` +
+            `      <button class="sheet-result__copy-btn" data-copy="${longLabel}">Copy address</button>` +
+            `      <button class="sheet-result__copy-btn" data-copy="${escapeHtml(coordStr)}">Copy coords</button>` +
+            `    </div>` +
+            `  </div>` +
             `</li>`
           );
         })

--- a/src/style.css
+++ b/src/style.css
@@ -483,7 +483,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 .sheet-result--expanded .sheet-result__detail {
-  max-height: 200px;
+  max-height: 300px;
   opacity: 1;
 }
 
@@ -542,6 +542,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #fff;
 }
 
+.sheet-result__go-btn:hover {
+  background: #3d82c4;
+}
+
 .sheet-result__go-btn:active {
   background: #3a7bc8;
 }
@@ -549,6 +553,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .sheet-result__copy-btn {
   background: #f0f0f0;
   color: #444;
+}
+
+.sheet-result__copy-btn:hover {
+  background: #e8e8e8;
 }
 
 .sheet-result__copy-btn:active {

--- a/src/style.css
+++ b/src/style.css
@@ -402,8 +402,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .sheet-result {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  flex-direction: column;
   padding: 12px 4px;
   border-bottom: 1px solid #f0f0f0;
   cursor: pointer;
@@ -456,6 +455,8 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   font-size: 18px;
   margin-left: 8px;
   align-self: center;
+  display: inline-block;
+  transition: transform 0.2s ease;
 }
 
 /* Active selection state for result list items */
@@ -463,6 +464,95 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   background: #e8f0fe;
   border-left: 3px solid #4a90d9;
   padding-left: calc(12px - 3px); /* compensate for border */
+}
+
+/* ── Expandable result detail (tap-to-preview on mobile) ── */
+.sheet-result__summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.sheet-result__detail {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.2s ease;
+  width: 100%;
+}
+
+.sheet-result--expanded .sheet-result__detail {
+  max-height: 200px;
+  opacity: 1;
+}
+
+.sheet-result--expanded .sheet-result__arrow {
+  transform: rotate(90deg);
+}
+
+.sheet-result__full-addr {
+  font-size: 13px;
+  color: #444;
+  margin-top: 8px;
+  line-height: 1.4;
+}
+
+.sheet-result__detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.sheet-result__detail-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #e8f0fe;
+  color: #4a90d9;
+  white-space: nowrap;
+}
+
+.sheet-result__detail-coords {
+  font-size: 11px;
+  color: #888;
+  font-family: monospace;
+}
+
+.sheet-result__detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.sheet-result__go-btn,
+.sheet-result__copy-btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sheet-result__go-btn {
+  background: #4a90d9;
+  color: #fff;
+}
+
+.sheet-result__go-btn:active {
+  background: #3a7bc8;
+}
+
+.sheet-result__copy-btn {
+  background: #f0f0f0;
+  color: #444;
+}
+
+.sheet-result__copy-btn:active {
+  background: #e0e0e0;
 }
 
 /* ── Reverse geocode bottom sheet ── */


### PR DESCRIPTION
## Summary
- **First tap** on a search result expands it inline to show full address (`LongLabel`/`Match_addr`), result type badge, coordinates, and action buttons (Go to location, Copy address, Copy coords)
- **Second tap** via the "Go to location" button flies to the location and collapses the item
- Expanding one result auto-collapses any previously expanded sibling
- Updated both the dropdown click handler (`geocoding.ts`) and the bottom-sheet body click handler (`bottom-sheet.ts`) to use the expand-then-navigate pattern
- CSS `max-height` transition for smooth expand/collapse animation with rotating arrow indicator

## Test plan
- [ ] Search for an address on mobile — verify first tap expands result with full details
- [ ] Verify tapping a different result auto-collapses the previous one
- [ ] Tap "Go to location" button — verify map flies to location and result collapses
- [ ] Tap "Copy address" and "Copy coords" buttons — verify clipboard content
- [ ] Verify desktop dropdown still works (expand/collapse + Go button)
- [ ] Verify marker click still highlights corresponding result in dropdown

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)