### PR TITLE
PR-3: guidance state machine + pill UI + Navigate-here entry points (#154)

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -7,6 +7,7 @@
 import L from 'leaflet';
 import { geosearch, arcgisOnlineProvider, geocodeService } from 'esri-leaflet-geocoder';
 import type { AppState } from './types';
+import { startGuidance } from './guidance';
 
 // Escape text for safe insertion into innerHTML
 function escapeHtml(str: string): string {
@@ -239,6 +240,19 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
   dropdownEl.addEventListener('click', (e: MouseEvent) => {
     const clicked = e.target as HTMLElement;
 
+    // "Navigate here" button — start routed guidance to the selected result
+    const navBtn = clicked.closest<HTMLElement>('.sheet-result__nav-btn');
+    if (navBtn) {
+      const li = navBtn.closest<HTMLElement>('.sheet-result[data-lat]');
+      if (li === null) return;
+      const lat = parseFloat(li.dataset['lat'] ?? '');
+      const lng = parseFloat(li.dataset['lng'] ?? '');
+      if (isNaN(lat) || isNaN(lng)) return;
+      const label = li.dataset['name'] ?? `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+      void startGuidance(state, map, { lat, lng, label }, onNoResults);
+      return;
+    }
+
     // "Go to location" button — fly to the result and show geocode bar
     const goBtn = clicked.closest<HTMLElement>('.sheet-result__go-btn');
     if (goBtn) {
@@ -382,6 +396,7 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
             `      <span class="sheet-result__detail-coords">${coordStr}</span>` +
             `    </div>` +
             `    <div class="sheet-result__detail-actions">` +
+            `      <button class="sheet-result__nav-btn">Navigate here</button>` +
             `      <button class="sheet-result__go-btn">Go to location</button>` +
             `      <button class="sheet-result__copy-btn" data-copy="${longLabel}">Copy address</button>` +
             `      <button class="sheet-result__copy-btn" data-copy="${escapeHtml(coordStr)}">Copy coords</button>` +
@@ -424,7 +439,11 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
   });
 }
 
-export function addReverseGeocoding(map: L.Map): void {
+export function addReverseGeocoding(
+  map: L.Map,
+  state: AppState,
+  showToast: (msg: string, durationMs?: number) => void,
+): void {
   const apikey = import.meta.env.VITE_ESRI_API_KEY;
   const geocoder = geocodeService({ apikey });
   const pinLayer = L.layerGroup().addTo(map);
@@ -440,6 +459,7 @@ export function addReverseGeocoding(map: L.Map): void {
     '  <div class="geocode-bar__handle-pill"></div>' +
     '</div>' +
     '<div class="geocode-bar__body">' +
+    '  <button class="geocode-bar__nav" aria-label="Navigate here">Navigate</button>' +
     '  <button class="geocode-bar__copy" aria-label="Copy address">Copy</button>' +
     '  <span class="geocode-bar__addr"></span>' +
     '  <button class="geocode-bar__close" aria-label="Dismiss">\u00d7</button>' +
@@ -448,7 +468,33 @@ export function addReverseGeocoding(map: L.Map): void {
 
   const barAddrEl  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__addr')!;
   const barCopyBtn = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__copy')!;
+  const barNavBtn  = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__nav')!;
   const barHandle  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__handle')!;
+
+  // "Navigate" button on the geocode-bar — start guidance to the dropped pin's
+  // current latlng. The pin location is on whichever marker is in pinLayer
+  // (there's always at most one when the bar is visible).
+  let currentPinLatLng: L.LatLng | null = null;
+  let currentPinLabel = '';
+  barNavBtn.addEventListener('click', () => {
+    if (currentPinLatLng === null) return;
+    void startGuidance(
+      state,
+      map,
+      { lat: currentPinLatLng.lat, lng: currentPinLatLng.lng, label: currentPinLabel },
+      showToast,
+    );
+  });
+
+  // Expose pin position to the Navigate button via closure-captured ref.
+  // Updated by showGeocodeBar through pinLayer inspection on each open.
+  pinLayer.on('layeradd', () => {
+    const layers = pinLayer.getLayers();
+    const pin = layers[layers.length - 1];
+    if (pin instanceof L.Marker) {
+      currentPinLatLng = pin.getLatLng();
+    }
+  });
 
   // Tap-to-expand: tapping a truncated address shows the full text for 3s
   // (or until a second tap). This makes long addresses readable on mobile
@@ -550,6 +596,7 @@ export function addReverseGeocoding(map: L.Map): void {
     barCopyBtn.dataset['copy'] = copyText;
     barCopyBtn.textContent = 'Copy';
     barCopyBtn.classList.remove('geocode-bar__copy--copied');
+    currentPinLabel = label;
 
     if (sheetState === 'hidden') {
       // Render off-screen first so offsetHeight is available, then use double-rAF

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import L from 'leaflet';
+import { updateGuidance, stopGuidance } from './guidance';
+import { createInitialState } from './types';
+import type { AppState } from './types';
+import type { Route, RouteStep } from './routing';
+
+function makeMap(): L.Map {
+  return {
+    removeLayer: () => undefined,
+    addLayer: () => undefined,
+  } as unknown as L.Map;
+}
+
+function makeRoute(coords: Array<[number, number]>, steps?: RouteStep[]): Route {
+  return {
+    coords: coords.map(([lat, lng]) => L.latLng(lat, lng)),
+    steps: steps ?? [
+      { instruction: 'Go', type: 1, lengthM: 100, durationS: 60, streetNames: [], beginShapeIndex: 0 },
+    ],
+    distanceM: 1000,
+    durationS: 600,
+  };
+}
+
+function setGuiding(
+  state: AppState,
+  route: Route,
+  dest: { lat: number; lng: number; label: string },
+): void {
+  state.guidance.status = 'guiding';
+  state.guidance.route = route;
+  state.guidance.destination = dest;
+  state.guidance.currentStepIdx = 0;
+}
+
+function fakeFix(lat: number, lng: number): L.LocationEvent {
+  return {
+    latlng: L.latLng(lat, lng),
+    bounds: L.latLngBounds(L.latLng(lat, lng), L.latLng(lat, lng)),
+    timestamp: 0,
+    accuracy: 10,
+    heading: NaN,
+    speed: 0,
+    altitude: null,
+    altitudeAccuracy: 0,
+    type: 'locationfound',
+  } as unknown as L.LocationEvent;
+}
+
+describe('updateGuidance — status gating', () => {
+  let state: AppState;
+  let map: L.Map;
+
+  beforeEach(() => {
+    state = createInitialState();
+    map = makeMap();
+  });
+
+  it('is a no-op when status is idle', () => {
+    updateGuidance(fakeFix(40, -74), state, map);
+    expect(state.guidance.status).toBe('idle');
+  });
+
+  it('is a no-op when status is routing', () => {
+    state.guidance.status = 'routing';
+    updateGuidance(fakeFix(40, -74), state, map);
+    expect(state.guidance.status).toBe('routing');
+  });
+
+  it('is a no-op when status is arrived', () => {
+    state.guidance.status = 'arrived';
+    updateGuidance(fakeFix(40, -74), state, map);
+    expect(state.guidance.status).toBe('arrived');
+  });
+});
+
+describe('updateGuidance — arrival', () => {
+  let state: AppState;
+  let map: L.Map;
+
+  beforeEach(() => {
+    state = createInitialState();
+    map = makeMap();
+  });
+
+  it('flips to arrived when within driving radius (25 m)', () => {
+    const route = makeRoute([[40, -74], [40.001, -74]]);
+    setGuiding(state, route, { lat: 40.001, lng: -74, label: 'X' });
+    state.guidance.costing = 'auto';
+    // ~12 m from dest (well within 25 m)
+    updateGuidance(fakeFix(40.00089, -74), state, map);
+    expect(state.guidance.status).toBe('arrived');
+  });
+
+  it('uses tighter pedestrian radius (10 m)', () => {
+    const route = makeRoute([[40, -74], [40.001, -74]]);
+    setGuiding(state, route, { lat: 40.001, lng: -74, label: 'X' });
+    state.guidance.costing = 'pedestrian';
+    // ~17 m from dest — outside pedestrian 10 m, would have been inside auto's 25 m
+    updateGuidance(fakeFix(40.00085, -74), state, map);
+    expect(state.guidance.status).toBe('guiding');
+  });
+
+  it('does not arrive when far from destination', () => {
+    const route = makeRoute([[40, -74], [40.01, -74]]);
+    setGuiding(state, route, { lat: 40.01, lng: -74, label: 'X' });
+    state.guidance.costing = 'auto';
+    updateGuidance(fakeFix(40, -74), state, map); // ~1.1 km away
+    expect(state.guidance.status).toBe('guiding');
+  });
+});
+
+describe('updateGuidance — off-route streak', () => {
+  let state: AppState;
+  let map: L.Map;
+
+  beforeEach(() => {
+    state = createInitialState();
+    map = makeMap();
+  });
+
+  it('does not flip on the first off-route fix', () => {
+    const route = makeRoute([[40, -74], [40, -73.99]]);
+    setGuiding(state, route, { lat: 40, lng: -73.99, label: 'X' });
+    state.guidance.costing = 'auto';
+    // ~110 m north of midpoint — well off the auto 30 m threshold
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    expect(state.guidance.offRouteStreak).toBe(1);
+    expect(state.guidance.status).toBe('guiding');
+  });
+
+  it('flips to off-route on the third consecutive fix', () => {
+    const route = makeRoute([[40, -74], [40, -73.99]]);
+    setGuiding(state, route, { lat: 40, lng: -73.99, label: 'X' });
+    state.guidance.costing = 'auto';
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    expect(state.guidance.status).toBe('guiding');
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    expect(state.guidance.status).toBe('off-route');
+  });
+
+  it('resets streak when fix returns to the segment', () => {
+    const route = makeRoute([[40, -74], [40, -73.99]]);
+    setGuiding(state, route, { lat: 40, lng: -73.99, label: 'X' });
+    state.guidance.costing = 'auto';
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    updateGuidance(fakeFix(40.001, -73.995), state, map);
+    expect(state.guidance.offRouteStreak).toBe(2);
+    updateGuidance(fakeFix(40, -73.995), state, map); // back on segment
+    expect(state.guidance.offRouteStreak).toBe(0);
+  });
+});
+
+describe('updateGuidance — step advance', () => {
+  let state: AppState;
+  let map: L.Map;
+
+  beforeEach(() => {
+    state = createInitialState();
+    map = makeMap();
+  });
+
+  it('advances currentStepIdx when within step radius (10 m)', () => {
+    const coords: Array<[number, number]> = [
+      [40.0, -74.0],
+      [40.001, -74.0], // step 2 begin
+      [40.002, -74.0],
+    ];
+    const steps: RouteStep[] = [
+      { instruction: 'Start', type: 1, lengthM: 100, durationS: 30, streetNames: [], beginShapeIndex: 0 },
+      { instruction: 'Continue', type: 17, lengthM: 100, durationS: 30, streetNames: [], beginShapeIndex: 1 },
+      { instruction: 'Arrive', type: 4, lengthM: 0, durationS: 0, streetNames: [], beginShapeIndex: 2 },
+    ];
+    const route = makeRoute(coords, steps);
+    setGuiding(state, route, { lat: 40.002, lng: -74, label: 'X' });
+    state.guidance.costing = 'auto';
+
+    expect(state.guidance.currentStepIdx).toBe(0);
+    // ~5 m from coords[1] — well within 10 m radius
+    updateGuidance(fakeFix(40.000955, -74), state, map);
+    expect(state.guidance.currentStepIdx).toBe(1);
+  });
+});
+
+describe('stopGuidance', () => {
+  it('is a no-op when already idle', () => {
+    const state = createInitialState();
+    const map = makeMap();
+    stopGuidance(state, map);
+    expect(state.guidance.status).toBe('idle');
+  });
+
+  it('clears route refs and destination on stop', () => {
+    const state = createInitialState();
+    const map = makeMap();
+    state.guidance.status = 'guiding';
+    state.guidance.routePolyline = {} as L.Polyline;
+    state.guidance.routeGlow = {} as L.Polyline;
+    state.guidance.destMarker = {} as L.Marker;
+    state.guidance.destination = { lat: 0, lng: 0, label: 'X' };
+    state.guidance.route = makeRoute([[0, 0], [0, 1]]);
+    state.guidance.currentStepIdx = 5;
+    state.guidance.offRouteStreak = 2;
+
+    stopGuidance(state, map);
+
+    expect(state.guidance.status).toBe('idle');
+    expect(state.guidance.destination).toBeNull();
+    expect(state.guidance.route).toBeNull();
+    expect(state.guidance.routePolyline).toBeNull();
+    expect(state.guidance.routeGlow).toBeNull();
+    expect(state.guidance.destMarker).toBeNull();
+    expect(state.guidance.currentStepIdx).toBe(0);
+    expect(state.guidance.offRouteStreak).toBe(0);
+  });
+
+  it('aborts in-flight recalc on stop', () => {
+    const state = createInitialState();
+    const map = makeMap();
+    state.guidance.status = 'off-route';
+    const ac = new AbortController();
+    state.guidance.recalcInFlight = ac;
+    stopGuidance(state, map);
+    expect(ac.signal.aborted).toBe(true);
+    expect(state.guidance.recalcInFlight).toBeNull();
+  });
+});

--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -184,6 +184,26 @@ describe('updateGuidance — step advance', () => {
   });
 });
 
+describe('startGuidance — re-entry', () => {
+  it('shows a toast and returns when called while not idle', async () => {
+    const { startGuidance } = await import('./guidance');
+    const state = createInitialState();
+    state.guidance.status = 'guiding';
+    state.guidance.destination = { lat: 40, lng: -74, label: 'old' };
+    const map = makeMap();
+    const toasts: string[] = [];
+    await startGuidance(
+      state,
+      map,
+      { lat: 40.1, lng: -73.9, label: 'new' },
+      (m) => toasts.push(m),
+    );
+    expect(state.guidance.status).toBe('guiding'); // unchanged
+    expect(state.guidance.destination?.label).toBe('old');
+    expect(toasts).toEqual(['Stop current navigation first']);
+  });
+});
+
 describe('stopGuidance', () => {
   it('is a no-op when already idle', () => {
     const state = createInitialState();

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -8,17 +8,23 @@ import type { Route } from './routing';
 import { fetchRoute } from './routing';
 import { haversineDistance, pointToSegmentMeters } from './geo';
 
-// Profile-dependent thresholds (metres).
-const ARRIVAL_RADIUS_M: Record<string, number> = {
+
+import type { Costing } from './routing';
+
+// Profile-dependent thresholds (metres). `auto` is the default fallback if a
+// future Costing value lands here before the maps are updated.
+const ARRIVAL_RADIUS_M: Record<Costing, number> = {
   auto: 25,
   pedestrian: 10,
   bicycle: 15,
 };
-const OFF_ROUTE_THRESHOLD_M: Record<string, number> = {
+const OFF_ROUTE_THRESHOLD_M: Record<Costing, number> = {
   auto: 30,
   pedestrian: 15,
   bicycle: 20,
 };
+function arrivalRadius(c: Costing): number { return ARRIVAL_RADIUS_M[c] ?? ARRIVAL_RADIUS_M.auto; }
+function offRouteThreshold(c: Costing): number { return OFF_ROUTE_THRESHOLD_M[c] ?? OFF_ROUTE_THRESHOLD_M.auto; }
 const OFF_ROUTE_STREAK = 3;
 const RECALC_THROTTLE_MS = 15_000;
 const ARRIVED_TRANSIENT_MS = 3_000;
@@ -88,7 +94,10 @@ export async function startGuidance(
   dest: { lat: number; lng: number; label: string },
   showToast?: (msg: string, durationMs?: number) => void,
 ): Promise<void> {
-  if (state.guidance.status !== 'idle') return;
+  if (state.guidance.status !== 'idle') {
+    showToast?.('Stop current navigation first', 2500);
+    return;
+  }
   if (state.youAreHereLocation === null) {
     showToast?.('Enable location to navigate', 3000);
     return;
@@ -98,7 +107,6 @@ export async function startGuidance(
   state.guidance.destination = dest;
   render();
 
-  if (state.guidance.recalcInFlight) state.guidance.recalcInFlight.abort();
   const ac = new AbortController();
   state.guidance.recalcInFlight = ac;
 
@@ -152,6 +160,7 @@ export function stopGuidance(state: AppState, map: L.Map): void {
   state.guidance.destMarker = null;
   state.guidance.currentStepIdx = 0;
   state.guidance.distanceToManeuverM = null;
+  state.guidance.distanceToDestinationM = null;
   state.guidance.offRouteStreak = 0;
   state.guidance.arrivedAt = null;
   render();
@@ -173,25 +182,29 @@ export function updateGuidance(e: L.LocationEvent, state: AppState, map: L.Map):
 
   const here = e.latlng;
 
-  // Arrived check: within radius of final destination
+  // Approximate remaining distance: straight-line to destination. Updates the
+  // pill's countdown so it doesn't flash full-route distance until arrival.
   const distToDest = haversineDistance(here.lat, here.lng, dest.lat, dest.lng);
-  if (distToDest <= ARRIVAL_RADIUS_M[state.guidance.costing]!) {
+  state.guidance.distanceToDestinationM = distToDest;
+
+  // Arrived check: within radius of final destination
+  if (distToDest <= arrivalRadius(state.guidance.costing)) {
     setArrived(state, map);
     return;
   }
 
   // Off-route check
-  const offRouteThreshold = OFF_ROUTE_THRESHOLD_M[state.guidance.costing]!;
+  const threshold = offRouteThreshold(state.guidance.costing);
   let minDist = Infinity;
   for (let i = 0; i < route.coords.length - 1; i++) {
     const a = route.coords[i]!;
     const b = route.coords[i + 1]!;
     const d = pointToSegmentMeters(here, a, b);
     if (d < minDist) minDist = d;
-    if (d < offRouteThreshold) break;
+    if (d < threshold) break;
   }
 
-  if (minDist > offRouteThreshold) {
+  if (minDist > threshold) {
     state.guidance.offRouteStreak += 1;
     if (state.guidance.offRouteStreak >= OFF_ROUTE_STREAK) {
       maybeRecalc(state, map);
@@ -342,8 +355,13 @@ function render(): void {
   } else {
     const stepIdx = Math.min(g.currentStepIdx, route.steps.length - 1);
     const step = route.steps[stepIdx];
-    const remaining = route.distanceM;
-    const eta = new Date(Date.now() + route.durationS * 1000);
+    // Remaining distance: prefer the live straight-line update; fall back to
+    // the original route distance for the brief window before the first fix.
+    const remaining = g.distanceToDestinationM ?? route.distanceM;
+    // ETA: scale the route's predicted duration by the share of distance left.
+    const remainingFraction = route.distanceM > 0 ? remaining / route.distanceM : 1;
+    const remainingDurationMs = route.durationS * 1000 * remainingFraction;
+    const eta = new Date(Date.now() + remainingDurationMs);
     const etaStr = eta.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
     const dist = g.distanceToManeuverM ?? step?.lengthM ?? 0;
 

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -1,0 +1,408 @@
+// Routed-guidance state machine + bottom-left pill UI.
+// Feeds off the GPS stream from location.ts via updateGuidance(); fetches
+// routes from routing.ts; renders maneuvers / off-route / arrived states.
+
+import L from 'leaflet';
+import type { AppState } from './types';
+import type { Route } from './routing';
+import { fetchRoute } from './routing';
+import { haversineDistance, pointToSegmentMeters } from './geo';
+
+// Profile-dependent thresholds (metres).
+const ARRIVAL_RADIUS_M: Record<string, number> = {
+  auto: 25,
+  pedestrian: 10,
+  bicycle: 15,
+};
+const OFF_ROUTE_THRESHOLD_M: Record<string, number> = {
+  auto: 30,
+  pedestrian: 15,
+  bicycle: 20,
+};
+const OFF_ROUTE_STREAK = 3;
+const RECALC_THROTTLE_MS = 15_000;
+const ARRIVED_TRANSIENT_MS = 3_000;
+const STEP_ADVANCE_RADIUS_M = 10;
+
+const ROUTE_LINE_OPTS: L.PolylineOptions = {
+  color: '#4287f5',
+  weight: 4,
+  smoothFactor: 2,
+  interactive: false,
+};
+const ROUTE_GLOW_OPTS: L.PolylineOptions = {
+  color: 'rgba(66,135,245,0.25)',
+  weight: 14,
+  smoothFactor: 2,
+  interactive: false,
+};
+
+const DEST_ICON = L.divIcon({
+  className: 'guidance-dest-marker',
+  html: '<div class="guidance-dest-marker__inner"></div>',
+  iconSize: [24, 24],
+  iconAnchor: [12, 12],
+});
+
+let panelEl: HTMLElement | null = null;
+let storedState: AppState | null = null;
+let storedMap: L.Map | null = null;
+let storedActivatePolling: (() => void) | null = null;
+let storedDeactivatePolling: (() => void) | null = null;
+let arrivedTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function addGuidanceControl(
+  map: L.Map,
+  state: AppState,
+  activatePolling: () => void,
+  deactivatePolling: () => void,
+): void {
+  storedState = state;
+  storedMap = map;
+  storedActivatePolling = activatePolling;
+  storedDeactivatePolling = deactivatePolling;
+
+  const Ctrl = L.Control.extend({
+    onAdd(): HTMLElement {
+      const c = L.DomUtil.create('div', 'guidance-panel guidance-panel--idle');
+      c.setAttribute('role', 'group');
+      c.setAttribute('aria-label', 'Navigation');
+      panelEl = c;
+      L.DomEvent.disableClickPropagation(c);
+      L.DomEvent.disableScrollPropagation(c);
+      render();
+      return c;
+    },
+  });
+
+  new (Ctrl as new (opts: L.ControlOptions) => L.Control)({
+    position: 'bottomleft',
+  }).addTo(map);
+}
+
+// ── Public state-machine API ───────────────────────────────────────────────
+
+export async function startGuidance(
+  state: AppState,
+  map: L.Map,
+  dest: { lat: number; lng: number; label: string },
+  showToast?: (msg: string, durationMs?: number) => void,
+): Promise<void> {
+  if (state.guidance.status !== 'idle') return;
+  if (state.youAreHereLocation === null) {
+    showToast?.('Enable location to navigate', 3000);
+    return;
+  }
+
+  state.guidance.status = 'routing';
+  state.guidance.destination = dest;
+  render();
+
+  if (state.guidance.recalcInFlight) state.guidance.recalcInFlight.abort();
+  const ac = new AbortController();
+  state.guidance.recalcInFlight = ac;
+
+  try {
+    const route = await fetchRoute({
+      start: state.youAreHereLocation,
+      dest: L.latLng(dest.lat, dest.lng),
+      costing: state.guidance.costing,
+      signal: ac.signal,
+    });
+    if (state.guidance.recalcInFlight !== ac) return; // newer fetch supersedes
+    state.guidance.recalcInFlight = null;
+    enterGuiding(state, map, route);
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === 'AbortError') return;
+    state.guidance.recalcInFlight = null;
+    state.guidance.status = 'idle';
+    state.guidance.destination = null;
+    render();
+    showToast?.(`Routing failed: ${err instanceof Error ? err.message : String(err)}`, 5000);
+  }
+}
+
+export function stopGuidance(state: AppState, map: L.Map): void {
+  if (state.guidance.status === 'idle') return;
+
+  const wasActive =
+    state.guidance.status === 'guiding' ||
+    state.guidance.status === 'off-route' ||
+    state.guidance.status === 'arrived';
+
+  if (state.guidance.recalcInFlight) {
+    state.guidance.recalcInFlight.abort();
+    state.guidance.recalcInFlight = null;
+  }
+  if (arrivedTimer !== null) {
+    clearTimeout(arrivedTimer);
+    arrivedTimer = null;
+  }
+  if (state.guidance.routePolyline) map.removeLayer(state.guidance.routePolyline);
+  if (state.guidance.routeGlow) map.removeLayer(state.guidance.routeGlow);
+  if (state.guidance.destMarker) map.removeLayer(state.guidance.destMarker);
+
+  if (wasActive) storedDeactivatePolling?.();
+
+  state.guidance.status = 'idle';
+  state.guidance.destination = null;
+  state.guidance.route = null;
+  state.guidance.routePolyline = null;
+  state.guidance.routeGlow = null;
+  state.guidance.destMarker = null;
+  state.guidance.currentStepIdx = 0;
+  state.guidance.distanceToManeuverM = null;
+  state.guidance.offRouteStreak = 0;
+  state.guidance.arrivedAt = null;
+  render();
+}
+
+/** Called from location.ts on every accepted GPS fix. No-op when idle/routing/arrived. */
+export function updateGuidance(e: L.LocationEvent, state: AppState, map: L.Map): void {
+  if (
+    state.guidance.status === 'idle' ||
+    state.guidance.status === 'routing' ||
+    state.guidance.status === 'arrived'
+  ) {
+    return;
+  }
+
+  const route = state.guidance.route;
+  const dest = state.guidance.destination;
+  if (!route || !dest) return;
+
+  const here = e.latlng;
+
+  // Arrived check: within radius of final destination
+  const distToDest = haversineDistance(here.lat, here.lng, dest.lat, dest.lng);
+  if (distToDest <= ARRIVAL_RADIUS_M[state.guidance.costing]!) {
+    setArrived(state, map);
+    return;
+  }
+
+  // Off-route check
+  const offRouteThreshold = OFF_ROUTE_THRESHOLD_M[state.guidance.costing]!;
+  let minDist = Infinity;
+  for (let i = 0; i < route.coords.length - 1; i++) {
+    const a = route.coords[i]!;
+    const b = route.coords[i + 1]!;
+    const d = pointToSegmentMeters(here, a, b);
+    if (d < minDist) minDist = d;
+    if (d < offRouteThreshold) break;
+  }
+
+  if (minDist > offRouteThreshold) {
+    state.guidance.offRouteStreak += 1;
+    if (state.guidance.offRouteStreak >= OFF_ROUTE_STREAK) {
+      maybeRecalc(state, map);
+    }
+  } else {
+    state.guidance.offRouteStreak = 0;
+    if (state.guidance.status === 'off-route') {
+      state.guidance.status = 'guiding';
+    }
+  }
+
+  // Step advance: when we approach the next maneuver location, increment.
+  if (state.guidance.currentStepIdx < route.steps.length - 1) {
+    const nextStep = route.steps[state.guidance.currentStepIdx + 1]!;
+    const nextLoc = route.coords[nextStep.beginShapeIndex];
+    if (nextLoc) {
+      const distToNext = haversineDistance(here.lat, here.lng, nextLoc.lat, nextLoc.lng);
+      if (distToNext < STEP_ADVANCE_RADIUS_M) {
+        state.guidance.currentStepIdx += 1;
+      }
+      state.guidance.distanceToManeuverM = distToNext;
+    }
+  }
+
+  render();
+}
+
+// ── Internal transitions ───────────────────────────────────────────────────
+
+function enterGuiding(state: AppState, map: L.Map, route: Route): void {
+  const wasInactive =
+    state.guidance.status !== 'guiding' && state.guidance.status !== 'off-route';
+  if (wasInactive) storedActivatePolling?.();
+
+  state.guidance.status = 'guiding';
+  state.guidance.route = route;
+  state.guidance.currentStepIdx = 0;
+  state.guidance.offRouteStreak = 0;
+  state.guidance.distanceToManeuverM = null;
+
+  if (state.guidance.routePolyline) map.removeLayer(state.guidance.routePolyline);
+  if (state.guidance.routeGlow) map.removeLayer(state.guidance.routeGlow);
+  state.guidance.routeGlow = L.polyline(route.coords, ROUTE_GLOW_OPTS).addTo(map);
+  state.guidance.routePolyline = L.polyline(route.coords, ROUTE_LINE_OPTS).addTo(map);
+
+  if (state.guidance.destMarker) map.removeLayer(state.guidance.destMarker);
+  if (state.guidance.destination) {
+    state.guidance.destMarker = L.marker(
+      L.latLng(state.guidance.destination.lat, state.guidance.destination.lng),
+      { icon: DEST_ICON, interactive: false },
+    ).addTo(map);
+  }
+
+  render();
+}
+
+function maybeRecalc(state: AppState, map: L.Map): void {
+  const now = performance.now();
+  if (now < state.guidance.recalcThrottleUntilMs) return;
+  if (state.guidance.recalcInFlight) return;
+
+  state.guidance.status = 'off-route';
+  state.guidance.recalcThrottleUntilMs = now + RECALC_THROTTLE_MS;
+  render();
+
+  const dest = state.guidance.destination;
+  const here = state.youAreHereLocation;
+  if (!dest || !here) return;
+
+  const ac = new AbortController();
+  state.guidance.recalcInFlight = ac;
+
+  fetchRoute({
+    start: here,
+    dest: L.latLng(dest.lat, dest.lng),
+    costing: state.guidance.costing,
+    signal: ac.signal,
+  })
+    .then((route) => {
+      if (state.guidance.recalcInFlight !== ac) return;
+      state.guidance.recalcInFlight = null;
+      enterGuiding(state, map, route);
+    })
+    .catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      state.guidance.recalcInFlight = null;
+      // Stay in off-route; next streak will retry past the throttle window.
+    });
+}
+
+function setArrived(state: AppState, map: L.Map): void {
+  state.guidance.status = 'arrived';
+  state.guidance.arrivedAt = performance.now();
+  render();
+  if (arrivedTimer !== null) clearTimeout(arrivedTimer);
+  arrivedTimer = setTimeout(() => {
+    arrivedTimer = null;
+    stopGuidance(state, map);
+  }, ARRIVED_TRANSIENT_MS);
+}
+
+// ── Render ─────────────────────────────────────────────────────────────────
+
+function render(): void {
+  if (!panelEl || !storedState) return;
+  const g = storedState.guidance;
+  panelEl.className = 'guidance-panel';
+  panelEl.innerHTML = '';
+
+  if (g.status === 'idle') {
+    panelEl.classList.add('guidance-panel--idle');
+    return;
+  }
+
+  if (g.status === 'routing') {
+    panelEl.classList.add('guidance-panel--routing');
+    panelEl.innerHTML =
+      '<div class="guidance-row guidance-row--maneuver">' +
+      '<span class="guidance-spinner" aria-hidden="true"></span>' +
+      `<span>Routing to ${escapeHtml(g.destination?.label ?? '?')}…</span>` +
+      '</div>';
+    appendButton('Cancel', 'guidance-btn--cancel', 'Cancel routing');
+    return;
+  }
+
+  if (g.status === 'arrived') {
+    panelEl.classList.add('guidance-panel--arrived');
+    panelEl.innerHTML =
+      '<div class="guidance-arrived">' +
+      `Arrived${g.destination ? ' at ' + escapeHtml(g.destination.label) : ''}` +
+      '</div>';
+    return;
+  }
+
+  // guiding | off-route
+  panelEl.classList.add('guidance-panel--active');
+  if (g.status === 'off-route') panelEl.classList.add('guidance-panel--off-route');
+
+  const route = g.route;
+  if (!route) return;
+
+  if (g.status === 'off-route') {
+    panelEl.innerHTML =
+      '<div class="guidance-row guidance-row--maneuver">' +
+      '<span class="guidance-spinner" aria-hidden="true"></span>' +
+      '<span>Off route — recalculating…</span>' +
+      '</div>';
+  } else {
+    const stepIdx = Math.min(g.currentStepIdx, route.steps.length - 1);
+    const step = route.steps[stepIdx];
+    const remaining = route.distanceM;
+    const eta = new Date(Date.now() + route.durationS * 1000);
+    const etaStr = eta.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    const dist = g.distanceToManeuverM ?? step?.lengthM ?? 0;
+
+    panelEl.innerHTML =
+      '<div class="guidance-row guidance-row--maneuver">' +
+      `<span class="maneuver-icon">${maneuverIcon(step?.type ?? 0)}</span>` +
+      `<span class="maneuver-distance">${formatDist(dist)}</span>` +
+      `<span class="maneuver-text">${escapeHtml(step?.instruction ?? '')}</span>` +
+      '</div>' +
+      '<div class="guidance-row guidance-row--summary">' +
+      `<span>${formatDist(remaining)}</span>` +
+      '<span class="guidance-row__sep">·</span>' +
+      `<span>ETA ${escapeHtml(etaStr)}</span>` +
+      '<span class="guidance-row__sep">·</span>' +
+      `<span class="guidance-mode-chip">${escapeHtml(g.costing)}</span>` +
+      '</div>';
+  }
+
+  appendButton('Stop', 'guidance-btn--stop', 'Stop navigation');
+}
+
+function appendButton(label: string, modifier: string, ariaLabel: string): void {
+  if (!panelEl) return;
+  const btn = document.createElement('button');
+  btn.className = `guidance-btn ${modifier}`;
+  btn.textContent = label;
+  btn.setAttribute('aria-label', ariaLabel);
+  btn.addEventListener('click', onStop);
+  panelEl.appendChild(btn);
+}
+
+function onStop(): void {
+  if (storedState && storedMap) stopGuidance(storedState, storedMap);
+}
+
+function maneuverIcon(type: number): string {
+  // Valhalla maneuver type codes — minimal subset; everything else falls back to →
+  // https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#maneuver-types
+  switch (type) {
+    case 1: return '↑';
+    case 4: case 5: case 6: return '🏁'; // destination variants
+    case 9: case 10: case 11: return '↰'; // left family
+    case 12: case 13: return '↶'; // u-turn
+    case 14: case 15: case 16: return '↱'; // right family
+    case 17: case 18: return '↑'; // continue / straight
+    default: return '→';
+  }
+}
+
+function formatDist(m: number): string {
+  if (!isFinite(m) || m < 0) return '—';
+  if (m >= 1000) return `${(m / 1000).toFixed(1)} km`;
+  return `${Math.round(m)} m`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/location.ts
+++ b/src/location.ts
@@ -9,6 +9,7 @@ import type { AppState } from './types';
 import { updateLocateIcon } from './controls';
 import { setWatchAccuracy } from './timer';
 import { haversineDistance } from './geo';
+import { updateGuidance } from './guidance';
 
 /** Discard GPS fixes coarser than this threshold (metres). */
 export const TRAIL_MAX_ACCURACY_M = 30;
@@ -111,10 +112,10 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
       }
     }
 
-    // Track speed + altitude so a future guidance feature can read them off
-    // AppState without re-reading the GPS event.
     state.lastSpeedMs = isNaN(e.speed) ? 0 : e.speed;
     state.lastAltM = (e.altitude as number | null) !== null ? e.altitude : undefined;
+
+    updateGuidance(e, state, map);
   }
 
   // Adaptive GPS accuracy: reduce power when stationary, restore when moving

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { initInfoPanel } from './bottom-sheet';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
 import { startWatching, stopWatching } from './timer';
 import { addOfflineDownloadControl } from './offline-download';
-import { fetchRoute } from './routing';
+import { addGuidanceControl } from './guidance';
 import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
 
@@ -303,44 +303,8 @@ addLayersControl(map, layerDefs, overlayDefs, ['hillshade']);
 initInfoPanel(map);
 addOfflineDownloadControl(map, showToast);
 addSearchControl(map, state, showToast);
-addReverseGeocoding(map);
-
-// Dev-only: visual smoke test for the routing layer. Removed in PR-3 once the
-// real "Navigate here" entry points are wired in.
-if (import.meta.env.DEV) {
-  let testRouteLine: L.Polyline | null = null;
-  let testRouteAbort: AbortController | null = null;
-  const testBtn = document.createElement('button');
-  testBtn.textContent = 'Test route';
-  testBtn.style.cssText =
-    'position:absolute;top:60px;right:8px;z-index:1000;padding:8px 12px;' +
-    'background:#fff;border:1px solid #ccc;border-radius:4px;cursor:pointer;font:12px system-ui';
-  testBtn.addEventListener('click', () => {
-    if (state.youAreHereLocation === null) {
-      showToast('Tap Locate first');
-      return;
-    }
-    if (testRouteAbort !== null) testRouteAbort.abort();
-    testRouteAbort = new AbortController();
-    const start = state.youAreHereLocation;
-    // ~1 km offset to the northeast — close enough that any costing finds a route
-    const dest = L.latLng(start.lat + 0.01, start.lng + 0.01);
-    fetchRoute({ start, dest, costing: 'auto', signal: testRouteAbort.signal })
-      .then((route) => {
-        if (testRouteLine !== null) map.removeLayer(testRouteLine);
-        testRouteLine = L.polyline(route.coords, { color: '#4287f5', weight: 4 }).addTo(map);
-        showToast(
-          `Route: ${(route.distanceM / 1000).toFixed(2)} km · ${route.steps.length} steps · ${Math.round(route.durationS)} s`,
-          5000,
-        );
-      })
-      .catch((err: unknown) => {
-        if (err instanceof Error && err.name === 'AbortError') return;
-        showToast(`Route failed: ${err instanceof Error ? err.message : String(err)}`, 5000);
-      });
-  });
-  document.getElementById('map')?.appendChild(testBtn);
-}
+addReverseGeocoding(map, state, showToast);
+addGuidanceControl(map, state, activatePolling, deactivatePolling);
 
 // ── Version badge + changelog panel ───────────────────────────────────────────
 const versionBadge = document.createElement('button');

--- a/src/style.css
+++ b/src/style.css
@@ -124,6 +124,187 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #fff;
 }
 
+/* ── Routed-guidance pill ──────────────────────────────────────────────────
+   Bottom-left pill driven by guidance.ts state machine. Hidden when idle;
+   compact during routing; expanded with maneuver / off-route / arrived
+   variants while a destination is set. */
+
+.guidance-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 16px;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 360px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.88);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  transition: padding 0.2s ease, background-color 0.2s ease;
+}
+
+.guidance-panel--idle {
+  display: none;
+}
+
+.guidance-panel--arrived {
+  background: rgba(34, 197, 94, 0.92);
+  text-align: center;
+  font-weight: 600;
+}
+
+.guidance-panel--off-route {
+  background: rgba(245, 158, 11, 0.92);
+  color: #1f2937;
+}
+
+.guidance-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.guidance-row--maneuver {
+  font-weight: 600;
+}
+
+.guidance-row--summary {
+  font-size: 12px;
+  color: #cbd5e1;
+}
+
+.guidance-row__sep {
+  color: #475569;
+}
+
+.maneuver-icon {
+  font-size: 24px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.maneuver-distance {
+  font-size: 16px;
+  flex-shrink: 0;
+  min-width: 60px;
+}
+
+.maneuver-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
+.guidance-mode-chip {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.guidance-arrived {
+  font-size: 16px;
+  color: #fff;
+}
+
+.guidance-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: guidance-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes guidance-spin {
+  to { transform: rotate(360deg); }
+}
+
+.guidance-btn {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+}
+
+.guidance-btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.guidance-btn--stop {
+  background: #ef4444;
+  color: #fff;
+}
+
+.guidance-btn--cancel {
+  background: rgba(239, 68, 68, 0.7);
+  color: #fff;
+}
+
+/* Destination marker — red pin with white border */
+.guidance-dest-marker {
+  background: transparent !important;
+  border: none !important;
+}
+
+.guidance-dest-marker__inner {
+  width: 24px;
+  height: 24px;
+  background: #ef4444;
+  border: 3px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+/* Geocode-bar Navigate button (sits next to Copy in the bottom sheet) */
+.geocode-bar__nav {
+  flex: none;
+  background: #22c55e;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 3px 9px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.geocode-bar__nav:hover {
+  background: #16a34a;
+}
+
+/* Search-result Navigate button — green primary, sits before the Go button */
+.sheet-result__nav-btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  background: #22c55e;
+  color: #fff;
+}
+
+.sheet-result__nav-btn:hover {
+  background: #16a34a;
+}
+
 /* ── Locate-button passive-state pulse animation ────────────────────────────
    Used by main.ts dropToPassive() to draw attention to the locate icon when
    it transitions from active → passive. */
@@ -799,6 +980,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
    locate → recording → zoom → scale → version-badge → attribution.
    Registration order doesn't match this so we use explicit `order`. */
 .leaflet-bottom.leaflet-left .leaflet-control-toggle { order: 1; }
+.leaflet-bottom.leaflet-left .guidance-panel         { order: 2; }
 .leaflet-bottom.leaflet-left .leaflet-control-zoom   { order: 3; }
 .leaflet-bottom.leaflet-left .leaflet-control-scale  { order: 4; }
 .leaflet-bottom.leaflet-left #version-badge          { order: 5; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,28 @@
  */
 import type L from 'leaflet';
 import type { Keepalive } from './keepalive';
+import type { Costing, Route } from './routing';
 
 // Three-state location button: off → active (following) → passive (dot visible, not following)
 export type LocateState = 'off' | 'active' | 'passive';
+
+export type GuidanceStatus = 'idle' | 'routing' | 'guiding' | 'off-route' | 'arrived';
+
+export interface GuidanceState {
+  status: GuidanceStatus;
+  destination: { lat: number; lng: number; label: string } | null;
+  costing: Costing;
+  route: Route | null;
+  routePolyline: L.Polyline | null;
+  routeGlow: L.Polyline | null;
+  destMarker: L.Marker | null;
+  currentStepIdx: number;
+  distanceToManeuverM: number | null;
+  offRouteStreak: number;
+  recalcInFlight: AbortController | null;
+  recalcThrottleUntilMs: number;
+  arrivedAt: number | null;
+}
 
 export interface AppState {
   // GPS position tracking
@@ -52,6 +71,9 @@ export interface AppState {
 
   // Background GPS keepalive: screen wake lock + silent audio loop
   keepalive: Keepalive | null;
+
+  // Routed-guidance feature state machine
+  guidance: GuidanceState;
 }
 
 export function createInitialState(): AppState {
@@ -78,5 +100,20 @@ export function createInitialState(): AppState {
     batteryDrainStartLevel: null,
     batteryDrainStartMs: 0,
     keepalive: null,
+    guidance: {
+      status: 'idle',
+      destination: null,
+      costing: 'auto',
+      route: null,
+      routePolyline: null,
+      routeGlow: null,
+      destMarker: null,
+      currentStepIdx: 0,
+      distanceToManeuverM: null,
+      offRouteStreak: 0,
+      recalcInFlight: null,
+      recalcThrottleUntilMs: 0,
+      arrivedAt: null,
+    },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface GuidanceState {
   destMarker: L.Marker | null;
   currentStepIdx: number;
   distanceToManeuverM: number | null;
+  /** Approximate straight-line distance from current GPS to destination — refreshed on each fix. */
+  distanceToDestinationM: number | null;
   offRouteStreak: number;
   recalcInFlight: AbortController | null;
   recalcThrottleUntilMs: number;
@@ -110,6 +112,7 @@ export function createInitialState(): AppState {
       destMarker: null,
       currentStepIdx: 0,
       distanceToManeuverM: null,
+      distanceToDestinationM: null,
       offRouteStreak: 0,
       recalcInFlight: null,
       recalcThrottleUntilMs: 0,


### PR DESCRIPTION
Closes #159. Part of #154. Depends on #157 (PR-2 routing).

## Summary

Wires the routing layer from PR-2 into a complete user-facing turn-by-turn guidance feature: tap "Navigate here" on a search result or dropped pin → routed polyline + maneuver pill at bottom-left. No map rotation or compass yet (PR-4); no consent text update yet (PR-5).

## State machine

`idle → routing → guiding ↔ off-route → arrived → idle`

- **idle** — pill hidden, no destination set
- **routing** — fetch in flight, compact pill with spinner + "Routing to {label}…" + Cancel
- **guiding** — route loaded, expanded pill with maneuver glyph + distance + instruction; total remaining + ETA; mode chip; Stop button
- **off-route** — sticky variant: amber pill with "Off route — recalculating…" while a fresh fetch is in flight
- **arrived** — transient (3 s) green pill, then auto-stops

## Profile-dependent thresholds

| Profile | Arrival radius | Off-route threshold |
|---|---|---|
| driving (`auto`)   | 25 m | 30 m |
| cycling            | 15 m | 20 m |
| pedestrian         | 10 m | 15 m |

Off-route fires after 3 consecutive fixes past the threshold; recalc is throttled to ≥15 s between attempts. AbortController cancels any in-flight recalc on a newer trigger.

## Files

- **`src/guidance.ts`** (~330 LOC) — pill control + state machine; `addGuidanceControl`, `startGuidance`, `stopGuidance`, `updateGuidance` exports.
- **`src/guidance.test.ts`** (13 tests) — status gating, arrival per profile, off-route streak, step advance, stopGuidance cleanup.
- **`src/types.ts`** — `GuidanceState` + `AppState.guidance` field.
- **`src/main.ts`** — mounts `addGuidanceControl`; drops the PR-2 dev Test-Route button.
- **`src/location.ts`** — `onLocationFound` now calls `updateGuidance(e, state, map)` after the GPS-metadata stash.
- **`src/geocoding.ts`** — "Navigate here" buttons in search-result detail (first action) and geocode-bar body (next to Copy). `addReverseGeocoding` re-takes `state` + `showToast` params.
- **`src/style.css`** — `.guidance-panel*` rules; new `.maneuver-*`, `.guidance-row*`, `.guidance-spinner`, `.guidance-mode-chip`, `.guidance-btn*`, `.guidance-dest-marker*`, `.geocode-bar__nav`, `.sheet-result__nav-btn`. Claims `order: 2` in the bottom-left flex column.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean (62 tests pass; +13 from this PR)
- [ ] `npm run dev`: tap Locate → search "Parque Lage" → "Navigate here" → routing → guiding within ~2s; polyline rendered; red pin at destination
- [ ] Long-press map → geocode-bar opens with Navigate / Copy / address / Close → tap Navigate → same flow
- [ ] Stop button → pill hidden, polyline + dest pin removed
- [ ] Walk off the route for 3 fixes → pill flips to amber "Off route — recalculating…" → new polyline appears
- [ ] Walk to within 25 m of destination → pill flips to green "Arrived at X" for 3 s → collapses
- [ ] No regressions in Locate / Layers / Download / search flow / version badge

## Out of scope

- **Map rotation + compass** (PR-4)
- **Travel-mode toggle UI** in pill kebab — chip displays mode but is read-only; default `'auto'`
- **ADR-006 + consent-text update for routing egress** (PR-5)
- **Voice instructions** — never planned for v1

## Privacy

Each route request sends start + destination to `valhalla1.openstreetmap.de` (FOSSGIS public Valhalla). Same surface as PR-2; the user-facing acknowledgement (consent flow update + ADR-006) lands in PR-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)