### PR TITLE
feat(gps): battery efficiency for continuous trail recording

### DIFF
--- a/src/battery.ts
+++ b/src/battery.ts
@@ -1,0 +1,67 @@
+/**
+ * Intent: Battery monitoring for projected battery life during trail recording
+ * Context: Uses the Battery Status API (Chromium-based browsers); gracefully degrades when unavailable
+ * Pattern: Capture battery level at recording start, track drain rate, project remaining time
+ */
+import type { AppState } from './types';
+
+interface BatteryManager extends EventTarget {
+  charging: boolean;
+  chargingTime: number;
+  dischargingTime: number;
+  level: number;
+}
+
+declare global {
+  interface Navigator {
+    getBattery?: () => Promise<BatteryManager>;
+  }
+}
+
+/** Initialize battery monitoring. Safe to call on browsers without Battery Status API. */
+export async function initBattery(state: AppState): Promise<void> {
+  if (!navigator.getBattery) return;
+  try {
+    const battery = await navigator.getBattery();
+    state.batteryLevel = battery.level;
+    state.batteryCharging = battery.charging;
+    battery.addEventListener('levelchange', () => {
+      state.batteryLevel = battery.level;
+    });
+    battery.addEventListener('chargingchange', () => {
+      state.batteryCharging = battery.charging;
+    });
+  } catch { /* Battery API unavailable or blocked by permissions policy */ }
+}
+
+/** Capture current battery level as the baseline for drain rate calculation. */
+export function snapshotBatteryStart(state: AppState): void {
+  state.batteryDrainStartLevel = state.batteryLevel;
+  state.batteryDrainStartMs = performance.now();
+}
+
+/** Format battery estimate for display: "73% — ~4h 52m left" or just "73%". */
+export function formatBatteryEstimate(state: AppState): string | null {
+  if (state.batteryLevel === null) return null;
+  const pct = `${Math.round(state.batteryLevel * 100)}%`;
+
+  if (state.batteryCharging) return `${pct} (charging)`;
+  if (state.batteryDrainStartLevel === null) return pct;
+
+  const drained = state.batteryDrainStartLevel - state.batteryLevel;
+  if (drained <= 0.005) return pct; // need at least 0.5% drain for useful estimate
+
+  const elapsedHours = (performance.now() - state.batteryDrainStartMs) / 3_600_000;
+  if (elapsedHours < 1 / 60) return pct; // need at least 1 minute of data
+
+  const drainPerHour = drained / elapsedHours;
+  if (drainPerHour <= 0) return pct;
+
+  const hoursLeft = state.batteryLevel / drainPerHour;
+  if (hoursLeft >= 1) {
+    const h = Math.floor(hoursLeft);
+    const m = Math.round((hoursLeft - h) * 60);
+    return `${pct} — ~${h}h${m > 0 ? ` ${m}m` : ''} left`;
+  }
+  return `${pct} — ~${Math.round(hoursLeft * 60)}m left`;
+}

--- a/src/location.ts
+++ b/src/location.ts
@@ -8,9 +8,15 @@ import L from 'leaflet';
 import type { AppState } from './types';
 import { updateLocateIcon } from './controls';
 import { appendTrailPoint } from './recording';
+import { setWatchAccuracy } from './timer';
 
 /** Discard GPS fixes coarser than this threshold for trail recording (metres). */
 export const TRAIL_MAX_ACCURACY_M = 30;
+
+/** Speed below which the user is considered stationary (m/s). 0.5 m/s ~ 1.8 km/h. */
+const STATIONARY_SPEED_MS = 0.5;
+/** Consecutive stationary fixes before switching to low-accuracy GPS to save battery. */
+const STATIONARY_THRESHOLD = 5;
 
 // divIcon HTML for the blue pulsing dot — styled via .blue-dot CSS in style.css
 const BLUE_DOT_ICON = L.divIcon({
@@ -67,8 +73,8 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
   const R = 6371000; // Earth's radius in meters
   const dist = 2 * R * Math.asin(Math.sqrt(f));
 
-  // On first GPS fix, zoom to street level
-  if (state.initialZoom) {
+  // On first GPS fix, zoom to street level (defer if screen is off)
+  if (state.initialZoom && !state.screenOff) {
     map.setZoom(16);
     state.initialZoom = false;
   }
@@ -80,36 +86,39 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     state.youAreHereLocationlng = e.latlng.lng;
     state.youAreHereLocation = e.latlng;
 
-    // Blue dot: create on first fix, update position on subsequent fixes
-    if (state.locationMarker === null) {
-      state.locationMarker = L.marker(e.latlng, {
-        icon: BLUE_DOT_ICON,
-        zIndexOffset: 1000,
-        interactive: false,
-      }).addTo(map);
-    } else {
-      state.locationMarker.setLatLng(e.latlng);
-      // Restore blue icon in case it was grayed out from a prior signal loss
-      state.locationMarker.setIcon(BLUE_DOT_ICON);
+    // Skip map rendering when screen is off — GPS data is still processed for recording
+    if (!state.screenOff) {
+      // Blue dot: create on first fix, update position on subsequent fixes
+      if (state.locationMarker === null) {
+        state.locationMarker = L.marker(e.latlng, {
+          icon: BLUE_DOT_ICON,
+          zIndexOffset: 1000,
+          interactive: false,
+        }).addTo(map);
+      } else {
+        state.locationMarker.setLatLng(e.latlng);
+        // Restore blue icon in case it was grayed out from a prior signal loss
+        state.locationMarker.setIcon(BLUE_DOT_ICON);
+      }
+
+      // Accuracy circle: translucent blue, no stroke, opacity fades as accuracy improves
+      // Opacity: full (0.35) at 100m+ accuracy, fades to 0.1 at 5m or better
+      const fillOpacity = Math.max(0.1, Math.min(0.35, e.accuracy / 300));
+      if (state.accuracyCircle === null) {
+        state.accuracyCircle = L.circle(e.latlng, {
+          radius: e.accuracy,
+          weight: 0,
+          fillColor: '#4285F4',
+          fillOpacity,
+        }).addTo(map);
+      } else {
+        state.accuracyCircle.setLatLng(e.latlng);
+        state.accuracyCircle.setRadius(e.accuracy);
+        state.accuracyCircle.setStyle({ fillOpacity });
+      }
     }
 
-    // Accuracy circle: translucent blue, no stroke, opacity fades as accuracy improves
-    // Opacity: full (0.35) at 100m+ accuracy, fades to 0.1 at 5m or better
-    const fillOpacity = Math.max(0.1, Math.min(0.35, e.accuracy / 300));
-    if (state.accuracyCircle === null) {
-      state.accuracyCircle = L.circle(e.latlng, {
-        radius: e.accuracy,
-        weight: 0,
-        fillColor: '#4285F4',
-        fillOpacity,
-      }).addTo(map);
-    } else {
-      state.accuracyCircle.setLatLng(e.latlng);
-      state.accuracyCircle.setRadius(e.accuracy);
-      state.accuracyCircle.setStyle({ fillOpacity });
-    }
-
-    // Append to the recording trail when actively recording.
+    // Append to the recording trail when actively recording (always, even screen off).
     // Discard fixes with accuracy > 30m — noisy fixes inflate trail distance and create zigzag artifacts.
     if (state.recordingState === 'recording' && e.accuracy <= TRAIL_MAX_ACCURACY_M) {
       const speedMs = isNaN(e.speed) ? 0 : e.speed;
@@ -119,12 +128,30 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     }
   }
 
-  // Update locate button icon to reflect current state
-  updateLocateIcon(state.locateState);
+  // Adaptive GPS accuracy: reduce power when stationary, restore when moving
+  const speed = e.speed;
+  if (!isNaN(speed) && speed >= 0) {
+    if (speed < STATIONARY_SPEED_MS) {
+      state.stationaryFixCount++;
+      if (state.stationaryFixCount >= STATIONARY_THRESHOLD && state.updateCallback > 0) {
+        setWatchAccuracy(map, false);
+      }
+    } else {
+      if (state.stationaryFixCount >= STATIONARY_THRESHOLD) {
+        setWatchAccuracy(map, true);
+      }
+      state.stationaryFixCount = 0;
+    }
+  }
 
-  // Follow GPS position when in active (following) state — animate smoothly
-  if (state.locateState === 'active' && state.youAreHereLocation !== null) {
-    map.panTo(state.youAreHereLocation, { animate: true, duration: 0.25 });
+  // Skip UI updates when screen is off
+  if (!state.screenOff) {
+    updateLocateIcon(state.locateState);
+
+    // Follow GPS position when in active (following) state — animate smoothly
+    if (state.locateState === 'active' && state.youAreHereLocation !== null) {
+      map.panTo(state.youAreHereLocation, { animate: true, duration: 0.25 });
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { onLocationFound, onLocationError, clearLocationMarkers } from './locati
 import { startWatching, stopWatching } from './timer';
 import { createStatsBar, addRecordingControl, updateRecordingButtons, maybeRestoreTrailBackup } from './recording';
 import { addOfflineDownloadControl } from './offline-download';
+import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
 
 const state = createInitialState();
@@ -269,6 +270,27 @@ window.addEventListener('offline', updateOfflineBanner);
 updateOfflineBanner();
 
 initOfflineTileFallback(showToast);
+
+// ── Screen-off optimization ───────────────────────────────────────────────────
+// Suppress map rendering and UI updates when screen is off during recording
+// to reduce CPU/GPU work. GPS data is still processed for trail recording.
+document.addEventListener('visibilitychange', () => {
+  state.screenOff = document.hidden;
+  // When screen comes back on, re-render latest state to catch up
+  if (!document.hidden) {
+    if (state.locationMarker !== null && state.youAreHereLocation !== null) {
+      state.locationMarker.setLatLng(state.youAreHereLocation);
+    }
+    if (state.accuracyCircle !== null && state.youAreHereLocation !== null && state.lastGpsAccuracy !== null) {
+      state.accuracyCircle.setLatLng(state.youAreHereLocation);
+      state.accuracyCircle.setRadius(state.lastGpsAccuracy);
+    }
+    updateLocateIcon(state.locateState);
+  }
+});
+
+// ── Battery monitoring ────────────────────────────────────────────────────────
+initBattery(state);
 
 let pendingSwUpdate: (() => void) | null = null;
 

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -7,6 +7,7 @@
 import L from 'leaflet';
 import type { AppState } from './types';
 import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup, dismissTrailBackup, isTrailBackupDismissed } from './trail-backup';
+import { snapshotBatteryStart, formatBatteryEstimate } from './battery';
 
 // tradeoff: 5m minimum distance filters GPS jitter at walking pace without skipping real movement; lower values add noise, higher values miss tight turns
 const MIN_TRAIL_DIST_M = 5;
@@ -117,12 +118,15 @@ export function createStatsBar(): void {
     '</div>' +
     '<div class="gps-badge" id="gps-weak-badge">' +
     'GPS ±<span id="gps-accuracy-val">--</span>m' +
-    '</div>';
+    '</div>' +
+    '<div class="battery-badge" id="battery-estimate"></div>';
 
   document.getElementById('map')?.appendChild(bar);
 }
 
 function updateStatsBar(state: AppState): void {
+  if (state.screenOff) return; // skip DOM updates when screen is off
+
   const timeEl = document.getElementById('stat-time');
   const distEl = document.getElementById('stat-dist');
   const ascentEl = document.getElementById('stat-ascent');
@@ -149,6 +153,18 @@ function updateStatsBar(state: AppState): void {
     gpsBadge.style.display = weak ? 'block' : 'none';
     if (weak && state.lastGpsAccuracy !== null) {
       gpsVal.textContent = String(Math.round(state.lastGpsAccuracy));
+    }
+  }
+
+  // Battery estimate: show projected remaining battery life during recording
+  const batteryEl = document.getElementById('battery-estimate');
+  if (batteryEl) {
+    const estimate = state.recordingState !== 'idle' ? formatBatteryEstimate(state) : null;
+    if (estimate) {
+      batteryEl.textContent = estimate;
+      batteryEl.style.display = 'block';
+    } else {
+      batteryEl.style.display = 'none';
     }
   }
 }
@@ -302,6 +318,9 @@ function startRecording(
   state.gpsWeakStreak = 0;
   state.gpsStrongStreak = 0;
   state.gpsWeakBadgeVisible = false;
+  state.stationaryFixCount = 0;
+
+  snapshotBatteryStart(state);
 
   // Glow layer beneath the main trail line
   state.trailGlow = L.polyline([], TRAIL_GLOW_OPTS).addTo(map);

--- a/src/style.css
+++ b/src/style.css
@@ -197,6 +197,19 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   text-align: center;
 }
 
+/* Battery estimate badge — shown in stats bar during recording */
+.battery-badge {
+  display: none;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 10px;
+  border-radius: 8px;
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+  text-align: center;
+}
+
 .stat-item {
   display: flex;
   flex-direction: column;

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,15 +1,38 @@
 /**
- * Intent: GPS watch management — start/stop continuous location tracking
- * Context: Called by main.ts refcount logic; each activate increments the refcount, each deactivate decrements — watch starts at 1, stops at 0
- * Pattern: Thin wrapper over Leaflet's map.locate({ watch: true }), which itself wraps the browser watchPosition API; no polling timer needed
- * Future: No accuracy timeout or stale-fix detection; a fix could be cached and never refresh on some devices
+ * Intent: GPS watch management with adaptive accuracy to save battery
+ * Context: Called by main.ts refcount logic; supports switching between high/low accuracy based on motion state
+ * Pattern: Wraps Leaflet's map.locate({ watch: true }) with accuracy toggling — high accuracy uses GPS hardware (power hungry), low accuracy uses WiFi/cell (power efficient)
  */
 import type L from 'leaflet';
 
+let highAccuracy = true;
+
 export function startWatching(map: L.Map): void {
-  map.locate({ watch: true, setView: false });
+  highAccuracy = true;
+  map.locate({ watch: true, setView: false, enableHighAccuracy: true });
 }
 
 export function stopWatching(map: L.Map): void {
   map.stopLocate();
+}
+
+/**
+ * Switch between high/low GPS accuracy to save battery when stationary.
+ * High accuracy uses GPS hardware (power-hungry); low accuracy uses WiFi/cell (efficient).
+ * Restarts the watch with new settings — brief gap between fixes is acceptable.
+ */
+export function setWatchAccuracy(map: L.Map, high: boolean): void {
+  if (high === highAccuracy) return;
+  highAccuracy = high;
+  map.stopLocate();
+  map.locate({
+    watch: true,
+    setView: false,
+    enableHighAccuracy: high,
+    maximumAge: high ? 0 : 5000,
+  });
+}
+
+export function isHighAccuracy(): boolean {
+  return highAccuracy;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,18 @@ export interface AppState {
   gpsWeakStreak: number;        // consecutive fixes with accuracy > TRAIL_MAX_ACCURACY_M
   gpsStrongStreak: number;      // consecutive fixes with accuracy < (TRAIL_MAX_ACCURACY_M - 5)
   gpsWeakBadgeVisible: boolean; // debounced badge state: true after 2+ weak, false after 2+ strong
+
+  // Battery efficiency: adaptive GPS accuracy
+  stationaryFixCount: number;   // consecutive fixes with no significant movement
+
+  // Battery efficiency: screen-off optimization
+  screenOff: boolean;           // true when document is hidden (Page Visibility API)
+
+  // Battery efficiency: battery monitoring
+  batteryLevel: number | null;          // current battery level 0–1, null if API unavailable
+  batteryCharging: boolean;             // true if device is charging
+  batteryDrainStartLevel: number | null; // battery level when recording started
+  batteryDrainStartMs: number;          // performance.now() when drain tracking began
 }
 
 export function createInitialState(): AppState {
@@ -85,5 +97,11 @@ export function createInitialState(): AppState {
     gpsWeakStreak: 0,
     gpsStrongStreak: 0,
     gpsWeakBadgeVisible: false,
+    stationaryFixCount: 0,
+    screenOff: false,
+    batteryLevel: null,
+    batteryCharging: false,
+    batteryDrainStartLevel: null,
+    batteryDrainStartMs: 0,
   };
 }


### PR DESCRIPTION
## Summary
- **Adaptive GPS accuracy**: switches to low-power WiFi/cell positioning when stationary (speed < 0.5 m/s for 5+ fixes); restores high-accuracy GPS on movement
- **Screen-off optimizations**: suppresses map rendering and UI updates when display is hidden via Page Visibility API, while continuing trail GPS data collection
- **Battery estimate display**: shows projected battery life remaining (e.g. "73% — ~4h 52m left") in the stats bar during recording via Battery Status API, with graceful degradation

## Files changed
| File | Change |
|---|---|
| `src/types.ts` | Added 6 state fields for adaptive polling, screen-off, and battery monitoring |
| `src/battery.ts` | **New** — Battery Status API integration, drain rate projection, formatted estimate |
| `src/timer.ts` | Added `setWatchAccuracy()` to switch between high/low GPS accuracy modes |
| `src/location.ts` | Stationary detection via speed, screen-off rendering guard, adaptive accuracy calls |
| `src/recording.ts` | Battery estimate in stats bar, screen-off guard in `updateStatsBar`, drain snapshot on record start |
| `src/main.ts` | Wired `visibilitychange` listener and `initBattery()` |
| `src/style.css` | `.battery-badge` styling (green pill, matches GPS badge pattern) |

## Test plan
- [ ] Start trail recording, verify stats bar shows battery estimate after ~1 min of drain data
- [ ] Stand still for ~30s, verify GPS accuracy indicator remains acceptable (WiFi positioning)
- [ ] Start moving, verify high-accuracy GPS resumes within a few seconds
- [ ] Lock screen during recording, unlock — verify trail points were still recorded
- [ ] Verify battery estimate shows "charging" label when plugged in
- [ ] Test on browser without Battery Status API (Firefox) — verify graceful degradation (no battery badge shown)
- [ ] `npm run type-check && npm run lint` pass clean

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)