### PR TITLE
refactor(controls): extract setupCollapsibleLabel helper (#140)

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -24,6 +24,31 @@ export function collapseControlLabel(container: HTMLElement): void {
   if (label) label.remove();
 }
 
+/** Wires first-use label collapse with optional localStorage persistence; returns the collapse trigger. */
+export function setupCollapsibleLabel(
+  container: HTMLElement,
+  label: HTMLElement,
+  storageKey: string | null,
+): () => void {
+  let collapsed = false;
+  if (storageKey !== null) {
+    try {
+      collapsed = localStorage.getItem(storageKey) === '1';
+    } catch { /* localStorage unavailable (e.g. private browsing) */ }
+  }
+  if (!collapsed) {
+    container.appendChild(label);
+  }
+  return (): void => {
+    if (collapsed) return;
+    collapseControlLabel(container);
+    collapsed = true;
+    if (storageKey !== null) {
+      try { localStorage.setItem(storageKey, '1'); } catch { /* ignore */ }
+    }
+  };
+}
+
 // tradeoff: Using a factory function rather than a class to avoid the complexity of
 // typing L.Control.extend() return values in strict TypeScript. The per-call closure
 // captures config cleanly without needing instance properties.
@@ -40,21 +65,15 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
 
       container.appendChild(img);
 
-      const storageKey = config.collapseOnFirstUse && config.id
-        ? `webmap-ctrl-label-${config.id}`
-        : null;
-
+      let collapseAndPersist: () => void = () => { /* no-op when no label */ };
       if (config.label) {
         const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
         label.textContent = config.label;
-        container.appendChild(label);
-        if (storageKey) {
-          try {
-            if (localStorage.getItem(storageKey) === '1') {
-              collapseControlLabel(container);
-              config.collapseOnFirstUse = false;
-            }
-          } catch { /* localStorage unavailable (e.g. private browsing) */ }
+        if (config.collapseOnFirstUse) {
+          const storageKey = config.id ? `webmap-ctrl-label-${config.id}` : null;
+          collapseAndPersist = setupCollapsibleLabel(container, label, storageKey);
+        } else {
+          container.appendChild(label);
         }
       }
 
@@ -63,13 +82,7 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
       L.DomEvent.disableClickPropagation(container);
 
       function handleClick(e: Event): void {
-        if (config.collapseOnFirstUse) {
-          collapseControlLabel(container);
-          config.collapseOnFirstUse = false; // only once
-          if (storageKey) {
-            try { localStorage.setItem(storageKey, '1'); } catch { /* ignore */ }
-          }
-        }
+        collapseAndPersist();
         config.onClick(e);
       }
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -19,7 +19,7 @@ interface ToggleControlConfig {
 }
 
 /** Remove the text label from a control container, leaving only the icon. */
-export function collapseControlLabel(container: HTMLElement): void {
+function collapseControlLabel(container: HTMLElement): void {
   const label = container.querySelector('.leaflet-control-toggle__label');
   if (label) label.remove();
 }
@@ -34,7 +34,7 @@ export function setupCollapsibleLabel(
   if (storageKey !== null) {
     try {
       collapsed = localStorage.getItem(storageKey) === '1';
-    } catch { /* localStorage unavailable (e.g. private browsing) */ }
+    } catch { /* localStorage unavailable */ }
   }
   if (!collapsed) {
     container.appendChild(label);
@@ -44,7 +44,7 @@ export function setupCollapsibleLabel(
     collapseControlLabel(container);
     collapsed = true;
     if (storageKey !== null) {
-      try { localStorage.setItem(storageKey, '1'); } catch { /* ignore */ }
+      try { localStorage.setItem(storageKey, '1'); } catch { /* localStorage unavailable */ }
     }
   };
 }
@@ -70,6 +70,7 @@ export function makeToggleControl(config: ToggleControlConfig): L.Control {
         const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
         label.textContent = config.label;
         if (config.collapseOnFirstUse) {
+          // storageKey is null when config.id is absent — collapse is session-only.
           const storageKey = config.id ? `webmap-ctrl-label-${config.id}` : null;
           collapseAndPersist = setupCollapsibleLabel(container, label, storageKey);
         } else {

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -10,7 +10,7 @@
  */
 
 import L from 'leaflet';
-import { collapseControlLabel } from './controls';
+import { setupCollapsibleLabel } from './controls';
 
 export interface LayerDef {
   id: string;
@@ -65,25 +65,9 @@ export class LayersControl extends L.Control {
 
     container.appendChild(icon);
 
-    // Label
     const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
     label.textContent = 'Layers';
-
-    const STORAGE_KEY = 'webmap-ctrl-label-layers';
-    let labelCollapsed = false;
-    try {
-      labelCollapsed = localStorage.getItem(STORAGE_KEY) === '1';
-    } catch { /* localStorage unavailable (e.g. private browsing) */ }
-    if (!labelCollapsed) {
-      container.appendChild(label);
-    }
-
-    const collapseAndPersist = (): void => {
-      if (labelCollapsed) return;
-      collapseControlLabel(container);
-      labelCollapsed = true;
-      try { localStorage.setItem(STORAGE_KEY, '1'); } catch { /* ignore */ }
-    };
+    const collapseAndPersist = setupCollapsibleLabel(container, label, 'webmap-ctrl-label-layers');
 
     // Prevent map interaction
     L.DomEvent.disableClickPropagation(container);

--- a/src/offline-download.ts
+++ b/src/offline-download.ts
@@ -5,7 +5,7 @@
  * Future: Only caches OSM tiles (the SW-cached layer); Mapbox/Google layers are not cached and won't benefit from pre-download
  */
 import L from 'leaflet';
-import { collapseControlLabel } from './controls';
+import { setupCollapsibleLabel } from './controls';
 import { OSM_TILE_CACHE_NAME } from './sw-constants';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -559,22 +559,7 @@ export function addOfflineDownloadControl(
 
       const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
       label.textContent = 'Download';
-
-      const STORAGE_KEY = 'webmap-ctrl-label-offline-dl';
-      let labelCollapsed = false;
-      try {
-        labelCollapsed = localStorage.getItem(STORAGE_KEY) === '1';
-      } catch { /* localStorage unavailable (e.g. private browsing) */ }
-      if (!labelCollapsed) {
-        container.appendChild(label);
-      }
-
-      const collapseAndPersist = (): void => {
-        if (labelCollapsed) return;
-        collapseControlLabel(container);
-        labelCollapsed = true;
-        try { localStorage.setItem(STORAGE_KEY, '1'); } catch { /* ignore */ }
-      };
+      const collapseAndPersist = setupCollapsibleLabel(container, label, 'webmap-ctrl-label-offline-dl');
 
       L.DomEvent.disableClickPropagation(container);
 


### PR DESCRIPTION
Closes #140.

## Summary

Three near-identical copies of "create a label, append it unless previously collapsed (per `localStorage`), return a `collapseAndPersist` function" lived in `controls.ts` (`makeToggleControl`), `layers-control.ts` (`LayersControl`), and `offline-download.ts` (inline `L.Control.extend`). Consolidated into a single `setupCollapsibleLabel` exported from `controls.ts`.

**Bonus side-effect**: the new helper skips appending the label entirely when previously persisted, so the brief flash-then-collapse the old `makeToggleControl` pattern produced is gone.

## Changes

- **`src/controls.ts`** — new `setupCollapsibleLabel(container, label, storageKey)` helper added next to `collapseControlLabel`. `makeToggleControl` now uses it; the local `config.collapseOnFirstUse` mutation is gone (helper's idempotency replaces the manual "only once" guard). `storageKey: null` skips persistence (covers `makeToggleControl`'s `collapseOnFirstUse: false` callers).
- **`src/layers-control.ts`** — 18 lines of inline collapse-and-persist replaced with one `setupCollapsibleLabel` call. Import updated.
- **`src/offline-download.ts`** — same. Import updated.

Net: 36 lines added, 54 removed.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean (33 tests pass)
- [ ] Locate label collapses on first tap, persists across reload (existing behavior, unchanged)
- [ ] Layers label collapses on first hover/tap, persists
- [ ] Download label collapses on first hover/tap, persists
- [ ] Private-browsing mode gracefully degrades (no localStorage error; collapse still works for the session)

## Out of scope

The `collapseOnFirstUse: false` callers (e.g., the dead `addTrackingControl`) keep their existing "label always visible, never collapses" behavior — the helper's `storageKey: null` path handles this when `setupCollapsibleLabel` isn't even invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)