### PR TITLE
a11y(recording): announce pill state + manage focus on transitions (#143)

### DIFF
--- a/src/recording.ts
+++ b/src/recording.ts
@@ -191,6 +191,11 @@ export function addRecordingControl(
   const RecCtrl = L.Control.extend({
     onAdd(): HTMLElement {
       const container = L.DomUtil.create('div', 'recording-panel');
+      // a11y: marks the pill as a labeled landmark for screen readers; the
+      // aria-label is rewritten per state (idle / recording / paused) by
+      // renderButtons so the announcement matches what's currently rendered.
+      container.setAttribute('role', 'region');
+      container.setAttribute('aria-label', 'Recording controls');
       recControlContainer = container;
       L.DomEvent.disableClickPropagation(container);
       L.DomEvent.disableScrollPropagation(container);
@@ -211,6 +216,11 @@ export function updateRecordingButtons(): void {
   }
 }
 
+// Tracks the most recent recordingState rendered so we can detect transitions
+// and move keyboard focus to the new primary button. Set to null on the initial
+// mount so we don't steal focus from elsewhere on page load.
+let previousRecordingState: AppState['recordingState'] | null = null;
+
 function renderButtons(
   state: AppState,
   activatePolling: () => void,
@@ -224,7 +234,8 @@ function renderButtons(
   if (state.recordingState === 'idle') {
     // Idle: compact pill — just the Record button. No stats, no background.
     c.className = 'recording-panel recording-panel--idle';
-    const btn = makeBtn('⏺ Record', 'rec-btn rec-btn-start', () => {
+    c.setAttribute('aria-label', 'Recording controls');
+    const btn = makeBtn('⏺ Record', 'rec-btn rec-btn-start', 'Start recording', () => {
       startRecording(state, map, activatePolling);
       renderButtons(state, activatePolling, deactivatePolling, map);
     });
@@ -233,6 +244,7 @@ function renderButtons(
       btn.title = 'Enable location first';
     }
     c.appendChild(btn);
+    previousRecordingState = state.recordingState;
     return;
   }
 
@@ -243,8 +255,9 @@ function renderButtons(
   if (state.recordingState === 'recording') {
     // Two-step Stop reveal: only Pause is visible while recording.
     // Tapping Pause is what reveals Finish (the paused branch).
+    c.setAttribute('aria-label', 'Recording in progress');
     c.appendChild(
-      makeBtn('⏸ Pause', 'rec-btn rec-btn-pause', () => {
+      makeBtn('⏸ Pause', 'rec-btn rec-btn-pause', 'Pause recording', () => {
         pauseRecording(state);
         renderButtons(state, activatePolling, deactivatePolling, map);
       }),
@@ -252,14 +265,15 @@ function renderButtons(
   } else {
     // paused — Resume continues recording; Finish ends the session immediately.
     // The Pause-then-Finish reveal IS the confirmation; no modal.
+    c.setAttribute('aria-label', 'Recording paused');
     c.appendChild(
-      makeBtn('▶ Resume', 'rec-btn rec-btn-resume', () => {
+      makeBtn('▶ Resume', 'rec-btn rec-btn-resume', 'Resume recording', () => {
         resumeRecording(state);
         renderButtons(state, activatePolling, deactivatePolling, map);
       }),
     );
     c.appendChild(
-      makeBtn('⏹ Finish', 'rec-btn rec-btn-finish', () => {
+      makeBtn('⏹ Finish', 'rec-btn rec-btn-finish', 'Finish recording', () => {
         stopRecording(state, deactivatePolling);
         showSavedTransient();
       }),
@@ -269,6 +283,18 @@ function renderButtons(
   // Populate stats values immediately so the pill doesn't flash placeholders
   // before the first 1Hz tick of the statsTimer.
   updateStatsBar(state);
+
+  // a11y: move focus to the primary button on a real state transition (Record
+  // → Pause, Pause → Resume, Resume → Pause). Skip on initial mount and on
+  // incidental re-renders (e.g. updateRecordingButtons on locate change) so
+  // we don't steal focus when the user is interacting elsewhere.
+  if (previousRecordingState !== null && previousRecordingState !== state.recordingState) {
+    const primarySelector = state.recordingState === 'recording'
+      ? '.rec-btn-pause'
+      : '.rec-btn-resume';
+    c.querySelector<HTMLButtonElement>(primarySelector)?.focus();
+  }
+  previousRecordingState = state.recordingState;
 }
 
 // Tracks the active "Saved ✓" timer so a future re-entry can cancel it.
@@ -292,10 +318,13 @@ function showSavedTransient(): void {
   }, 1500);
 }
 
-function makeBtn(label: string, className: string, onClick: () => void): HTMLButtonElement {
+function makeBtn(label: string, className: string, ariaLabel: string, onClick: () => void): HTMLButtonElement {
   const btn = document.createElement('button');
   btn.textContent = label;
   btn.className = className;
+  // The visible label leads with an emoji; aria-label gives screen readers a
+  // plain-text affordance instead of the symbol's Unicode name.
+  btn.setAttribute('aria-label', ariaLabel);
   btn.addEventListener('click', onClick);
   return btn;
 }

--- a/src/recording.ts
+++ b/src/recording.ts
@@ -191,10 +191,8 @@ export function addRecordingControl(
   const RecCtrl = L.Control.extend({
     onAdd(): HTMLElement {
       const container = L.DomUtil.create('div', 'recording-panel');
-      // a11y: marks the pill as a labeled landmark for screen readers; the
-      // aria-label is rewritten per state (idle / recording / paused) by
-      // renderButtons so the announcement matches what's currently rendered.
-      container.setAttribute('role', 'region');
+      // a11y: role="group" gives screen readers a labeled grouping without polluting landmark navigation; aria-label is rewritten per state by renderButtons.
+      container.setAttribute('role', 'group');
       container.setAttribute('aria-label', 'Recording controls');
       recControlContainer = container;
       L.DomEvent.disableClickPropagation(container);
@@ -216,9 +214,7 @@ export function updateRecordingButtons(): void {
   }
 }
 
-// Tracks the most recent recordingState rendered so we can detect transitions
-// and move keyboard focus to the new primary button. Set to null on the initial
-// mount so we don't steal focus from elsewhere on page load.
+// a11y: null on initial mount lets the focus guard skip the very first render.
 let previousRecordingState: AppState['recordingState'] | null = null;
 
 function renderButtons(
@@ -284,10 +280,7 @@ function renderButtons(
   // before the first 1Hz tick of the statsTimer.
   updateStatsBar(state);
 
-  // a11y: move focus to the primary button on a real state transition (Record
-  // → Pause, Pause → Resume, Resume → Pause). Skip on initial mount and on
-  // incidental re-renders (e.g. updateRecordingButtons on locate change) so
-  // we don't steal focus when the user is interacting elsewhere.
+  // a11y: move focus only on real state transitions so locate-state re-renders don't steal focus.
   if (previousRecordingState !== null && previousRecordingState !== state.recordingState) {
     const primarySelector = state.recordingState === 'recording'
       ? '.rec-btn-pause'
@@ -322,8 +315,7 @@ function makeBtn(label: string, className: string, ariaLabel: string, onClick: (
   const btn = document.createElement('button');
   btn.textContent = label;
   btn.className = className;
-  // The visible label leads with an emoji; aria-label gives screen readers a
-  // plain-text affordance instead of the symbol's Unicode name.
+  // a11y: visible label leads with an emoji; aria-label is the plain-text screen-reader affordance.
   btn.setAttribute('aria-label', ariaLabel);
   btn.addEventListener('click', onClick);
   return btn;


### PR DESCRIPTION
Closes #143. Addresses the screen-reader regression flagged in #142's review.

## Summary

When the two-step Pause→Finish reveal replaced the Stop confirmation modal in #142, AT users lost the explicit `role="dialog"` / `aria-label` / focus management the modal had given them. This PR puts equivalent affordances on the pill itself.

## Changes

`src/recording.ts`:

- **Container**: `role="region"` + a state-driven `aria-label` rewritten on every render — `"Recording controls"` (idle) / `"Recording in progress"` / `"Recording paused"`.
- **Buttons**: each button gets a plain-text `aria-label` (`"Start recording"`, `"Pause recording"`, `"Resume recording"`, `"Finish recording"`). The visible label keeps the leading emoji; the aria-label keeps screen readers from reading the Unicode glyph name.
- **Focus management**: a module-level `previousRecordingState` tracks the last rendered state. On real transitions (Record → Pause, Pause → Resume, Resume → Pause) `renderButtons` moves keyboard focus to the new primary button (`.rec-btn-pause` or `.rec-btn-resume`), which triggers the screen reader to announce it.
  - **Suppressed on initial mount** (`previousRecordingState === null`) so we don't grab focus on page load.
  - **Suppressed on incidental re-renders** (`updateRecordingButtons` called from a locate-state change) since the recording state itself didn't change.

No visual or behavioral changes for sighted users.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean
- [ ] VoiceOver / NVDA: tap Record — screen reader announces "Pause recording, button"
- [ ] After Pause: announces "Resume recording, button"
- [ ] After Resume: announces "Pause recording, button"
- [ ] Tab traversal lands on the buttons; aria-label is read instead of "circle button" / glyph name
- [ ] Page load: no focus stolen by the pill
- [ ] Locate-state change while idle: no focus stolen by the pill

## Out of scope

- aria-live announcement of stats updates — the 1 Hz Duration/Distance tick would be too verbose. Focus management on transitions is the targeted UX surface.
- Saved transient announcement — body-focus on Finish click is acceptable; the user just took the terminal action and a brief visual confirmation is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)