### PR TITLE
fix(gpx): document required <time> on every trkpt for Strava/Garmin compatibility

### DIFF
--- a/src/recording.ts
+++ b/src/recording.ts
@@ -448,7 +448,8 @@ function buildGpx(state: AppState): string {
   const formatPoint = ({ latlng, t, speedMs, altM }: { latlng: L.LatLng; t: number; speedMs: number; altM?: number }): string => {
     const pointTime = new Date(epochOffset + t).toISOString();
     const eleTag = altM !== undefined ? `<ele>${altM.toFixed(1)}</ele>` : '';
-    // required on every trkpt for Strava/Garmin moving-time and elevation-over-time graphs; GPX 1.1 schema orders <time> after <ele> and before <extensions>
+    // <time> required on every trkpt for Strava/Garmin moving-time and elevation-over-time graphs
+    // GPX 1.1 schema order: <ele> → <time> → <extensions>
     const timeTag = `<time>${pointTime}</time>`;
     const speedTag =
       speedMs > 0

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -448,6 +448,7 @@ function buildGpx(state: AppState): string {
   const formatPoint = ({ latlng, t, speedMs, altM }: { latlng: L.LatLng; t: number; speedMs: number; altM?: number }): string => {
     const pointTime = new Date(epochOffset + t).toISOString();
     const eleTag = altM !== undefined ? `<ele>${altM.toFixed(1)}</ele>` : '';
+    // required on every trkpt for Strava/Garmin moving-time and elevation-over-time graphs; GPX 1.1 schema orders <time> after <ele> and before <extensions>
     const timeTag = `<time>${pointTime}</time>`;
     const speedTag =
       speedMs > 0


### PR DESCRIPTION
## Summary

- Adds an explicit comment to `buildGpx` in `src/recording.ts` clarifying that `<time>` is required on every `<trkpt>` for Strava, Garmin Connect, and komoot compatibility
- Verifies the existing implementation already correctly includes `<time>` on every trail point using `epochOffset + point.t` → ISO 8601 string, in GPX 1.1 schema order (`<ele>` → `<time>` → `<extensions>`)

**Note:** The underlying fix (timestamps on every `<trkpt>`) was already implemented correctly since the initial GPX export feature in #85. Issue #126 was filed as a suspected bug; this PR confirms and documents the behavior.

Closes #126

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes
- [ ] Manual: export a GPX track and verify every `<trkpt>` contains a `<time>` element with a valid ISO 8601 UTC timestamp
- [ ] Manual: import the GPX into Strava or Garmin Connect and verify elevation-over-time graphs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)