### PR TITLE
fix(locate): double-tap map to re-activate locate on mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -221,7 +221,7 @@ map.on('dragstart', () => {
 {
   let lastTouchEnd = 0;
   map.getContainer().addEventListener('touchend', (e: TouchEvent) => {
-    if (e.touches.length !== 0) return; // multi-touch in progress, ignore
+    if (e.touches.length !== 0 || e.changedTouches.length !== 1) return; // multi-touch
     const now = Date.now();
     if (state.locateState === 'passive' && now - lastTouchEnd < 300) {
       e.preventDefault(); // suppress synthesized dblclick → prevents zoom-in

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,6 +173,16 @@ function startLocating(): void {
   updateLocateIcon('active');
 }
 
+// Re-center on current position and resume following — shared by the locate
+// button click handler and the mobile double-tap gesture.
+function reactivateLocate(): void {
+  state.locateState = 'active';
+  if (state.youAreHereLocation !== null) {
+    map.flyTo(state.youAreHereLocation, map.getZoom(), { animate: true, duration: 0.8 });
+  }
+  updateLocateIcon('active');
+}
+
 addLocateControl(map, () => {
   switch (state.locateState) {
     case 'off':
@@ -192,12 +202,7 @@ addLocateControl(map, () => {
       break;
 
     case 'passive':
-      // Re-center: fly to current position and resume following
-      state.locateState = 'active';
-      if (state.youAreHereLocation !== null) {
-        map.flyTo(state.youAreHereLocation, map.getZoom(), { animate: true, duration: 0.8 });
-      }
-      updateLocateIcon('active');
+      reactivateLocate();
       break;
   }
 });
@@ -209,6 +214,26 @@ map.on('dragstart', () => {
     updateLocateIcon('passive');
   }
 });
+
+// Double-tap on the map re-activates locate (mobile) — when the user has panned
+// away (active → passive), a double-tap snaps back to their position without
+// requiring them to reach the locate button.
+// Intercepted at capture phase so e.preventDefault() suppresses the browser's
+// synthesized dblclick event (which would zoom instead of re-centering).
+{
+  let lastTouchEnd = 0;
+  map.getContainer().addEventListener('touchend', (e: TouchEvent) => {
+    if (e.touches.length !== 0) return; // multi-touch in progress, ignore
+    const now = Date.now();
+    if (state.locateState === 'passive' && now - lastTouchEnd < 300) {
+      e.preventDefault(); // suppress synthesized dblclick → prevents zoom-in
+      reactivateLocate();
+      lastTouchEnd = 0;   // reset so a third tap starts a fresh sequence
+    } else {
+      lastTouchEnd = now;
+    }
+  }, { capture: true });
+}
 
 // ── Recording (trail with stats) ──────────────────────────────────────────────
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,8 +173,6 @@ function startLocating(): void {
   updateLocateIcon('active');
 }
 
-// Re-center on current position and resume following — shared by the locate
-// button click handler and the mobile double-tap gesture.
 function reactivateLocate(): void {
   state.locateState = 'active';
   if (state.youAreHereLocation !== null) {
@@ -232,7 +230,7 @@ map.on('dragstart', () => {
     } else {
       lastTouchEnd = now;
     }
-  }, { capture: true });
+  }, { capture: true, passive: false });
 }
 
 // ── Recording (trail with stats) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a double-tap gesture on the map to re-activate locate when in passive state (GPS on, not following)
- Extracts `reactivateLocate()` to eliminate the duplicate `flyTo` logic between the button click and the new touch handler

## Root Cause / Context

After PR #12 introduced the three-state locate button, the only way to return to active (following) mode after a pan was to reach the locate button in the top-left corner. On a phone with one hand, that corner is often hard to hit during a hike. A double-tap on the map is a natural gesture that matches user mental models (double-tap to zoom is universal; here we intercept it specifically when the user has GPS on but not following).

## Changes

**`src/main.ts`**
- Extract `reactivateLocate()` from the `passive` branch of the locate-button click handler — shared by both button and gesture
- Add `touchend` listener on `map.getContainer()` in **capture phase** with `{ capture: true }`:
  - Tracks last single-finger `touchend` timestamp
  - On second tap within 300ms while `locateState === 'passive'`: calls `e.preventDefault()` (suppresses the synthesized `dblclick` and its zoom-in), then calls `reactivateLocate()`
  - Does nothing in `off` or `active` states — normal Leaflet zoom still applies

## Why capture phase + `preventDefault` on `touchend`?

Leaflet's `doubleClickZoom` handler processes the synthesized `dblclick` event in the bubble phase. By intercepting `touchend` in the capture phase first and calling `preventDefault()`, the browser never synthesizes the `dblclick` at all — Leaflet's zoom never fires. This is cleaner than temporarily toggling `map.doubleClickZoom.enable/disable`.

## Test Plan

- [ ] Tap locate button → GPS starts, map follows (active)
- [ ] Pan map → button dims to passive
- [ ] **Double-tap the map** → map flies back to current position, button returns to active — no zoom-in
- [ ] Single-tap the map in passive state → no re-activation (still passive)
- [ ] Double-tap in active or off state → normal Leaflet zoom-in (unchanged)
- [ ] Triple-tap → second pair treated as a new sequence; third tap re-zooms normally
- [ ] Multi-touch (pinch) → ignored, no accidental activation

Relates to #12 (three-state locate) and #13 (recording state machine follow-ups).