### PR TITLE
Phase 4: expanding pill — fold #recording-stats into recording panel (#138)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
 import { startWatching, stopWatching } from './timer';
-import { createStatsBar, addRecordingControl, updateRecordingButtons, maybeRestoreTrailBackup } from './recording';
+import { addRecordingControl, updateRecordingButtons, maybeRestoreTrailBackup } from './recording';
 import { addOfflineDownloadControl } from './offline-download';
 import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
@@ -257,7 +257,6 @@ map.on('dragstart', () => {
 
 // ── Recording (trail with stats) ──────────────────────────────────────────────
 
-createStatsBar();
 addRecordingControl(map, state, activatePolling, deactivatePolling);
 
 // Offer to restore an interrupted trail if a backup exists in localStorage

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -271,13 +271,21 @@ function renderButtons(
   updateStatsBar(state);
 }
 
+// Tracks the active "Saved ✓" timer so a future re-entry can cancel it.
+// Today this is defensive — the saved pill exposes no buttons that could
+// trigger another stop — but a teardown path or a second Finish during the
+// 1.5 s window would otherwise leak a stale callback into the next render.
+let savedTransientTimer: ReturnType<typeof setTimeout> | null = null;
+
 /** Brief "Saved ✓" confirmation after Finish, then collapse back to idle. */
 function showSavedTransient(): void {
   const c = recControlContainer;
   if (!c) return;
+  if (savedTransientTimer !== null) clearTimeout(savedTransientTimer);
   c.className = 'recording-panel recording-panel--saved';
   c.innerHTML = '<div class="rec-saved">Saved ✓</div>';
-  setTimeout(() => {
+  savedTransientTimer = setTimeout(() => {
+    savedTransientTimer = null;
     if (recControlContainer && storedState && storedActivatePolling && storedDeactivatePolling && storedMap) {
       renderButtons(storedState, storedActivatePolling, storedDeactivatePolling, storedMap);
     }

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -91,40 +91,36 @@ function formatDistance(m: number): string {
 }
 
 
-// ── Stats bar DOM ─────────────────────────────────────────────────────────────
-
-export function createStatsBar(): void {
-  if (document.getElementById('recording-stats')) return;
-
-  const bar = document.createElement('div');
-  bar.id = 'recording-stats';
-  bar.style.display = 'none';
-  bar.innerHTML =
-    '<div class="stat-item stat-item--full">' +
-    '<span class="stat-label">Duration</span>' +
-    '<span class="stat-value" id="stat-time">00:00</span>' +
-    '</div>' +
-    '<div class="stats-row">' +
-    '<div class="stat-item">' +
-    '<span class="stat-label">Dist</span>' +
-    '<span class="stat-value" id="stat-dist">0 m</span>' +
-    '</div>' +
-    '<div class="stat-item">' +
-    '<span class="stat-label">Ascent</span>' +
-    '<span class="stat-value" id="stat-ascent">-- m</span>' +
-    '</div>' +
-    '</div>' +
-    '<div class="rec-indicator">' +
-    '<span class="rec-dot"></span>' +
-    '<span id="rec-status-label">RECORDING</span>' +
-    '</div>' +
-    '<div class="gps-badge" id="gps-weak-badge">' +
-    'GPS ±<span id="gps-accuracy-val">--</span>m' +
-    '</div>' +
-    '<div class="battery-badge" id="battery-estimate"></div>';
-
-  document.getElementById('map')?.appendChild(bar);
-}
+// ── Stats DOM (rendered inside the recording pill) ────────────────────────────
+// HTML for the stats portion of the pill — Duration, Dist, Ascent, recording
+// dot + label, optional GPS-weak / battery badges. Re-injected on every state
+// transition (renderButtons rebuilds the pill's inner HTML), so the IDs are
+// always present in the DOM while the pill is in its active state.
+const STATS_HTML =
+  '<div class="rec-stats">' +
+  '<div class="stat-item stat-item--full">' +
+  '<span class="stat-label">Duration</span>' +
+  '<span class="stat-value" id="stat-time">00:00</span>' +
+  '</div>' +
+  '<div class="stats-row">' +
+  '<div class="stat-item">' +
+  '<span class="stat-label">Dist</span>' +
+  '<span class="stat-value" id="stat-dist">0 m</span>' +
+  '</div>' +
+  '<div class="stat-item">' +
+  '<span class="stat-label">Ascent</span>' +
+  '<span class="stat-value" id="stat-ascent">-- m</span>' +
+  '</div>' +
+  '</div>' +
+  '<div class="rec-indicator">' +
+  '<span class="rec-dot"></span>' +
+  '<span id="rec-status-label">RECORDING</span>' +
+  '</div>' +
+  '<div class="gps-badge" id="gps-weak-badge">' +
+  'GPS ±<span id="gps-accuracy-val">--</span>m' +
+  '</div>' +
+  '<div class="battery-badge" id="battery-estimate"></div>' +
+  '</div>';
 
 function updateStatsBar(state: AppState): void {
   if (state.screenOff) return; // skip DOM updates when screen is off
@@ -169,11 +165,6 @@ function updateStatsBar(state: AppState): void {
       batteryEl.style.display = 'none';
     }
   }
-}
-
-function setStatsBarVisible(visible: boolean): void {
-  const bar = document.getElementById('recording-stats');
-  if (bar) bar.style.display = visible ? 'flex' : 'none';
 }
 
 // ── Recording control panel ───────────────────────────────────────────────────
@@ -231,6 +222,8 @@ function renderButtons(
   c.innerHTML = '';
 
   if (state.recordingState === 'idle') {
+    // Idle: compact pill — just the Record button. No stats, no background.
+    c.className = 'recording-panel recording-panel--idle';
     const btn = makeBtn('⏺ Record', 'rec-btn rec-btn-start', () => {
       startRecording(state, map, activatePolling);
       renderButtons(state, activatePolling, deactivatePolling, map);
@@ -240,7 +233,14 @@ function renderButtons(
       btn.title = 'Enable location first';
     }
     c.appendChild(btn);
-  } else if (state.recordingState === 'recording') {
+    return;
+  }
+
+  // Active (recording or paused): expanded pill — stats above buttons.
+  c.className = 'recording-panel recording-panel--active';
+  c.innerHTML = STATS_HTML;
+
+  if (state.recordingState === 'recording') {
     // Two-step Stop reveal: only Pause is visible while recording.
     // Tapping Pause is what reveals Finish (the paused branch).
     c.appendChild(
@@ -261,10 +261,27 @@ function renderButtons(
     c.appendChild(
       makeBtn('⏹ Finish', 'rec-btn rec-btn-finish', () => {
         stopRecording(state, deactivatePolling);
-        renderButtons(state, activatePolling, deactivatePolling, map);
+        showSavedTransient();
       }),
     );
   }
+
+  // Populate stats values immediately so the pill doesn't flash placeholders
+  // before the first 1Hz tick of the statsTimer.
+  updateStatsBar(state);
+}
+
+/** Brief "Saved ✓" confirmation after Finish, then collapse back to idle. */
+function showSavedTransient(): void {
+  const c = recControlContainer;
+  if (!c) return;
+  c.className = 'recording-panel recording-panel--saved';
+  c.innerHTML = '<div class="rec-saved">Saved ✓</div>';
+  setTimeout(() => {
+    if (recControlContainer && storedState && storedActivatePolling && storedDeactivatePolling && storedMap) {
+      renderButtons(storedState, storedActivatePolling, storedDeactivatePolling, storedMap);
+    }
+  }, 1500);
 }
 
 function makeBtn(label: string, className: string, onClick: () => void): HTMLButtonElement {
@@ -324,7 +341,6 @@ function startRecording(
   state.keepalive = new Keepalive();
   state.keepalive.start().catch(() => undefined);
 
-  setStatsBarVisible(true);
   if (state.statsTimer !== null) clearInterval(state.statsTimer);
   state.statsTimer = setInterval(() => updateStatsBar(state), 1000);
 }
@@ -371,7 +387,8 @@ function stopRecording(state: AppState, deactivatePolling: () => void): void {
     clearInterval(state.statsTimer);
     state.statsTimer = null;
   }
-  setStatsBarVisible(false);
+  // No need to toggle visibility — the pill's own state-driven rendering
+  // (showSavedTransient → renderButtons in idle mode) handles the collapse.
 }
 
 // ── GPX export ────────────────────────────────────────────────────────────────
@@ -570,9 +587,11 @@ export function maybeRestoreTrailBackup(
 
   activatePolling(); // recording refcount
 
-  setStatsBarVisible(true);
   if (state.statsTimer !== null) clearInterval(state.statsTimer);
   state.statsTimer = setInterval(() => updateStatsBar(state), 1000);
+  // Re-render the pill in active state — addRecordingControl initially
+  // rendered idle (Record button) before this restore completed.
+  updateRecordingButtons();
 
   return true;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -244,8 +244,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   min-width: 0;
   max-width: 360px;
   /* Smooth transition between idle (transparent, no padding) and the
-     expanded states (dark/green, padded). max-width transitions help the
-     pill grow into its content rather than snap. */
+     expanded states (dark/green, padded). The height step comes from
+     injecting STATS_HTML and is intentionally instant — transitioning
+     height on dynamic content requires extra machinery this UI doesn't
+     warrant. */
   transition: padding 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
 }
 
@@ -278,8 +280,8 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* Fallback class — toggle on .recording-panel to lock it in expanded sizing
-   if the height/padding transition stutters on low-end Android. */
-.recording-panel.recording-pill--always-expanded {
+   if the padding/background transition stutters on low-end Android. */
+.recording-panel.recording-panel--always-expanded {
   background: rgba(0, 0, 0, 0.88);
   color: #fff;
   padding: 12px 16px;

--- a/src/style.css
+++ b/src/style.css
@@ -121,27 +121,17 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #fff;
 }
 
-/* ── Recording stats bar ──────────────────────────────────────────────────── */
-#recording-stats {
-  position: absolute;
-  /* Top-left corner during recording (the "dashboard"). Sits above any
-     Leaflet controls in the same anchor; pointer-events: none keeps map
-     interactions through the panel. */
-  top: calc(8px + env(safe-area-inset-top, 0px));
-  left: calc(8px + env(safe-area-inset-left, 0px));
-  background: rgba(0, 0, 0, 0.88);
-  color: #fff;
-  padding: 10px 20px;
-  border-radius: 16px;
+/* ── Recording pill (stats + buttons in one bottom-left surface) ──────────── */
+/* Stats DOM is rendered inside .recording-panel by recording.ts's renderButtons.
+   The standalone #recording-stats element is gone — the pill now owns the
+   recording lifecycle UI. */
+
+.rec-stats {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  z-index: 1000;
-  pointer-events: none;
-  white-space: nowrap;
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
+  width: 100%;
 }
 
 .stats-row {
@@ -237,11 +227,65 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   letter-spacing: 0.01em;
 }
 
-/* ── Recording control panel ─────────────────────────────────────────────── */
+/* ── Recording pill — single surface for the recording lifecycle ──────────
+   - .recording-panel--idle: compact, transparent, just the green Record button
+   - .recording-panel--active: dark expanded pill with stats + Pause (or
+     Resume + Finish in paused state)
+   - .recording-panel--saved: transient green "Saved ✓" after Finish, then
+     collapses back to idle */
 .recording-panel {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  border-radius: 16px;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 360px;
+  /* Smooth transition between idle (transparent, no padding) and the
+     expanded states (dark/green, padded). max-width transitions help the
+     pill grow into its content rather than snap. */
+  transition: padding 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.recording-panel--idle {
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+}
+
+.recording-panel--active {
+  background: rgba(0, 0, 0, 0.88);
+  color: #fff;
+  padding: 12px 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  min-width: 200px;
+}
+
+.recording-panel--saved {
+  background: rgba(34, 197, 94, 0.92);
+  color: #fff;
+  padding: 12px 16px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.recording-panel--saved .rec-saved {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+/* Fallback class — toggle on .recording-panel to lock it in expanded sizing
+   if the height/padding transition stutters on low-end Android. */
+.recording-panel.recording-pill--always-expanded {
+  background: rgba(0, 0, 0, 0.88);
+  color: #fff;
+  padding: 12px 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  min-width: 200px;
+  transition: none;
 }
 
 .rec-btn {


### PR DESCRIPTION
Closes #138. Part of epic #134.

## Summary

The standalone `#recording-stats` element is gone. The recording panel at bottom-left now owns the full recording lifecycle UI as a single **pill** with three state-driven appearances:

| State | Pill |
|---|---|
| Idle | compact, transparent, just the green **Record** button |
| Active (recording) | dark expanded pill: stats above **Pause** only |
| Active (paused) | dark expanded pill: stats above **Resume** + **Finish** |
| Saved (1.5 s transient) | green pill with **"Saved ✓"**, then collapses to idle |

CSS transitions `padding`, `background-color`, and `box-shadow` over 0.25 s for a smooth idle ↔ active morph. A `.recording-pill--always-expanded` fallback class is provided to lock the expanded sizing if the transition stutters on low-end Android.

## Changes

### `src/recording.ts`
- `createStatsBar()` removed — its DOM is now in a `STATS_HTML` const, injected by `renderButtons()` when the pill enters its active state.
- `setStatsBarVisible()` removed — visibility is implicit in the state-driven class and content swap.
- `renderButtons()` now sets `recording-panel--idle` / `--active` on the container and rebuilds inner HTML accordingly. `updateStatsBar(state)` runs once after the active render so the pill doesn't flash placeholders before the 1 Hz statsTimer fires.
- `showSavedTransient()` added — sets `recording-panel--saved`, shows "Saved ✓" for 1.5 s, then re-renders idle. Called from the Finish handler instead of an immediate `renderButtons` call.
- `maybeRestoreTrailBackup()` now calls `updateRecordingButtons()` to re-render the pill in active state after a restore (the initial mount renders idle).

### `src/main.ts`
- Dropped `createStatsBar` from the import and the call site.

### `src/style.css`
- Dropped the `#recording-stats` fixed-position rules (the element no longer exists).
- `.recording-panel` gets the new pill styling + state modifiers.
- `.rec-stats` is the wrapper inside the pill (replaces the old standalone container).

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean
- [ ] Idle: pill is compact, just the green Record button visible
- [ ] Tap Record → pill expands smoothly to show Duration / Dist / Ascent + Pause
- [ ] Tap Pause → Resume + Finish revealed (Pause replaced by them); stats still visible
- [ ] Tap Resume → back to recording state with Pause only
- [ ] Tap Finish → "Saved ✓" green pill for 1.5 s, then collapses to compact Record
- [ ] Real-time stats update at 1 Hz while recording
- [ ] GPS-weak badge + battery badge render inside the pill when applicable
- [ ] Recording dot pulses red in recording state, static orange + "PAUSED" label in paused state
- [ ] Refresh during recording: trail-backup restore prompt → accept → pill re-renders in active state with stats

## Out of scope

The `.recording-pill--always-expanded` fallback class is shipped but not auto-applied; if real-world testing on low-end Android flags transition stutter, a follow-up issue can wire detection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)