### PR TITLE
fix(types): add lastValidHeading state fields to AppState (mainline broken)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,10 @@ export interface AppState {
   lastAltM: number | undefined;
   lastGpsAccuracy: number | null; // most recent GPS fix accuracy (metres)
 
+  // Heading-cone wedge: hold last valid GPS bearing for ~10s when course is NaN at low speeds
+  lastValidHeadingDeg: number | null;
+  lastValidHeadingMs: number;
+
   // Hysteresis state for GPS weak-signal badge — prevents flicker in marginal signal
   gpsWeakStreak: number;        // consecutive fixes with accuracy > TRAIL_MAX_ACCURACY_M
   gpsStrongStreak: number;      // consecutive fixes with accuracy < (TRAIL_MAX_ACCURACY_M - 5)
@@ -92,6 +96,8 @@ export function createInitialState(): AppState {
     lastSpeedMs: 0,
     lastAltM: undefined,
     lastGpsAccuracy: null,
+    lastValidHeadingDeg: null,
+    lastValidHeadingMs: 0,
     gpsWeakStreak: 0,
     gpsStrongStreak: 0,
     gpsWeakBadgeVisible: false,


### PR DESCRIPTION
## Summary

- PR #162 introduced \`state.lastValidHeadingDeg\` / \`state.lastValidHeadingMs\` references in \`src/location.ts\` but the corresponding \`AppState\` fields were never added — \`npm run type-check\` is currently broken on mainline.
- Adds the two missing fields to the \`AppState\` interface (next to other GPS-fix metadata) and to \`createInitialState()\` defaults.

Closes #164

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` clean (628 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)