### PR TITLE
Add Architecture Decision Records

### DIFF
--- a/docs/adr/ADR-001-single-mutable-state.md
+++ b/docs/adr/ADR-001-single-mutable-state.md
@@ -1,0 +1,79 @@
+# ADR-001: Single Mutable State
+
+**Status:** Accepted
+
+## Context
+
+webmap.dev is a single-page GPS tracking application with multiple independent features:
+- Real-time location tracking with three-state button (off → active → passive)
+- Recording trails with pause/resume and statistics
+- Offline tile caching and management
+- Battery and network optimizations
+
+Managing state across these features requires a pattern that allows modules to coordinate without tight coupling. Two common approaches are:
+1. **Event-bus or pub/sub** — modules publish state changes, others subscribe to updates
+2. **Redux or centralized store** — all state flows through a single reducer with dispatched actions
+
+## Decision
+
+Use a **single mutable `AppState` object** that is created once in `main.ts` and passed by reference to all modules. Modules mutate the state object directly.
+
+### Implementation
+
+```typescript
+// types.ts
+export interface AppState {
+  youAreHereLocation: L.LatLng | null;
+  locateState: LocateState;
+  updateCallback: number; // refcount for GPS polling
+  recordingState: RecordingState;
+  // ... 40+ properties tracking GPS, trails, battery, offline progress
+}
+
+// main.ts
+const state = createInitialState();
+initMap(state, map);
+addLocateControl(state, map);
+addRecordingControl(state, map);
+// all modules receive state by reference and mutate directly
+```
+
+## Alternatives Considered
+
+1. **Event-bus / Pub-Sub Pattern**
+   - Modules would dispatch events (e.g., `userStartedRecording`) and listen for state updates
+   - Pros: Decoupled modules, clear event flow
+   - Cons: Adds indirection and listener management; GPS updates fire every 1–2 seconds and would flood the event bus
+
+2. **Redux with Centralized Reducer**
+   - All state changes go through a single `reducer(state, action)` function
+   - Pros: Auditable action history, time-travel debugging, typed action dispatching
+   - Cons: Boilerplate (action types, action creators), overkill for a single-page app with synchronous mutations, unnecessary TypeScript ceremony
+
+3. **Component-Local State (React-style)**
+   - Each module manages its own state and passes callbacks up
+   - Pros: Encapsulation per feature
+   - Cons: GPS position is needed by *all* modules; leads to prop-drilling or a global fallback anyway
+
+## Consequences
+
+### Advantages
+- **Simplicity:** Direct mutation is straightforward; no middleware, reducers, or async complexity needed
+- **Performance:** Synchronous updates; no event-loop delays
+- **Transparency:** Reading code shows exactly what state changes happen and when
+- **Single source of truth:** All modules read from and write to one object; no sync bugs between state copies
+
+### Disadvantages
+- **Scalability risk:** As the app grows, the single state object becomes a monolith; difficult to split responsibilities
+- **Mutation safety:** No guard against accidental mutations in unexpected places; relies on developer discipline
+- **Debugging:** Without an audit trail of mutations, understanding *how* state reached its current value requires tracing through many modules
+- **Refactor brittleness:** Moving or renaming a state property requires grep-and-replace across all modules
+
+### Mitigation
+- Keep the state object focused on the features the app currently supports (GPS tracking, recording, offline)
+- Document each state property's ownership module in comments
+- Use TypeScript strict mode and `noUncheckedIndexedAccess` to catch typos and undefined accesses
+- Future refactor: If the app grows substantially (e.g., user accounts, cloud sync), consider migrating to Redux or a store library at that time
+
+## Related Decisions
+- [ADR-002: Refcount-based GPS Polling](ADR-002-refcount-gps-polling.md) — GPS watch refcount leverages the mutable AppState pattern

--- a/docs/adr/ADR-002-refcount-gps-polling.md
+++ b/docs/adr/ADR-002-refcount-gps-polling.md
@@ -1,0 +1,88 @@
+# ADR-002: Refcount-based GPS Polling
+
+**Status:** Accepted
+
+## Context
+
+Two independent features request GPS location updates:
+1. **Locate button** — User taps to center the map on their current location
+2. **Recording** — User records a trail and needs continuous GPS updates for statistics (distance, ascent, speed)
+
+Both features call `map.locate({ watch: true })` to start polling the device's GPS. A naive approach would have each feature independently start and stop the watch, creating a race condition:
+- Locate starts → Recording starts (both watching)
+- Recording stops → Watch stops entirely → Locate breaks
+
+## Decision
+
+Use an **integer refcount** (`updateCallback: number` in `AppState`) to coordinate GPS polling:
+- `0` = watch is stopped
+- `1` = only one consumer (e.g., locate or recording)
+- `2` = both consumers are active
+
+Each feature increments the refcount when it starts needing location updates and decrements when it stops. Only when the refcount transitions 0↔1 does the map actually start or stop the watch.
+
+### Implementation
+
+```typescript
+// timer.ts
+export function startWatching(map: L.Map): void {
+  map.locate({ watch: true, setView: false, enableHighAccuracy: true });
+}
+
+export function stopWatching(map: L.Map): void {
+  map.stopLocate();
+}
+
+// main.ts — refcount logic
+if (state.updateCallback === 0) {
+  startWatching(map); // transition 0→1: start the watch
+}
+state.updateCallback++;
+
+// Later, when a consumer stops:
+state.updateCallback--;
+if (state.updateCallback === 0) {
+  stopWatching(map); // transition 1→0: stop the watch
+}
+```
+
+## Alternatives Considered
+
+1. **Pub/Sub Event Bus**
+   - Each feature publishes `RequestGPSUpdates` and `ReleaseGPSUpdates` events
+   - A GPS manager listens and refcounts internally
+   - Pros: Decoupled; clear separation of concerns
+   - Cons: Adds a middle layer; indirection for a simple counter operation
+
+2. **Boolean Flags (Multiple States)**
+   - Store `isLocatingActive` and `isRecordingActive` separately
+   - Start watch if either is true, stop if both are false
+   - Pros: Simple to understand
+   - Cons: Requires if-statement logic every time either flag changes; brittle if a third feature needs GPS later
+
+3. **Single Boolean, One Owner**
+   - Only one feature (e.g., recording) is allowed to control the watch
+   - Other features rely on that owner (locate would wait for recording, or fail if recording is off)
+   - Pros: Simple logic
+   - Cons: Inflexible; violates feature independence
+
+## Consequences
+
+### Advantages
+- **Feature independence:** Locate and recording can start/stop GPS independently without knowing about each other
+- **Efficiency:** GPS watch runs only when needed; no redundant polling if both features are active
+- **Simplicity:** Refcount logic is a few lines of code; no middleware or event listeners needed
+- **Resilience:** Works for any number of consumers; adding a third feature that needs GPS requires only a new increment/decrement pair
+
+### Disadvantages
+- **Silent failures:** If any consumer forgets to decrement (e.g., due to an error path), the refcount stays > 0 and the watch never stops, draining battery indefinitely
+- **Refcount fragility:** Easy to introduce off-by-one bugs; requires careful testing and synchronization
+- **No visibility:** No built-in logging of who requested GPS and when; debugging refcount leaks requires tracing through code
+
+### Mitigation
+- Wrap increment/decrement in utility functions with clear names (`requestGPSWatch()`, `releaseGPSWatch()`) to reduce typos
+- Add TypeScript compile-time checks to ensure increment is paired with a corresponding decrement in try/finally blocks
+- Consider adding a debug mode that logs refcount changes and stack traces to identify leaks during development
+
+## Related Decisions
+- [ADR-001: Single Mutable State](ADR-001-single-mutable-state.md) — Refcount is stored in the mutable AppState object

--- a/docs/adr/ADR-002-refcount-gps-polling.md
+++ b/docs/adr/ADR-002-refcount-gps-polling.md
@@ -80,9 +80,9 @@ if (state.updateCallback === 0) {
 - **No visibility:** No built-in logging of who requested GPS and when; debugging refcount leaks requires tracing through code
 
 ### Mitigation
-- Wrap increment/decrement in utility functions with clear names (`requestGPSWatch()`, `releaseGPSWatch()`) to reduce typos
-- Add TypeScript compile-time checks to ensure increment is paired with a corresponding decrement in try/finally blocks
-- Consider adding a debug mode that logs refcount changes and stack traces to identify leaks during development
+- Current code uses `activatePolling()` / `deactivatePolling()` wrappers in `main.ts` to encapsulate increment/decrement (not yet extracted to standalone utility functions)
+- Future: add TypeScript compile-time checks to ensure increment is paired with a corresponding decrement in try/finally blocks
+- Future: consider a debug mode that logs refcount changes and stack traces to identify leaks during development
 
 ## Related Decisions
 - [ADR-001: Single Mutable State](ADR-001-single-mutable-state.md) — Refcount is stored in the mutable AppState object

--- a/docs/adr/ADR-003-offsetheight-ios-safari.md
+++ b/docs/adr/ADR-003-offsetheight-ios-safari.md
@@ -1,0 +1,87 @@
+# ADR-003: offsetHeight for iOS Safari Snap-Points
+
+**Status:** Accepted
+
+## Context
+
+The bottom sheet (information panel) on mobile has three snap points:
+- **Peek** — Small handle visible, most of map exposed (72px from bottom)
+- **Half** — Sheet occupies ~45% of viewport height
+- **Full** — Sheet fills the viewport
+
+To position the sheet correctly, the code needs to calculate its height and translate it off-screen via CSS `transform: translateY()`. The snap-point math depends on knowing the actual rendered height of the sheet element.
+
+### The iOS Safari Problem
+
+On iOS Safari, there is a critical discrepancy between two viewport measurements:
+- **`window.innerHeight`** — Reflects the *currently visible* viewport (excludes the browser's bottom toolbar when it's visible)
+- **CSS `vh` units** — Computed based on the *largest possible* viewport (includes virtual space for a hidden toolbar)
+
+When the browser toolbar is shown (user scrolling), these two measurements can differ by 50–100 pixels. A sheet with CSS `height: 90vh` may render *taller* than `window.innerHeight * 0.9`, causing snap-point calculations to break:
+
+```typescript
+// Wrong approach
+const h = Math.round(window.innerHeight * 0.9); // e.g., 900px
+_el.style.transform = `translateY(${h}px)`; // may not align with actual rendered height
+```
+
+The sheet would render as 950px (due to `vh` calculation) but be told to translate 900px, leaving a visible gap or misalignment.
+
+## Decision
+
+Query the actual rendered height of the sheet element using **`element.offsetHeight`** instead of calculating from `window.innerHeight`:
+
+```typescript
+function fullHeightPx(): number {
+  // Use the actual rendered height when the element exists in the DOM.
+  // On older iOS Safari, CSS `90vh` and `window.innerHeight * 0.9` disagree
+  // because `vh` is based on the largest possible viewport (toolbar hidden)
+  // while `innerHeight` reflects the current visible viewport. Using
+  // offsetHeight keeps snap-point math consistent with the rendered sheet.
+  if (_el) return _el.offsetHeight;
+  return Math.round(window.innerHeight * SHEET_VH);
+}
+```
+
+## Alternatives Considered
+
+1. **Always use CSS `vh` units without JavaScript calculation**
+   - Position snap-points entirely in CSS media queries and CSS custom properties
+   - Pros: Simpler, no JavaScript bridging
+   - Cons: Hard to achieve dynamic snap-points that respond to gesture; CSS alone cannot implement smooth drag-to-snap behavior
+
+2. **Always use `window.innerHeight` with a hardcoded iOS correction factor**
+   - Add a platform-detection check and apply a +60px adjustment only on iOS
+   - Pros: Works without querying the DOM
+   - Cons: Brittle; correction factor differs by iOS version and orientation; breaks on non-mobile iOS browsers
+
+3. **Measure viewport height at different lifecycle events (resize, orientationchange)**
+   - Cache measurements and update them on viewport change
+   - Pros: Avoid repeated DOM queries
+   - Cons: Still requires logic to detect when cache is stale; doesn't solve the fundamental `vh` vs. `innerHeight` mismatch
+
+4. **Use Intersection Observer or ResizeObserver to track sheet height changes**
+   - Set up a ResizeObserver to monitor `offsetHeight` and update snap-points when it changes
+   - Pros: Reactive; automatically handles dynamic content in the sheet
+   - Cons: Overkill for static sheet dimensions; adds observer lifecycle management
+
+## Consequences
+
+### Advantages
+- **Correctness:** Snap-points align perfectly with the rendered sheet, regardless of iOS Safari's toolbar state
+- **Simplicity:** Direct DOM measurement; no platform sniffing or correction factors
+- **Robustness:** Works across browser versions and orientations without hardcoded adjustments
+- **Cross-browser compatibility:** Falls back gracefully to `window.innerHeight * 0.9` if the sheet element doesn't exist yet (e.g., during initialization)
+
+### Disadvantages
+- **DOM dependency:** Snap-point calculations require the element to be in the DOM; cannot calculate heights before the element is created
+- **Performance:** `offsetHeight` triggers a reflow if any CSS or layout properties have changed since the last reflow; calling it during drag events (very frequently) could be costly
+- **Assumptions:** Assumes the rendered height is always stable; if content changes dynamically, snap-points may need recalculation
+
+### Mitigation
+- Cache `offsetHeight` during initialization and only re-query after major layout changes (orientation, window resize)
+- For drag events, use the cached value from the most recent snap-point transition to avoid repeated reflow triggers
+- Add a `ResizeObserver` or `window.orientationchange` listener to update the cache if the sheet's height changes
+
+## Related Decisions
+- [ADR-001: Single Mutable State](ADR-001-single-mutable-state.md) — Sheet snap point state is stored in the mutable AppState object

--- a/docs/adr/ADR-004-local-only-data.md
+++ b/docs/adr/ADR-004-local-only-data.md
@@ -1,0 +1,77 @@
+# ADR-004: Local-Only Data
+
+**Status:** Accepted
+
+## Context
+
+webmap.dev is a GPS tracking and mapping application. Users create trails, record statistics, and manage offline tile caches. Several options exist for persisting user data:
+
+1. **Local browser storage only** — All data stays in the device's browser cache, IndexedDB, or localStorage
+2. **Server-backed storage** — Trails, statistics, and user preferences sync to a backend server
+3. **Hybrid** — Local-first with optional cloud sync for backups or cross-device access
+
+A backend introduces significant complexity:
+- Authentication and authorization
+- Data encryption in transit and at rest
+- Server scaling and cost
+- GDPR/privacy regulations (data retention, deletion, export)
+- Cross-device account management
+
+## Decision
+
+**All data stays in the browser.** webmap.dev does not have a backend server or user accounts. Trails, statistics, offline tiles, and preferences are stored exclusively in the browser using:
+- `AppState` object (in-memory during the session)
+- `localStorage` or `IndexedDB` (persistent across sessions)
+- Service Worker cache via the Cache API (offline tile storage)
+
+Users are responsible for their own data backup and sharing.
+
+## Alternatives Considered
+
+1. **Cloud-Backed Storage (Firestore, Supabase, or custom API)**
+   - Users log in and trails sync to a server database
+   - Pros: Automatic backup, cross-device sync, undo/history, optional sharing
+   - Cons: Requires authentication, backend infrastructure, privacy policy, data retention policy, user account management; increases attack surface; incompatible with offline-first design
+
+2. **Optional Cloud Sync (Local-first with opt-in upload)**
+   - Data stored locally by default; users can choose to export or upload trails
+   - Pros: Empowers privacy-conscious users; no mandatory backend
+   - Cons: Partial feature set; manual export workflow is cumbersome; cross-device access impossible
+
+3. **Hybrid with local analytics**
+   - Store raw trail data locally; send anonymized statistics to a backend for app insights
+   - Pros: No user data exposed; helps improve the app with usage metrics
+   - Cons: Still requires backend infrastructure; privacy concerns even with anonymization
+
+## Consequences
+
+### Advantages
+- **Privacy by default:** No data leaves the device; no terms of service or privacy policy needed for data handling
+- **Offline-first:** App is fully functional without a network connection; no dependency on server uptime
+- **Simplicity:** No authentication, authorization, or account management to build or maintain
+- **User autonomy:** Users own their data; no risk of account lockout or service termination
+- **Low cost:** No server infrastructure to host, scale, or monitor
+- **Compliance:** No GDPR data retention or deletion obligations
+
+### Disadvantages
+- **No backup:** If the user clears browser data or reinstalls the app, all trails are lost
+- **No cross-device sync:** Trails recorded on one device don't appear on another
+- **No sharing:** Users cannot easily share trails with others without manual export
+- **Limited social features:** No leaderboards, group activities, or community features possible
+- **No analytics:** App developers have no insight into how users interact with the app
+
+### Mitigation
+- Provide clear UI guidance on exporting trails as JSON or GPX files
+- Implement periodic local backup reminders (e.g., "Export your trails monthly")
+- Use browser APIs (Service Workers, PWA manifest) to make data as persistent as possible (request persistent storage permission)
+- Document the local-only design prominently so users understand their data is their responsibility
+
+## Future Considerations
+
+If webmap.dev grows to require cross-device sync or user accounts, this decision can be revisited. A migration path could involve:
+1. Keeping local data as the source of truth
+2. Adding optional cloud sync as an opt-in feature
+3. Using a privacy-respecting backend (e.g., user-owned server, encrypted cloud storage)
+
+## Related Decisions
+- [ADR-005: Two-Tier Offline Tile Strategy](ADR-005-offline-tile-strategy.md) — Offline data uses browser Cache API and Service Worker, consistent with local-only design

--- a/docs/adr/ADR-005-offline-tile-strategy.md
+++ b/docs/adr/ADR-005-offline-tile-strategy.md
@@ -49,24 +49,29 @@ runtimeCaching: [
 Provide a UI control to select a bounding box, choose zoom levels, and pre-download all tiles for that region into the Cache API:
 
 ```typescript
-// offline-download.ts
-async function downloadTiles(urls: string[], onProgress: ProgressCallback): Promise<void> {
+// offline-download.ts (simplified — see source for full implementation)
+async function downloadTiles(urls: string[], onProgress: ProgressCallback): Promise<DownloadProgress> {
   const cache = await caches.open(OSM_TILE_CACHE_NAME);
+  const progress: DownloadProgress = { total: urls.length, done: 0, cached: 0, failed: 0 };
+
+  // Skip already-cached tiles
   for (const url of urls) {
-    const resp = await fetch(url);
-    if (resp.ok) {
-      await cache.put(url, resp);
-    }
+    if (await cache.match(url)) { progress.cached++; progress.done++; }
   }
-  onProgress({ done: urls.length, failed: 0 });
+
+  // Fetch uncached tiles in parallel (6 concurrent workers)
+  // Each worker calls onProgress after every tile for real-time UI updates
+  // AbortController enables user cancellation mid-download
 }
 ```
 
 **Behavior:**
 - User drags a rectangle on the map and selects zoom levels
-- App estimates tile count and storage size
-- User initiates download; tiles are fetched and cached in parallel (6 concurrent fetches)
-- Progress is shown in the UI; can be cancelled at any time
+- App estimates tile count and storage size in real-time
+- User initiates download; tiles are fetched in 6 parallel workers
+- `onProgress` fires after each tile (not just at the end) for real-time progress bar
+- Download can be cancelled at any time via `AbortController`
+- Already-cached tiles are skipped (not re-fetched)
 - Pre-downloaded tiles are stored in the same cache as passive tiles
 
 ## Alternatives Considered

--- a/docs/adr/ADR-005-offline-tile-strategy.md
+++ b/docs/adr/ADR-005-offline-tile-strategy.md
@@ -1,0 +1,127 @@
+# ADR-005: Two-Tier Offline Tile Strategy
+
+**Status:** Accepted
+
+## Context
+
+Maps require tile imagery from a provider (e.g., OpenStreetMap). Without an internet connection, the map is blank and unusable. Users want to record trails offline, so the app needs a strategy to cache map tiles for offline access.
+
+Two complementary caching strategies are available:
+
+1. **Passive caching** — Cache tiles *as the user views them* (Workbox StaleWhileRevalidate pattern)
+2. **Proactive pre-caching** — User selects a region in advance and pre-downloads all tiles for that area before heading out
+
+A single strategy alone is insufficient:
+- Passive caching only covers areas the user has previously visited
+- Pre-caching requires the app to predict which regions users will need
+- Together, they provide flexible offline coverage: use old cached tiles from past trips, or pre-download new areas before traveling
+
+## Decision
+
+Implement a **two-tier offline tile strategy**:
+
+### Tier 1: Workbox Passive Caching (Service Worker)
+Use Workbox's `StaleWhileRevalidate` handler for OpenStreetMap tiles:
+
+```typescript
+// vite.config.ts
+runtimeCaching: [
+  {
+    urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: OSM_TILE_CACHE_NAME,
+      expiration: {
+        maxEntries: 500,
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+      },
+    },
+  },
+]
+```
+
+**Behavior:**
+- On a network request for a tile, return the cached version if available (stale is acceptable)
+- Fetch the fresh tile in the background and update the cache for next time
+- If the cache miss and network is offline, request fails gracefully
+
+### Tier 2: Cache API Pre-Download (User-Initiated)
+Provide a UI control to select a bounding box, choose zoom levels, and pre-download all tiles for that region into the Cache API:
+
+```typescript
+// offline-download.ts
+async function downloadTiles(urls: string[], onProgress: ProgressCallback): Promise<void> {
+  const cache = await caches.open(OSM_TILE_CACHE_NAME);
+  for (const url of urls) {
+    const resp = await fetch(url);
+    if (resp.ok) {
+      await cache.put(url, resp);
+    }
+  }
+  onProgress({ done: urls.length, failed: 0 });
+}
+```
+
+**Behavior:**
+- User drags a rectangle on the map and selects zoom levels
+- App estimates tile count and storage size
+- User initiates download; tiles are fetched and cached in parallel (6 concurrent fetches)
+- Progress is shown in the UI; can be cancelled at any time
+- Pre-downloaded tiles are stored in the same cache as passive tiles
+
+## Alternatives Considered
+
+1. **Passive Caching Only (StaleWhileRevalidate)**
+   - Tiles are cached as the user explores the map
+   - Pros: Zero configuration; works automatically
+   - Cons: Only covers visited areas; limited offline utility for new regions
+
+2. **Pre-Download Only (No Passive Cache)**
+   - User pre-downloads regions explicitly before trips
+   - Pros: Predictable; users control bandwidth usage
+   - Cons: Doesn't benefit from opportunistic caching during online sessions; forces users to plan ahead
+
+3. **Server-Side Tile Hosting with Sync API**
+   - App uploads user location trails and downloads only the tiles needed for those routes
+   - Pros: Minimal storage; personalized to user's activities
+   - Cons: Requires a backend server; breaks local-only principle ([ADR-004](ADR-004-local-only-data.md)); privacy concerns
+
+4. **Distributed Tile Archive (MBTiles)**
+   - Download a single `.mbtiles` file (SQLite database) for a region instead of individual tiles
+   - Pros: More efficient than many individual requests; single file to manage
+   - Cons: Requires custom code to parse and serve from IndexedDB; no integration with Workbox; larger file size due to packaging overhead
+
+## Consequences
+
+### Advantages
+- **Automatic coverage:** Passive caching provides offline maps for all previously-visited areas with zero user action
+- **Flexible pre-download:** Users can prepare specific regions for upcoming trips
+- **Efficient storage:** Only tiles the user has viewed (or explicitly pre-downloaded) are stored; cache is bounded at 500 entries
+- **Graceful degradation:** If a tile is not cached and offline, the map shows missing tile placeholders; app remains functional
+- **Service Worker integration:** Workbox is battle-tested and maintained; no custom synchronization logic needed
+
+### Disadvantages
+- **Cache bloat:** Popular routes (e.g., hiking trails) can accumulate many tiles; 500-entry limit may evict frequently-used tiles
+- **Storage quota:** Browser cache quota varies by browser and device (50MB on Safari, 1GB on Chrome); large pre-downloads may exceed quota
+- **Stale imagery:** StaleWhileRevalidate always returns cached tiles first, even if the network is available; map imagery may be days or weeks old
+- **OSM only:** Only OpenStreetMap tiles are cached; Mapbox, Google, and other providers are not cached and are unusable offline
+- **No vector tiles:** Raster tile caching doesn't support vector-based maps (`.pbf` format); future map providers may require a different caching strategy
+
+### Mitigation
+- Display a warning when the user approaches the 500-tile cache limit, suggesting cleanup
+- Implement a "clear offline tiles" UI button to allow manual cache clearing
+- Add a fallback UI hint ("Go online to refresh maps") when tiles are stale
+- Consider future support for vector tile caching (e.g., PMTiles) if Mapbox or Maplibre integration is needed
+- Monitor browser cache quota usage and alert users if approaching their device's storage limit
+
+## Implementation Details
+
+**Shared Cache Name:** Both tiers write to the same cache (`OSM_TILE_CACHE_NAME` = `"osm-tiles-v1"`), so pre-downloaded tiles are treated identically to passively-cached tiles. Workbox automatically adds pre-downloaded tiles to the cache, and subsequent passive requests reuse them.
+
+**Tile Format:** Both strategies cache PNG tiles (raster, ~15KB each).
+
+**Tile Expiration:** Workbox's expiration policy stores up to 500 tiles, each valid for 30 days. Pre-downloaded tiles follow the same expiration, so old maps can be manually refreshed.
+
+## Related Decisions
+- [ADR-004: Local-Only Data](ADR-004-local-only-data.md) — Offline data is stored entirely locally using the Cache API, consistent with the local-only principle
+- [ADR-003: offsetHeight for iOS Safari Snap-Points](ADR-003-offsetheight-ios-safari.md) — The offline pre-download UI is implemented in the bottom sheet, which uses offsetHeight for snap-point calculations

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for webmap.dev, documenting major design choices and their rationale.
+
+## What is an ADR?
+
+An ADR is a lightweight document that captures an important architectural decision made by a team, including the context of the decision, its consequences, and alternatives that were considered. ADRs serve as a historical record and aid onboarding by explaining *why* the system is designed the way it is.
+
+## Format
+
+Each ADR follows a consistent template:
+- **Status** — Proposed, Accepted, Deprecated, Superseded, or Accepted
+- **Context** — The issue or problem that motivated the decision
+- **Decision** — The choice made
+- **Alternatives Considered** — Other options evaluated
+- **Consequences** — Trade-offs and impacts of the decision
+
+## Index
+
+1. [ADR-001: Single Mutable State](ADR-001-single-mutable-state.md) — Why AppState is a single mutable object instead of Redux or event-bus patterns
+2. [ADR-002: Refcount-based GPS Polling](ADR-002-refcount-gps-polling.md) — Why GPS polling uses an integer refcount instead of pub/sub
+3. [ADR-003: offsetHeight for iOS Safari Snap-Points](ADR-003-offsetheight-ios-safari.md) — Why bottom sheet snap-point math uses offsetHeight instead of CSS vh units
+4. [ADR-004: Local-Only Data](ADR-004-local-only-data.md) — Why all data stays in the browser with no server-side storage
+5. [ADR-005: Two-Tier Offline Tile Strategy](ADR-005-offline-tile-strategy.md) — Why offline uses Workbox passive caching plus Cache API pre-download
+
+## References
+
+- [Michael Nygard's ADR Template](https://github.com/adr/madr)
+- [webmap.dev GitHub Repository](https://github.com/jplumb/webmap.dev)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ An ADR is a lightweight document that captures an important architectural decisi
 ## Format
 
 Each ADR follows a consistent template:
-- **Status** — Proposed, Accepted, Deprecated, Superseded, or Accepted
+- **Status** — Proposed, Accepted, Rejected, Deprecated, or Superseded
 - **Context** — The issue or problem that motivated the decision
 - **Decision** — The choice made
 - **Alternatives Considered** — Other options evaluated
@@ -26,4 +26,4 @@ Each ADR follows a consistent template:
 ## References
 
 - [Michael Nygard's ADR Template](https://github.com/adr/madr)
-- [webmap.dev GitHub Repository](https://github.com/jplumb/webmap.dev)
+- [webmap.dev GitHub Repository](https://github.com/jasoneplumb/webmap.dev)


### PR DESCRIPTION
## Summary

This PR adds a comprehensive set of Architecture Decision Records (ADRs) documenting the key design choices behind webmap.dev's architecture.

### ADRs Added

- **ADR-001**: Single mutable AppState pattern — explains why the app uses a single shared state object instead of Redux or event buses
- **ADR-002**: Refcount-based GPS polling — documents the integer refcount coordination between the locate button and recording features
- **ADR-003**: offsetHeight for iOS Safari snap-points — details why the bottom sheet uses DOM measurement instead of CSS vh units
- **ADR-004**: Local-only data — rationale for keeping all user data in the browser with no server-side storage
- **ADR-005**: Two-tier offline tile strategy — explains the Workbox passive caching + Cache API pre-download approach

Each ADR follows the standard template: Status, Context, Decision, Alternatives Considered, and Consequences.

### Files Added

- `docs/adr/README.md` — Overview and index of all ADRs
- `docs/adr/ADR-001-*.md` through `docs/adr/ADR-005-*.md` — Five detailed ADRs

Closes #109

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>