### PR TITLE
Phase 3: two-step Pause→Finish reveal (#137)

### DIFF
--- a/src/recording.ts
+++ b/src/recording.ts
@@ -241,22 +241,17 @@ function renderButtons(
     }
     c.appendChild(btn);
   } else if (state.recordingState === 'recording') {
+    // Two-step Stop reveal: only Pause is visible while recording.
+    // Tapping Pause is what reveals Finish (the paused branch).
     c.appendChild(
       makeBtn('⏸ Pause', 'rec-btn rec-btn-pause', () => {
         pauseRecording(state);
         renderButtons(state, activatePolling, deactivatePolling, map);
       }),
     );
-    c.appendChild(
-      makeBtn('⏹ Stop', 'rec-btn rec-btn-stop', async () => {
-        if (await confirmStop()) {
-          stopRecording(state, deactivatePolling);
-          renderButtons(state, activatePolling, deactivatePolling, map);
-        }
-      }),
-    );
   } else {
-    // paused
+    // paused — Resume continues recording; Finish ends the session immediately.
+    // The Pause-then-Finish reveal IS the confirmation; no modal.
     c.appendChild(
       makeBtn('▶ Resume', 'rec-btn rec-btn-resume', () => {
         resumeRecording(state);
@@ -264,11 +259,9 @@ function renderButtons(
       }),
     );
     c.appendChild(
-      makeBtn('⏹ Stop', 'rec-btn rec-btn-stop', async () => {
-        if (await confirmStop()) {
-          stopRecording(state, deactivatePolling);
-          renderButtons(state, activatePolling, deactivatePolling, map);
-        }
+      makeBtn('⏹ Finish', 'rec-btn rec-btn-finish', () => {
+        stopRecording(state, deactivatePolling);
+        renderButtons(state, activatePolling, deactivatePolling, map);
       }),
     );
   }
@@ -280,50 +273,6 @@ function makeBtn(label: string, className: string, onClick: () => void): HTMLBut
   btn.className = className;
   btn.addEventListener('click', onClick);
   return btn;
-}
-
-function confirmStop(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const overlay = document.createElement('div');
-    overlay.id = 'consent-overlay';
-
-    const panel = document.createElement('div');
-    panel.id = 'consent-panel';
-    panel.setAttribute('role', 'dialog');
-    panel.setAttribute('aria-label', 'Stop recording');
-    panel.innerHTML = `
-      <h2>Stop recording?</h2>
-      <p>The track will be finalized. You can export it as a GPX file from the stats bar.</p>
-      <div id="consent-actions">
-        <button id="confirm-stop-yes" class="rec-btn rec-btn-stop">Stop recording</button>
-        <button id="consent-decline">Cancel</button>
-      </div>
-    `;
-
-    overlay.appendChild(panel);
-    document.body.appendChild(overlay);
-
-    function cleanup(accepted: boolean): void {
-      overlay.remove();
-      resolve(accepted);
-    }
-
-    document.getElementById('confirm-stop-yes')!.addEventListener('click', () => cleanup(true));
-    document.getElementById('consent-decline')!.addEventListener('click', () => cleanup(false));
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) cleanup(false);
-    });
-
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        document.removeEventListener('keydown', onKey);
-        cleanup(false);
-      }
-    };
-    document.addEventListener('keydown', onKey);
-
-    document.getElementById('confirm-stop-yes')!.focus();
-  });
 }
 
 // ── State machine ─────────────────────────────────────────────────────────────

--- a/src/style.css
+++ b/src/style.css
@@ -277,15 +277,17 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   }
 }
 
-/* Push Stop away from Pause/Resume so it can't be accidentally tapped */
-.rec-btn-stop {
+/* Push Finish away from Resume so it can't be accidentally tapped — Finish
+   is only visible in the paused state (two-step reveal); the gap below is
+   the second mis-tap guard after the reveal itself. */
+.rec-btn-finish {
   margin-top: 12px;
 }
 
 .rec-btn-start  { background: #22c55e; color: #fff; }
 .rec-btn-pause  { background: #f59e0b; color: #fff; }
 .rec-btn-resume { background: #22c55e; color: #fff; }
-.rec-btn-stop   { background: #ef4444; color: #fff; }
+.rec-btn-finish { background: #ef4444; color: #fff; }
 
 /* ── Trail direction arrows ──────────────────────────────────────────────── */
 .trail-arrow {


### PR DESCRIPTION
Closes #137. Part of epic #134.

## Summary

During active recording only **Pause** is visible — tapping Pause is what reveals **Resume + Finish** in the paused state. The reveal IS the confirmation; the previous `confirmStop()` modal is removed entirely.

This is the dominant convention across Strava and AllTrails per the reference-app survey that informed the epic.

## Changes

- `src/recording.ts` `renderButtons()`:
  - `'recording'` branch now renders only Pause (Stop button dropped)
  - `'paused'` branch renames Stop → Finish; calls `stopRecording()` directly instead of awaiting `confirmStop()`
- `src/recording.ts`: `confirmStop()` and its associated DOM manipulation deleted in full
- `src/style.css`: `.rec-btn-stop` → `.rec-btn-finish` (background color unchanged; comment updated to explain the post-reveal mis-tap guard rationale)

## Notes for reviewers

- The deleted `confirmStop()` reused `#consent-overlay` / `#consent-panel` IDs — those styles remain in use by `consent.ts` (privacy consent at app startup), so removing the function does not orphan any CSS.
- The recording-dot animation is unchanged: red pulsing in `'recording'` state, static orange when `'paused'` (`.rec-dot-paused` already had `animation: none`). The PAUSED label is set in `updateStatsBar` based on `recordingState`, also unchanged.
- The `.rec-btn-finish { margin-top: 12px }` rule kept as a second-tier mis-tap guard — Resume sits above Finish in the paused panel, and the gap reduces accidental Finish taps when the user means Resume.

## Test plan

- [x] `npm run type-check && npm run lint && npm test` — all 33 vitest tests pass
- [x] `npm run build` — production build clean
- [ ] Manual smoke: full recording lifecycle on the dev server
  - Start → only Pause visible
  - Tap Pause → Resume + Finish revealed
  - Tap Resume → back to Recording state with Pause-only
  - Tap Pause → Resume + Finish revealed
  - Tap Finish → recording ends, GPX downloads, no modal
- [ ] Recording dot pulses in recording state; static orange + "PAUSED" label when paused

## Out of scope

Pill expansion + stats merge (Phase 4, #138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)