### PR TITLE
fix(gps): warn in dev when polling refcount goes out of bounds

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,9 @@ map.on('locationerror', (e: L.ErrorEvent) => {
 // Polling refcount helpers — shared by locate and recording
 function activatePolling(): void {
   state.updateCallback += 1;
+  if (import.meta.env.DEV && state.updateCallback > 2) {
+    console.warn('[webmap] updateCallback > 2 — possible activatePolling() leak', state.updateCallback);
+  }
   if (state.updateCallback === 1) startWatching(map);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,9 @@ function activatePolling(): void {
 function deactivatePolling(): void {
   state.prior = 1000;
   state.updateCallback -= 1;
+  if (import.meta.env.DEV && state.updateCallback < 0) {
+    console.warn('[webmap] updateCallback < 0 — possible deactivatePolling() leak', state.updateCallback);
+  }
   if (state.updateCallback === 0) stopWatching(map);
 }
 


### PR DESCRIPTION
## Summary

- Adds dev-only `console.warn` guards in both `activatePolling()` and `deactivatePolling()` using `import.meta.env.DEV` (stripped by Vite in production builds)
- `activatePolling()`: warns when `updateCallback > 2` (above expected max of 2)
- `deactivatePolling()`: warns when `updateCallback < 0` (underflow from unmatched deactivate)
- Both warnings include the current value for fast diagnosis

## Changes

- `src/main.ts`: Added 3-line warn block in `activatePolling()` (overflow guard) and 3-line warn block in `deactivatePolling()` (underflow guard)

## Test plan

- [ ] `npm run type-check` — passes
- [ ] `npm run lint` — passes
- [ ] In dev build: trigger leak scenario to verify warn appears in console
- [ ] In production build: verify warns are absent (Vite strips `import.meta.env.DEV` blocks)

## Assumptions

- `import.meta.env.DEV` is the correct Vite idiom for dev-only guards; no polyfill or type augmentation needed
- No clamping: invalid values are left in place intentionally so callers can observe the leaked state

Closes #125