### PR TITLE
fix(pwa): defer SW reload to prevent blank page on iOS Safari (#121)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,12 @@ if (!hasConsent()) {
   // The top-level await alternative requires ESM module output; use an async
   // IIFE that delays the rest of init until consent is granted.  The import
   // side-effects above (CSS, Leaflet icon config) are harmless before consent.
-  void waitForConsent().then(() => initApp());
+  void waitForConsent()
+    .then(() => initApp())
+    .catch((err: unknown) => {
+      console.error('[webmap] consent flow failed — reloading', err);
+      location.reload();
+    });
 } else {
   initApp();
 }
@@ -382,7 +387,12 @@ function applyUpdateWhenSafe(update: () => void): void {
 // Not wired here — silent first-install caching is acceptable.
 const updateSW = registerSW({
   onNeedRefresh() {
-    applyUpdateWhenSafe(() => updateSW(true));
+    // Defer SW update until after first paint — immediate reload during init
+    // causes a blank page on iOS Safari (new SW activates + clientsClaim
+    // triggers location.reload() before Leaflet has rendered anything).
+    requestAnimationFrame(() => {
+      applyUpdateWhenSafe(() => updateSW(true));
+    });
   },
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,13 @@ if (!hasConsent()) {
   void waitForConsent()
     .then(() => initApp())
     .catch((err: unknown) => {
-      console.error('[webmap] consent flow failed — reloading', err);
-      location.reload();
+      console.error('[webmap] consent flow failed', err);
+      // Only reload if consent wasn't recorded yet — avoids a reload loop if
+      // initApp() itself threw after the user already accepted (next load will
+      // skip straight to initApp() via the else branch with no catch needed).
+      if (!hasConsent()) {
+        location.reload();
+      }
     });
 } else {
   initApp();
@@ -390,6 +395,8 @@ const updateSW = registerSW({
     // Defer SW update until after first paint — immediate reload during init
     // causes a blank page on iOS Safari (new SW activates + clientsClaim
     // triggers location.reload() before Leaflet has rendered anything).
+    // rAF is also suspended in background tabs, which further protects active
+    // recordings from an unintended mid-session reload (intentional benefit).
     requestAnimationFrame(() => {
       applyUpdateWhenSafe(() => updateSW(true));
     });


### PR DESCRIPTION
## Summary

- Wraps `onNeedRefresh` body in `requestAnimationFrame()` to defer the service worker reload until after first paint
- Adds `.catch()` to the `waitForConsent()` promise chain so a consent-flow error triggers a reload instead of silently dropping `initApp()`

## Root Cause

On iOS Safari, `onNeedRefresh` can fire during `initApp()` initialization when a new SW is waiting (post-deploy). The immediate `skipWaiting` → `clientsClaim` → `location.reload()` sequence aborts initialization before Leaflet renders anything, leaving a blank page. iOS Safari doesn't recover gracefully from a navigation triggered mid-load — the user sees white until they manually reload.

The `requestAnimationFrame` deferral ensures the map has painted at least one frame before any reload is triggered.

## Changes

**`src/main.ts`**
1. `onNeedRefresh` — wrapped `applyUpdateWhenSafe` call in `requestAnimationFrame()`
2. `waitForConsent()` chain — added `.catch()` that calls `location.reload()` on consent-flow failure

## Test Plan

- [ ] Build and serve locally (`npm run build && npm run preview`)
- [ ] In Chrome DevTools: Application → Service Workers → force update → reload — confirm map renders before any reload fires
- [ ] On iPhone: install PWA, deploy update, cold-open — confirm no blank screen
- [ ] Verify recording flow unaffected: start/pause/stop still works, SW update deferred until recording stops

Closes #121