### PR TITLE
PR-4: heading-cone wedge on the blue dot (replaces planned rotation/compass) (#154)

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -19,10 +19,17 @@ const STATIONARY_SPEED_MS = 0.5;
 /** Consecutive stationary fixes before switching to low-accuracy GPS to save battery. */
 const STATIONARY_THRESHOLD = 5;
 
-// divIcon HTML for the blue pulsing dot — styled via .blue-dot CSS in style.css
+// Blue pulsing dot — styled via .blue-dot CSS in style.css.
+// .blue-dot__heading is hidden until a valid GPS course (e.heading) is observed
+// via the .blue-dot--has-heading class set in onLocationFound; rotation is
+// driven by a CSS custom property --heading-deg.
+const BLUE_DOT_HTML =
+  '<div class="blue-dot__heading" aria-hidden="true"></div>' +
+  '<div class="blue-dot__inner"></div>';
+
 const BLUE_DOT_ICON = L.divIcon({
   className: 'blue-dot',
-  html: '<div class="blue-dot__inner"></div>',
+  html: BLUE_DOT_HTML,
   iconSize: [16, 16],
   iconAnchor: [8, 8],
 });
@@ -31,11 +38,17 @@ const BLUE_DOT_ICON = L.divIcon({
 function createGrayDotIcon(): L.DivIcon {
   return L.divIcon({
     className: 'blue-dot blue-dot--gray',
-    html: '<div class="blue-dot__inner"></div>',
+    html: BLUE_DOT_HTML,
     iconSize: [16, 16],
     iconAnchor: [8, 8],
   });
 }
+
+// Hold-last-bearing: GPS course is NaN at low speeds. Keep the wedge pointed in
+// the last valid direction for HEADING_HOLD_MS, then fade it out.
+const HEADING_HOLD_MS = 10_000;
+let lastValidHeadingDeg: number | null = null;
+let lastValidHeadingMs = 0;
 
 /**
  * intent: Accept or reject a GPS fix based on whether we moved meaningfully or accuracy improved
@@ -114,6 +127,30 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
 
     state.lastSpeedMs = isNaN(e.speed) ? 0 : e.speed;
     state.lastAltM = (e.altitude as number | null) !== null ? e.altitude : undefined;
+
+    // Heading wedge: rotate the cone behind the blue dot to match GPS course.
+    // Hold the last valid bearing for ~10s when course is NaN (low speed);
+    // fade out after that so the wedge doesn't lie about direction.
+    if (state.locationMarker !== null && !state.screenOff) {
+      const el = state.locationMarker.getElement();
+      if (el) {
+        const heading = (e as L.LocationEvent & { heading?: number }).heading;
+        if (typeof heading === 'number' && !isNaN(heading)) {
+          lastValidHeadingDeg = heading;
+          lastValidHeadingMs = performance.now();
+          el.style.setProperty('--heading-deg', `${heading}deg`);
+          el.classList.add('blue-dot--has-heading');
+        } else if (
+          lastValidHeadingDeg !== null &&
+          performance.now() - lastValidHeadingMs < HEADING_HOLD_MS
+        ) {
+          el.style.setProperty('--heading-deg', `${lastValidHeadingDeg}deg`);
+          el.classList.add('blue-dot--has-heading');
+        } else {
+          el.classList.remove('blue-dot--has-heading');
+        }
+      }
+    }
 
     updateGuidance(e, state, map);
   }

--- a/src/location.ts
+++ b/src/location.ts
@@ -44,11 +44,9 @@ function createGrayDotIcon(): L.DivIcon {
   });
 }
 
-// Hold-last-bearing: GPS course is NaN at low speeds. Keep the wedge pointed in
-// the last valid direction for HEADING_HOLD_MS, then fade it out.
+// Hold-last-bearing window: GPS course is NaN at low speeds, so keep the wedge
+// pointed in the last valid direction for this long before fading it out.
 const HEADING_HOLD_MS = 10_000;
-let lastValidHeadingDeg: number | null = null;
-let lastValidHeadingMs = 0;
 
 /**
  * intent: Accept or reject a GPS fix based on whether we moved meaningfully or accuracy improved
@@ -134,17 +132,15 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     if (state.locationMarker !== null && !state.screenOff) {
       const el = state.locationMarker.getElement();
       if (el) {
-        const heading = (e as L.LocationEvent & { heading?: number }).heading;
-        if (typeof heading === 'number' && !isNaN(heading)) {
-          lastValidHeadingDeg = heading;
-          lastValidHeadingMs = performance.now();
-          el.style.setProperty('--heading-deg', `${heading}deg`);
+        if (!isNaN(e.heading)) {
+          state.lastValidHeadingDeg = e.heading;
+          state.lastValidHeadingMs = performance.now();
+          el.style.setProperty('--heading-deg', `${e.heading}deg`);
           el.classList.add('blue-dot--has-heading');
         } else if (
-          lastValidHeadingDeg !== null &&
-          performance.now() - lastValidHeadingMs < HEADING_HOLD_MS
+          state.lastValidHeadingDeg !== null &&
+          performance.now() - state.lastValidHeadingMs < HEADING_HOLD_MS
         ) {
-          el.style.setProperty('--heading-deg', `${lastValidHeadingDeg}deg`);
           el.classList.add('blue-dot--has-heading');
         } else {
           el.classList.remove('blue-dot--has-heading');

--- a/src/style.css
+++ b/src/style.css
@@ -44,6 +44,33 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   position: relative;
 }
 
+/* Heading wedge — Google/Apple Maps "direction cone" pattern. Centered on the
+   dot; rotated by --heading-deg set in location.ts on each fix; fades to
+   transparent at the cone edges. Hidden until .blue-dot--has-heading is set. */
+.blue-dot__heading {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  top: -22px;
+  left: -22px;
+  border-radius: 50%;
+  background: conic-gradient(
+    from calc(var(--heading-deg, 0deg) - 30deg),
+    rgba(66, 133, 244, 0.55) 0deg,
+    rgba(66, 133, 244, 0)   60deg,
+    rgba(66, 133, 244, 0)   360deg
+  );
+  -webkit-mask-image: radial-gradient(circle at center, black 0, black 30%, transparent 100%);
+  mask-image: radial-gradient(circle at center, black 0, black 30%, transparent 100%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.blue-dot--has-heading .blue-dot__heading {
+  opacity: 1;
+}
+
 /* Pulsing ring on the blue dot */
 .blue-dot__inner::before {
   content: '';


### PR DESCRIPTION
Closes #161. Part of #154.

## Scope change

The original plan called for `leaflet-rotate` (map rotates so direction of travel is up) plus a top-right compass widget. Two issues surfaced:

1. **License clash**: `leaflet-rotate` is GPL-3; the project is MIT. Bundling GPL-3 into an MIT app would taint the license.
2. **Standalone compass adds chrome that duplicates info already implied by GPS course.**

Per user direction, switched to the **heading-cone** pattern (Google/Apple Maps style): the existing blue location dot grows a translucent wedge pointing in the direction of travel. No map rotation, no separate widget, no new dep.

## Changes

`src/location.ts`:
- `BLUE_DOT_HTML` now includes a `.blue-dot__heading` wedge alongside `.blue-dot__inner`.
- On each location fix:
  - Valid `e.heading` → save to module-level `lastValidHeadingDeg` + timestamp, set `--heading-deg` CSS var on the marker, add `.blue-dot--has-heading`.
  - NaN heading (low speed / no movement) → hold last valid bearing for `HEADING_HOLD_MS` (10 s), then drop `.blue-dot--has-heading` so the wedge fades out.
  - Skipped when `state.screenOff` (matches existing render-skip pattern).

`src/style.css`:
- `.blue-dot__heading` is a 60×60 px conic-gradient cone centered on the dot, rotated by `var(--heading-deg)`. A radial mask fades the cone from blue at the dot to transparent at the edges. Hidden by default; opacity fades in via `.blue-dot--has-heading`.

## Test plan

- [x] `npm run type-check && npm run lint && npm test && npm run build` — clean (63 tests pass)
- [ ] Walk on a phone with locate active → blue dot grows a translucent fan pointing in direction of travel
- [ ] Stand still → wedge holds for ~10 s then fades
- [ ] Resume walking → wedge re-appears with new bearing
- [ ] No regression: search dropdown, geocode-bar, guidance pill all still work

## Risks

- `e.heading` from the Geolocation API is platform-dependent. Some Android devices report it only when speed > a threshold (1–2 m/s). The hold-last-bearing logic mitigates the worst of that.
- Conic-gradient + radial mask is well-supported in modern browsers but may render slightly differently on older WebKit. Worst case: wedge is square or has a hard edge — still functional, just less polished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)