### PR TITLE
feat: background GPS keepalive via Wake Lock + silent audio (#119)

### DIFF
--- a/src/keepalive.ts
+++ b/src/keepalive.ts
@@ -1,0 +1,49 @@
+export class Keepalive {
+  private wakeLock: WakeLockSentinel | null = null;
+  private audioCtx: AudioContext | null = null;
+  private sourceNode: AudioBufferSourceNode | null = null;
+
+  async start(): Promise<void> {
+    await this.acquireWakeLock();
+    this.startSilentAudio();
+  }
+
+  stop(): void {
+    this.wakeLock?.release().catch(() => undefined);
+    this.wakeLock = null;
+    this.sourceNode?.stop();
+    this.audioCtx?.close().catch(() => undefined);
+    this.audioCtx = null;
+    this.sourceNode = null;
+  }
+
+  async reacquireWakeLock(): Promise<void> {
+    if (this.wakeLock === null || this.wakeLock.released) {
+      await this.acquireWakeLock();
+    }
+  }
+
+  private async acquireWakeLock(): Promise<void> {
+    if (!('wakeLock' in navigator)) return;
+    try {
+      this.wakeLock = await navigator.wakeLock.request('screen');
+    } catch {
+      // Permission denied or not supported — silent degradation
+    }
+  }
+
+  private startSilentAudio(): void {
+    try {
+      this.audioCtx = new AudioContext();
+      const buffer = this.audioCtx.createBuffer(1, 1, 22050);
+      const source = this.audioCtx.createBufferSource();
+      source.buffer = buffer;
+      source.loop = true;
+      source.connect(this.audioCtx.destination);
+      source.start();
+      this.sourceNode = source;
+    } catch {
+      // AudioContext unavailable — silent degradation
+    }
+  }
+}

--- a/src/keepalive.ts
+++ b/src/keepalive.ts
@@ -4,8 +4,8 @@ export class Keepalive {
   private sourceNode: AudioBufferSourceNode | null = null;
 
   async start(): Promise<void> {
+    this.startSilentAudio(); // synchronous — must run before any await to stay in gesture stack
     await this.acquireWakeLock();
-    this.startSilentAudio();
   }
 
   stop(): void {
@@ -35,13 +35,16 @@ export class Keepalive {
   private startSilentAudio(): void {
     try {
       this.audioCtx = new AudioContext();
-      const buffer = this.audioCtx.createBuffer(1, 1, 22050);
+      // 1-second silent buffer — loops once per second instead of 22k/s with a 1-sample buffer
+      const buffer = this.audioCtx.createBuffer(1, 22050, 22050);
       const source = this.audioCtx.createBufferSource();
       source.buffer = buffer;
       source.loop = true;
       source.connect(this.audioCtx.destination);
       source.start();
       this.sourceNode = source;
+      // Resume explicitly — Chrome may create AudioContext in suspended state
+      this.audioCtx.resume().catch(() => undefined);
     } catch {
       // AudioContext unavailable — silent degradation
     }

--- a/src/keepalive.ts
+++ b/src/keepalive.ts
@@ -26,7 +26,13 @@ export class Keepalive {
   private async acquireWakeLock(): Promise<void> {
     if (!('wakeLock' in navigator)) return;
     try {
-      this.wakeLock = await navigator.wakeLock.request('screen');
+      const sentinel = await navigator.wakeLock.request('screen');
+      // Guard: stop() may have been called while awaiting (race between start/stop)
+      if (this.audioCtx === null) {
+        sentinel.release().catch(() => undefined);
+      } else {
+        this.wakeLock = sentinel;
+      }
     } catch {
       // Permission denied or not supported — silent degradation
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -348,6 +348,9 @@ document.addEventListener('visibilitychange', () => {
       state.accuracyCircle.setRadius(state.lastGpsAccuracy);
     }
     updateLocateIcon(state.locateState);
+    if (state.recordingState === 'recording') {
+      state.keepalive?.reacquireWakeLock().catch(() => undefined);
+    }
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -348,9 +348,8 @@ document.addEventListener('visibilitychange', () => {
       state.accuracyCircle.setRadius(state.lastGpsAccuracy);
     }
     updateLocateIcon(state.locateState);
-    if (state.recordingState === 'recording') {
-      state.keepalive?.reacquireWakeLock().catch(() => undefined);
-    }
+    // keepalive is non-null iff recording or paused — reacquire in both cases
+    state.keepalive?.reacquireWakeLock().catch(() => undefined);
   }
 });
 

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -8,6 +8,7 @@ import L from 'leaflet';
 import type { AppState } from './types';
 import { saveTrailBackup, clearTrailBackup, loadTrailBackup, applyTrailBackup, dismissTrailBackup, isTrailBackupDismissed } from './trail-backup';
 import { snapshotBatteryStart, formatBatteryEstimate } from './battery';
+import { Keepalive } from './keepalive';
 
 
 // tradeoff: 5m minimum distance filters GPS jitter at walking pace without skipping real movement; lower values add noise, higher values miss tight turns
@@ -371,6 +372,9 @@ function startRecording(
 
   activatePolling(); // recording refcount
 
+  state.keepalive = new Keepalive();
+  state.keepalive.start().catch(() => undefined);
+
   setStatsBarVisible(true);
   if (state.statsTimer !== null) clearInterval(state.statsTimer);
   state.statsTimer = setInterval(() => updateStatsBar(state), 1000);
@@ -401,6 +405,9 @@ function resumeRecording(state: AppState): void {
 
 function stopRecording(state: AppState, deactivatePolling: () => void): void {
   if (state.recordingState === 'idle') return;
+
+  state.keepalive?.stop();
+  state.keepalive = null;
 
   if (state.trailPoints.length > 0 || state.trailSegments.length > 0) {
     downloadGpx(state);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
  * Future: Will become unwieldy if state grows significantly; consider splitting into domain sub-objects
  */
 import type L from 'leaflet';
+import type { Keepalive } from './keepalive';
 
 // Three-state location button: off → active (following) → passive (dot visible, not following)
 export type LocateState = 'off' | 'active' | 'passive';
@@ -64,6 +65,9 @@ export interface AppState {
   batteryCharging: boolean;             // true if device is charging
   batteryDrainStartLevel: number | null; // battery level when recording started
   batteryDrainStartMs: number;          // performance.now() when drain tracking began
+
+  // Background GPS keepalive: screen wake lock + silent audio loop
+  keepalive: Keepalive | null;
 }
 
 export function createInitialState(): AppState {
@@ -103,5 +107,6 @@ export function createInitialState(): AppState {
     batteryCharging: false,
     batteryDrainStartLevel: null,
     batteryDrainStartMs: 0,
+    keepalive: null,
   };
 }


### PR DESCRIPTION
## Summary
- Adds `Keepalive` class (`src/keepalive.ts`) wrapping the Screen Wake Lock API and a silent `AudioContext` loop to prevent the browser from suspending GPS during background recording
- Keepalive starts when recording begins (`startRecording`) and stops when recording ends (`stopRecording`)
- Wake lock is reacquired on `visibilitychange` when screen returns from off/hidden while recording is active

## Changes
- `src/keepalive.ts` — new `Keepalive` class with `start()`, `stop()`, and `reacquireWakeLock()` methods; all platform APIs wrapped in try/catch for silent degradation
- `src/types.ts` — added `keepalive: Keepalive | null` to `AppState` interface, initialized to `null`
- `src/recording.ts` — start keepalive at end of `startRecording()`; stop and null it at start of `stopRecording()`; pause/resume untouched (GPS polling continues during pause)
- `src/main.ts` — extended `visibilitychange` handler to call `reacquireWakeLock()` when screen comes back on during recording

## Test plan
- [ ] Start recording on a mobile device, lock the screen — GPS trail should continue populating
- [ ] Unlock the screen mid-recording — wake lock should be reacquired (no screen sleep during active recording)
- [ ] Stop recording — wake lock released, silent audio stopped
- [ ] Open in browser that doesn't support Wake Lock API — no errors, silent degradation
- [ ] `npm run type-check && npm run lint` — both pass clean

## Assumptions
- `WakeLockSentinel` types are provided by `lib: ["DOM"]` in tsconfig — no polyfill or extra dependency needed
- Silent 1-sample AudioContext loop is the standard workaround for iOS browsers that ignore Wake Lock; both mechanisms complement each other

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)