### PR TITLE
feat(locate): passive-state visual hint for double-tap gesture discoverability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -210,6 +210,24 @@ map.on('dragstart', () => {
   if (state.locateState === 'active') {
     state.locateState = 'passive';
     updateLocateIcon('passive');
+
+    // Show discoverability hint once per session on touch devices
+    if (navigator.maxTouchPoints > 0 && !sessionStorage.getItem('locate-hint-shown')) {
+      sessionStorage.setItem('locate-hint-shown', '1');
+      showToast('Double-tap map to re-center', 2500);
+    }
+
+    // Pulse the locate icon for 2 cycles to draw attention to the state change
+    const locateImg = document.getElementById('locate');
+    if (locateImg) {
+      locateImg.classList.remove('locate-passive-pulse');
+      // Force reflow so re-adding the class restarts the animation
+      void locateImg.offsetWidth;
+      locateImg.classList.add('locate-passive-pulse');
+      locateImg.addEventListener('animationend', () => {
+        locateImg.classList.remove('locate-passive-pulse');
+      }, { once: true });
+    }
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,13 +211,11 @@ map.on('dragstart', () => {
     state.locateState = 'passive';
     updateLocateIcon('passive');
 
-    // Show discoverability hint once per session on touch devices
     if (navigator.maxTouchPoints > 0 && !sessionStorage.getItem('locate-hint-shown')) {
       sessionStorage.setItem('locate-hint-shown', '1');
       showToast('Double-tap map to re-center', 2500);
     }
 
-    // Pulse the locate icon for 2 cycles to draw attention to the state change
     const locateImg = document.getElementById('locate');
     if (locateImg) {
       locateImg.classList.remove('locate-passive-pulse');

--- a/src/style.css
+++ b/src/style.css
@@ -177,6 +177,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   50%       { opacity: 0.25; }
 }
 
+/* 2-cycle pulse on the locate button when dropping to passive state */
+.locate-passive-pulse {
+  animation: rec-pulse 0.6s ease-out 2;
+}
+
 #rec-status-label {
   font-weight: 700;
   font-size: 12px;


### PR DESCRIPTION
## Summary

- On touch devices, pulses the locate button icon for 2 cycles when active→passive transition occurs, drawing attention to the state change
- Shows a one-shot toast ("Double-tap map to re-center") on the first active→passive transition per session, teaching the gesture from PR #123
- Toast is suppressed on repeat transitions via `sessionStorage` key `locate-hint-shown`; pulse always fires on each transition

## Implementation notes

- CSS class `.locate-passive-pulse` uses the existing `rec-pulse` keyframe (2 cycles, 0.6s each), removed via `animationend` listener
- Forced reflow (`void locateImg.offsetWidth`) ensures the animation restarts cleanly if the button re-enters passive state before the prior animation ends
- Toast only shown when `navigator.maxTouchPoints > 0` — desktop users panning with a mouse don't get the hint

## Test plan

- [ ] On mobile: pan the map while locate is active → icon pulses 2× and toast appears once
- [ ] Pan again (same session) → icon pulses but toast does not reappear
- [ ] On desktop: pan while active → no toast (only pulse)
- [ ] After toast appears, double-tap map → locate re-activates

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)