### PR TITLE
feat(layers): use mix-blend-mode multiply on Hillshade (#149)

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -233,10 +233,7 @@ export function createMap(): L.Map {
     'https://server.arcgisonline.com/ArcGIS/rest/services/Elevation/World_Hillshade/MapServer/tile/{z}/{y}/{x}',
     {
       attribution: 'Esri',
-      // CSS mix-blend-mode: multiply (.hillshade-blend in style.css) governs the
-      // composite — flat/lit pixels leave the base unchanged; only shaded
-      // slopes darken. Dropping the prior opacity:0.4 lets multiply run at
-      // full strength; alpha-blending on top would damp it.
+      // multiply: flat/lit pixels (near-white) pass through; slopes darken. See .hillshade-blend in style.css.
       className: 'hillshade-blend',
       tileSize: 256,
       zoomOffset: 0,

--- a/src/map.ts
+++ b/src/map.ts
@@ -233,7 +233,11 @@ export function createMap(): L.Map {
     'https://server.arcgisonline.com/ArcGIS/rest/services/Elevation/World_Hillshade/MapServer/tile/{z}/{y}/{x}',
     {
       attribution: 'Esri',
-      opacity: 0.4,
+      // CSS mix-blend-mode: multiply (.hillshade-blend in style.css) governs the
+      // composite — flat/lit pixels leave the base unchanged; only shaded
+      // slopes darken. Dropping the prior opacity:0.4 lets multiply run at
+      // full strength; alpha-blending on top would damp it.
+      className: 'hillshade-blend',
       tileSize: 256,
       zoomOffset: 0,
       maxZoom: 18,

--- a/src/style.css
+++ b/src/style.css
@@ -8,6 +8,9 @@ html { height: 100%; width: 100%; padding: 0; margin: 0; }
 body { height: 100%; width: 100%; padding: 0; margin: 0; }
 #map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
 
+/* Multiply preserves base-map color in flat areas (hillshade ≈ white there) and only darkens slopes. */
+.hillshade-blend { mix-blend-mode: multiply; }
+
 /* Icon state classes for GPS accuracy filter visual feedback */
 #disabled {
   -webkit-filter: grayscale(1);


### PR DESCRIPTION
Closes #149.

## Summary

Replace the hillshade overlay's `opacity: 0.4` alpha-blend with CSS `mix-blend-mode: multiply`.

Alpha-blending uniformly dims the underlying base map — flat areas get washed out for no visual benefit since hillshade is near-white there. Multiply preserves white-ish pixels (flat / lit terrain → no change to base) and darkens proportional to source darkness (slopes → still readable as relief).

## Changes

- **`src/map.ts`** — hillshade `L.tileLayer` config now passes `className: 'hillshade-blend'` (Leaflet adds the class to the wrapper `<div>`); `opacity: 0.4` removed since alpha-blending on top of `mix-blend-mode` would damp the effect.
- **`src/style.css`** — new `.hillshade-blend { mix-blend-mode: multiply; }` rule.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean
- [ ] With Hillshade overlay enabled, base-map color in flat areas is unchanged from "no overlay" (multiply leaves whites alone)
- [ ] Slope shadows are visible — relief is still readable
- [ ] Disabling Hillshade overlay restores plain base-map (no leftover blend)
- [ ] Switching base maps under hillshade overlay applies multiply correctly to each (Streets / Topographic / Parks & POIs)

## Out of scope

If multiply at full strength reads as too dark, follow-up can re-introduce a small opacity (e.g. 0.7) — but per the issue description, full strength is the right starting point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)