### PR TITLE
Add README badges and update repo metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # webmap.dev
 
+[![CI](https://github.com/jasoneplumb/webmap.dev/actions/workflows/ci.yml/badge.svg)](https://github.com/jasoneplumb/webmap.dev/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![TypeScript](https://img.shields.io/badge/TypeScript-ES2020-blue)
+
 > A mobile-first Progressive Web App for GPS trail recording and map exploration.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add CI, License, and TypeScript badges to README.md after the heading
- Update repo description via gh repo edit
- Add 10 topics (PWA, TypeScript, Leaflet, GPS, Mapping, Offline-first, Progressive Web App, Trail Recording, GPX, Service Worker)

## Badges Added
- [![CI](https://github.com/jasoneplumb/webmap.dev/actions/workflows/ci.yml/badge.svg)](https://github.com/jasoneplumb/webmap.dev/actions/workflows/ci.yml) — Links to CI workflow
- [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) — Links to MIT license
- ![TypeScript](https://img.shields.io/badge/TypeScript-ES2020-blue) — Shows TypeScript ES2020 target

## Closes
Closes #106