### PR TITLE
fix(controls): persist collapseOnFirstUse label state across sessions

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -40,13 +40,14 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
 
       container.appendChild(img);
 
-      const storageKey = config.collapseOnFirstUse ? `webmap-ctrl-label-${config.id}` : null;
+      const storageKey = config.collapseOnFirstUse && config.id
+        ? `webmap-ctrl-label-${config.id}`
+        : null;
 
       if (config.label) {
         const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
         label.textContent = config.label;
         container.appendChild(label);
-        // Restore collapsed state from previous session
         if (storageKey) {
           try {
             if (localStorage.getItem(storageKey) === '1') {

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -40,10 +40,21 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
 
       container.appendChild(img);
 
+      const storageKey = config.collapseOnFirstUse ? `webmap-ctrl-label-${config.id}` : null;
+
       if (config.label) {
         const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
         label.textContent = config.label;
         container.appendChild(label);
+        // Restore collapsed state from previous session
+        if (storageKey) {
+          try {
+            if (localStorage.getItem(storageKey) === '1') {
+              collapseControlLabel(container);
+              config.collapseOnFirstUse = false;
+            }
+          } catch { /* localStorage unavailable (e.g. private browsing) */ }
+        }
       }
 
       // Prevent click, dblclick, and touchstart from bubbling to the map,
@@ -54,6 +65,9 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
         if (config.collapseOnFirstUse) {
           collapseControlLabel(container);
           config.collapseOnFirstUse = false; // only once
+          if (storageKey) {
+            try { localStorage.setItem(storageKey, '1'); } catch { /* ignore */ }
+          }
         }
         config.onClick(e);
       }


### PR DESCRIPTION
## Summary

The 'Locate' button showed its text label on every page reload, even after a user had already tapped it once (which collapsed it). Now the collapsed state is persisted in `localStorage` and restored on load.

## Changes

**`src/controls.ts`** — `makeToggleControl()`
- Compute `storageKey = 'webmap-ctrl-label-{id}'` when `collapseOnFirstUse: true`, `null` otherwise
- On `onAdd()`: after appending the label span, read localStorage and call `collapseControlLabel()` immediately if already collapsed
- On `handleClick()`: when collapsing for the first time, write `'1'` to localStorage
- Both reads/writes are wrapped in `try/catch` for private-browsing compatibility

## Test Plan

- [ ] First load: 'Locate' label is visible
- [ ] Tap locate button: label collapses, `webmap-ctrl-label-locate = '1'` written to localStorage
- [ ] Reload page: label is gone immediately on render (no flash)
- [ ] Clear site data / localStorage: label reappears on next load
- [ ] Private browsing (localStorage blocked): label still collapses on tap; no error thrown