### PR TITLE
feat(locate): drop to passive on mouse wheel zoom (#147)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -211,11 +211,7 @@ addLocateControl(map, () => {
   }
 });
 
-// Drop locate from active → passive on user-driven map manipulation.
-// Drag and wheel-zoom both translate the map view away from the user's
-// position, so the "follow" semantic no longer holds. Button-zoom
-// (zoom +/− controls) is deliberate and keeps the active center, so
-// it intentionally does not trigger this.
+// Drag and wheel-zoom move the view off the user's position; button-zoom is deliberate so it keeps active.
 function dropToPassive(showTouchHint: boolean): void {
   if (state.locateState !== 'active') return;
   state.locateState = 'passive';
@@ -239,13 +235,8 @@ function dropToPassive(showTouchHint: boolean): void {
 }
 
 map.on('dragstart', () => dropToPassive(true));
-// passive: true is fine — Leaflet handles the wheel-zoom mechanics; we only
-// observe and update locate state.
-map.getContainer().addEventListener(
-  'wheel',
-  () => dropToPassive(false),
-  { passive: true },
-);
+// passive: true — we observe only; Leaflet owns wheel-zoom mechanics.
+map.getContainer().addEventListener('wheel', () => dropToPassive(false), { passive: true });
 
 // Double-tap on the map re-activates locate (mobile) — when the user has panned
 // away (active → passive), a double-tap snaps back to their position without

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,29 +211,41 @@ addLocateControl(map, () => {
   }
 });
 
-// Pan while following → drop to passive (map stays on user's panned position)
-map.on('dragstart', () => {
-  if (state.locateState === 'active') {
-    state.locateState = 'passive';
-    updateLocateIcon('passive');
+// Drop locate from active → passive on user-driven map manipulation.
+// Drag and wheel-zoom both translate the map view away from the user's
+// position, so the "follow" semantic no longer holds. Button-zoom
+// (zoom +/− controls) is deliberate and keeps the active center, so
+// it intentionally does not trigger this.
+function dropToPassive(showTouchHint: boolean): void {
+  if (state.locateState !== 'active') return;
+  state.locateState = 'passive';
+  updateLocateIcon('passive');
 
-    if (navigator.maxTouchPoints > 0 && !sessionStorage.getItem('locate-hint-shown')) {
-      sessionStorage.setItem('locate-hint-shown', '1');
-      showToast('Double-tap map to re-center', 2500);
-    }
-
-    const locateImg = document.getElementById('locate');
-    if (locateImg) {
-      locateImg.classList.remove('locate-passive-pulse');
-      // Force reflow so re-adding the class restarts the animation
-      void locateImg.offsetWidth;
-      locateImg.classList.add('locate-passive-pulse');
-      locateImg.addEventListener('animationend', () => {
-        locateImg.classList.remove('locate-passive-pulse');
-      }, { once: true });
-    }
+  if (showTouchHint && navigator.maxTouchPoints > 0 && !sessionStorage.getItem('locate-hint-shown')) {
+    sessionStorage.setItem('locate-hint-shown', '1');
+    showToast('Double-tap map to re-center', 2500);
   }
-});
+
+  const locateImg = document.getElementById('locate');
+  if (locateImg) {
+    locateImg.classList.remove('locate-passive-pulse');
+    // Force reflow so re-adding the class restarts the animation
+    void locateImg.offsetWidth;
+    locateImg.classList.add('locate-passive-pulse');
+    locateImg.addEventListener('animationend', () => {
+      locateImg.classList.remove('locate-passive-pulse');
+    }, { once: true });
+  }
+}
+
+map.on('dragstart', () => dropToPassive(true));
+// passive: true is fine — Leaflet handles the wheel-zoom mechanics; we only
+// observe and update locate state.
+map.getContainer().addEventListener(
+  'wheel',
+  () => dropToPassive(false),
+  { passive: true },
+);
 
 // Double-tap on the map re-activates locate (mobile) — when the user has panned
 // away (active → passive), a double-tap snaps back to their position without


### PR DESCRIPTION
Closes #147.

## Summary

Wheel zoom translates the map view toward the cursor, which moves the center away from the user's GPS position — same effective consequence as a drag. Today the map snaps back on the next GPS tick, which feels janky during zoom. Now wheel-zoom mirrors the existing `dragstart` handler and flips locate from `active` → `passive` on the first wheel turn.

## Changes

`src/main.ts`:

- Extracted the existing dragstart drop-to-passive logic into a `dropToPassive(showTouchHint)` helper. Drag passes `true` (keeps the one-time touch toast); wheel passes `false` (the toast already gates on `navigator.maxTouchPoints`, but skipping the call is clearer).
- Wheel listener registered on `map.getContainer()` with `{ passive: true }` — we observe, not `preventDefault`, so Leaflet's wheel-zoom mechanics aren't blocked.

## Notes

- **Subsequent wheel turns short-circuit** on `state.locateState !== 'active'` — the pulse animation fires once per drop-to-passive event, not every wheel tick.
- **Button zoom (zoom +/−)** is intentionally not wired in; those clicks are deliberate and keep the active center.
- **Pinch-zoom on touch** is a separate concern (different gesture, different platform) — not in scope here.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean
- [ ] Desktop: enable locate (active state) → wheel-zoom → locate flips to passive on first wheel turn; pulse fires once
- [ ] Multiple consecutive wheel ticks don't re-pulse
- [ ] Drag-while-active still drops to passive (no regression)
- [ ] Zoom +/− buttons while active keep locate in active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)