### PR TITLE
PR-5: ADR-006 + consent text update for routing egress (#154)

### DIFF
--- a/docs/adr/ADR-006-routed-guidance.md
+++ b/docs/adr/ADR-006-routed-guidance.md
@@ -1,0 +1,96 @@
+# ADR-006: Routed Turn-by-Turn Guidance over GPS Trail Recording
+
+**Status:** Accepted
+
+## Context
+
+The original feature set centered on GPS trail recording: the user starts a recording, the app appends every GPS fix to a polyline, and at the end exports a GPX. This is useful after the fact (sharing a hike, importing into Strava) but does little in the moment — there is no destination, no route, no turn-by-turn instructions.
+
+For the typical "I'm at point A and I want to get to point B" flow, recording is the wrong primitive. Live guidance is what people actually do with a map app on the move. The destination surfaces (search results, long-press reverse-geocode) already exist in the UI but did not lead anywhere.
+
+A guidance feature requires three external decisions:
+
+1. Which routing service to use (driving, cycling, walking — all three required)
+2. How to indicate direction of travel on the map (rotation? compass? something else?)
+3. How to disclose the additional privacy tradeoff (every route request leaves the device)
+
+## Decision
+
+Replace GPS trail recording with **turn-by-turn routed guidance** powered by:
+
+### 1. Valhalla via FOSSGIS
+
+Routing requests go to `https://valhalla1.openstreetmap.de/route`, the FOSSGIS public Valhalla instance.
+
+- All three required profiles (`auto`, `pedestrian`, `bicycle`) are served from a single endpoint.
+- Pre-formatted natural-language maneuver instructions in the response (saves ~50 LOC of formatting).
+- No API key. CORS-enabled. Best-effort SLA — same risk class as OSRM's public demo.
+- Polyline6-encoded geometry; a ~25-LOC inline decoder handles parsing.
+
+### 2. Heading-Cone Wedge on the Blue Dot (no map rotation)
+
+Direction of travel is indicated by a translucent **heading-cone wedge** rendered behind the GPS blue dot — the same idiom used by Google Maps and Apple Maps. The wedge is a CSS `conic-gradient` masked by a `radial-gradient`, rotated by a `--heading-deg` custom property.
+
+- The wedge points in the direction of GPS course (`e.heading` from the Geolocation API).
+- When `e.heading` is `NaN` (typical at speeds < 1 m/s), the last valid bearing is held for ~10 s before the wedge fades out.
+
+The map itself does **not** rotate.
+
+### 3. Updated Consent Text
+
+`src/consent.ts` now explicitly lists Valhalla / FOSSGIS as a third-party service, and `CONSENT_VERSION` was bumped to force re-acceptance from existing users.
+
+## Alternatives Considered
+
+### Routing Service
+
+1. **OSRM (public demo)** — only the `car` profile is hosted on the public demo server; would have required either self-hosting or an additional service for cycling/walking. Rejected for v1.
+2. **Mapbox Directions API / OpenRouteService** — both require API keys, billing accounts, and server-side proxying to avoid leaking the key in client code. Out of scope for an MIT, no-account, no-backend project.
+3. **Self-hosted Valhalla / OSRM** — operationally heavyweight; rejected.
+
+### Direction-of-Travel Indicator
+
+1. **`leaflet-rotate` plugin (full map rotation)** — the most-maintained fork is GPL-3 licensed; webmap.dev is MIT, and importing GPL-3 code would force a relicense or a dual-license arrangement. Rejected.
+2. **CSS-transform rotation** — requires manual coordinate inversion on every overlay (markers, popups, accuracy circle, route polyline) to keep them upright. Per-overlay invariants would multiply across the codebase. Rejected.
+3. **MapLibre GL** — first-class rotation support, but the migration is much larger than the guidance feature itself. Out of scope.
+4. **Compass-rose widget alone (no heading indicator on the dot)** — provides north-up orientation but does not show direction of travel, which is the actually-useful signal during navigation. Rejected as insufficient.
+
+The heading-cone wedge solves the actually-useful subset of "rotation" (showing the user which way they are facing) without the licensing or refactor cost.
+
+## Consequences
+
+### Advantages
+
+- **Three travel modes from a single endpoint.** No additional service for cycling or walking.
+- **Pre-formatted instructions.** Less client-side formatting code.
+- **Familiar UX pattern.** The wedge-on-dot idiom is recognized by anyone who has used Google Maps or Apple Maps.
+- **No license entanglement.** All new code is MIT-compatible; CSS gradients and Geolocation `heading` are platform features, not third-party dependencies.
+- **Smaller diff than full rotation.** No plugin, no shim, no per-overlay coordinate work.
+
+### Disadvantages
+
+- **Privacy regression vs. the local-only baseline ([ADR-004](ADR-004-local-only-data.md)).** Every routing request sends the start and destination to FOSSGIS. Mitigated by: explicit consent text, only firing on explicit "Navigate here" actions (no background traffic), and abstracting `fetchRoute()` so the provider can be swapped in one place.
+- **Public Valhalla server reliability.** No SLA. Failure mode is a clear error toast with manual Retry; no auto-loop.
+- **GPS course `NaN` at low speeds.** Many devices report `NaN` below ~1 m/s. Mitigated by holding the last valid bearing for ~10 s before fading the wedge.
+- **No north-up disorientation cue.** Without a compass widget, the user has no built-in way to recover north-up if they manually rotate or tilt the map. Acceptable because the map itself does not rotate — north is always up.
+
+### Privacy Mitigation
+
+- Routing requests fire only on explicit user action (`Navigate here` button).
+- Consent text (`src/consent.ts`) explicitly lists FOSSGIS Valhalla as a third-party service alongside OpenStreetMap and Esri.
+- Consent version bumped to force re-acceptance from upgrading users.
+- `fetchRoute()` is the single egress point; replacing the provider is a one-line change.
+
+## Implementation Details
+
+- **Module:** `src/routing.ts` — Valhalla client, polyline6 decoder, types (`RouteRequest`, `Route`, `RouteStep`, `Costing`).
+- **State machine:** `idle → routing → guiding ↔ off-route → arrived → idle` (`src/guidance.ts`).
+- **Off-route detection:** profile-dependent thresholds (driving 30 m / cycling 20 m / walking 15 m) with a 3-fix streak before recalc, throttled to once per 15 s.
+- **Arrived detection:** profile-dependent radius (driving 25 m / cycling 15 m / walking 10 m).
+- **Heading hold:** 10 s window after the last valid `e.heading`, then the wedge fades.
+
+## Related Decisions
+
+- [ADR-001: Single Mutable State](ADR-001-single-mutable-state.md) — Guidance state lives as a nested `guidance` object on `AppState`; no event bus.
+- [ADR-002: Refcount-based GPS Polling](ADR-002-refcount-gps-polling.md) — Guidance holds one refcount on `updateCallback` while active, mirroring the previous recording lifecycle.
+- [ADR-004: Local-Only Data](ADR-004-local-only-data.md) — Guidance is the first feature that *intentionally* breaks the local-only invariant for routing requests; the privacy mitigations above are why.

--- a/docs/adr/ADR-006-routed-guidance.md
+++ b/docs/adr/ADR-006-routed-guidance.md
@@ -83,10 +83,12 @@ The heading-cone wedge solves the actually-useful subset of "rotation" (showing 
 
 ## Implementation Details
 
+The numeric thresholds below are **initial** values chosen for the v1 launch; they will be tuned with field experience and should be read from the source files (`src/guidance.ts`, `src/location.ts`) when current values matter.
+
 - **Module:** `src/routing.ts` — Valhalla client, polyline6 decoder, types (`RouteRequest`, `Route`, `RouteStep`, `Costing`).
 - **State machine:** `idle → routing → guiding ↔ off-route → arrived → idle` (`src/guidance.ts`).
-- **Off-route detection:** profile-dependent thresholds (driving 30 m / cycling 20 m / walking 15 m) with a 3-fix streak before recalc, throttled to once per 15 s.
-- **Arrived detection:** profile-dependent radius (driving 25 m / cycling 15 m / walking 10 m).
+- **Off-route detection:** profile-dependent thresholds (driving 30 m / cycling 20 m / walking 15 m initially) with a 3-fix streak before recalc, throttled to once per 15 s.
+- **Arrived detection:** profile-dependent radius (driving 25 m / cycling 15 m / walking 10 m initially).
 - **Heading hold:** 10 s window after the last valid `e.heading`, then the wedge fades.
 
 ## Related Decisions

--- a/docs/adr/ADR-006-routed-guidance.md
+++ b/docs/adr/ADR-006-routed-guidance.md
@@ -20,7 +20,7 @@ Replace GPS trail recording with **turn-by-turn routed guidance** powered by:
 
 ### 1. Valhalla via FOSSGIS
 
-Routing requests go to `https://valhalla1.openstreetmap.de/route`, the FOSSGIS public Valhalla instance.
+Routing requests go to the **FOSSGIS public Valhalla instance**. The canonical endpoint URL lives in `src/routing.ts` so this ADR doesn't need to be updated when FOSSGIS shuffles hostnames.
 
 - All three required profiles (`auto`, `pedestrian`, `bicycle`) are served from a single endpoint.
 - Pre-formatted natural-language maneuver instructions in the response (saves ~50 LOC of formatting).
@@ -86,7 +86,7 @@ The heading-cone wedge solves the actually-useful subset of "rotation" (showing 
 The numeric thresholds below are **initial** values chosen for the v1 launch; they will be tuned with field experience and should be read from the source files (`src/guidance.ts`, `src/location.ts`) when current values matter.
 
 - **Module:** `src/routing.ts` — Valhalla client, polyline6 decoder, types (`RouteRequest`, `Route`, `RouteStep`, `Costing`).
-- **State machine:** `idle → routing → guiding ↔ off-route → arrived → idle` (`src/guidance.ts`).
+- **State machine:** `idle → routing → guiding ↔ off-route → arrived → idle` (`src/guidance.ts`). The final `arrived → idle` transition is automatic — the pill displays the "Arrived" message for ~3 s, then `stopGuidance()` collapses the UI back to idle.
 - **Off-route detection:** profile-dependent thresholds (driving 30 m / cycling 20 m / walking 15 m initially) with a 3-fix streak before recalc, throttled to once per 15 s.
 - **Arrived detection:** profile-dependent radius (driving 25 m / cycling 15 m / walking 10 m initially).
 - **Heading hold:** 10 s window after the last valid `e.heading`, then the wedge fades.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ Each ADR follows a consistent template:
 3. [ADR-003: offsetHeight for iOS Safari Snap-Points](ADR-003-offsetheight-ios-safari.md) — Why bottom sheet snap-point math uses offsetHeight instead of CSS vh units
 4. [ADR-004: Local-Only Data](ADR-004-local-only-data.md) — Why all data stays in the browser with no server-side storage
 5. [ADR-005: Two-Tier Offline Tile Strategy](ADR-005-offline-tile-strategy.md) — Why offline uses Workbox passive caching plus Cache API pre-download
+6. [ADR-006: Routed Turn-by-Turn Guidance](ADR-006-routed-guidance.md) — Why recording was replaced with Valhalla-powered guidance and a heading-cone wedge instead of map rotation
 
 ## References
 

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -4,7 +4,7 @@
  * Pattern: Returns a Promise that resolves true (accepted) or false (declined); no AppState dependency
  */
 
-const CONSENT_VERSION = '2.1';
+const CONSENT_VERSION = '2.2';
 const KEY_VERSION = 'webmap-consent-version';
 const KEY_ACCEPTED_AT = 'webmap-consent-accepted-at';
 const KEY_INSTALL_ID = 'webmap-consent-install-id';
@@ -40,16 +40,16 @@ export function showConsentModal(): Promise<boolean> {
       <div id="consent-body">
         <h3>Privacy Policy</h3>
         <ul class="consent-legal">
-          <li><strong>Local only.</strong> All GPS data, trail recordings, and app settings stay in your browser. Nothing is sent to our servers.</li>
+          <li><strong>Local only.</strong> All GPS data and app settings stay in your browser. Nothing is sent to our servers.</li>
           <li><strong>No tracking.</strong> No analytics, cookies, or tracking pixels.</li>
-          <li><strong>Third-party services.</strong> Map tiles load from OpenStreetMap servers. Address search uses the Esri ArcGIS geocoding API. These services may log standard HTTP request data per their own policies.</li>
-          <li><strong>Stored items.</strong> The app stores a consent record and an anonymous install ID in localStorage. Trail backups are also stored locally for crash recovery.</li>
+          <li><strong>Third-party services.</strong> Map tiles load from OpenStreetMap servers. Address search uses the Esri ArcGIS geocoding API. Turn-by-turn routing uses the FOSSGIS Valhalla service — your current location and selected destination are sent only when you explicitly tap "Navigate here". These services may log standard HTTP request data per their own policies.</li>
+          <li><strong>Stored items.</strong> The app stores a consent record and an anonymous install ID in localStorage.</li>
           <li><strong>Deletion.</strong> Clear your browser's site data for webmap.dev to remove everything.</li>
         </ul>
 
         <h3>Terms of Use</h3>
         <ol class="consent-legal">
-          <li>This app is for <strong>personal, non-commercial</strong> map viewing and GPS trail recording.</li>
+          <li>This app is for <strong>personal, non-commercial</strong> map viewing and GPS-based navigation.</li>
           <li>The app is provided <strong>as-is with no warranty</strong>. GPS accuracy varies. Do not rely on it for navigation, emergency response, or safety-critical decisions.</li>
           <li><strong>You are responsible</strong> for your own safety. Pay attention to your surroundings and obey local laws.</li>
           <li>To the maximum extent permitted by law, the developer is <strong>not liable</strong> for any damages arising from use of this app.</li>

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -42,7 +42,8 @@ export function showConsentModal(): Promise<boolean> {
         <ul class="consent-legal">
           <li><strong>Local only.</strong> All GPS data and app settings stay in your browser. Nothing is sent to our servers.</li>
           <li><strong>No tracking.</strong> No analytics, cookies, or tracking pixels.</li>
-          <li><strong>Third-party services.</strong> Map tiles load from OpenStreetMap servers. Address search uses the Esri ArcGIS geocoding API. Turn-by-turn routing uses the FOSSGIS Valhalla service — your current location and selected destination are sent only when you explicitly tap "Navigate here". These services may log standard HTTP request data per their own policies.</li>
+          <li><strong>Third-party services.</strong> Map tiles load from OpenStreetMap servers. Address search uses the Esri ArcGIS geocoding API. These services may log standard HTTP request data per their own policies.</li>
+          <li><strong>Turn-by-turn routing.</strong> When you tap "Navigate here", your current location and destination are sent to the FOSSGIS Valhalla service to compute a route. No other location data is transmitted.</li>
           <li><strong>Stored items.</strong> The app stores a consent record and an anonymous install ID in localStorage.</li>
           <li><strong>Deletion.</strong> Clear your browser's site data for webmap.dev to remove everything.</li>
         </ul>

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -50,7 +50,7 @@ export function showConsentModal(): Promise<boolean> {
         <h3>Terms of Use</h3>
         <ol class="consent-legal">
           <li>This app is for <strong>personal, non-commercial</strong> map viewing and GPS-based navigation.</li>
-          <li>The app is provided <strong>as-is with no warranty</strong>. GPS accuracy varies. Do not rely on it for navigation, emergency response, or safety-critical decisions.</li>
+          <li>The app is provided <strong>as-is with no warranty</strong>. GPS accuracy varies and routing directions may be incorrect. Do not rely on this app as your sole navigation source, or for emergency response or safety-critical decisions.</li>
           <li><strong>You are responsible</strong> for your own safety. Pay attention to your surroundings and obey local laws.</li>
           <li>To the maximum extent permitted by law, the developer is <strong>not liable</strong> for any damages arising from use of this app.</li>
           <li>These terms may be updated. Material changes will require re-acceptance.</li>

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -43,7 +43,7 @@ export function showConsentModal(): Promise<boolean> {
           <li><strong>Local only.</strong> All GPS data and app settings stay in your browser. Nothing is sent to our servers.</li>
           <li><strong>No tracking.</strong> No analytics, cookies, or tracking pixels.</li>
           <li><strong>Third-party services.</strong> Map tiles load from OpenStreetMap servers. Address search uses the Esri ArcGIS geocoding API. These services may log standard HTTP request data per their own policies.</li>
-          <li><strong>Turn-by-turn routing.</strong> When you tap "Navigate here", your current location and destination are sent to the FOSSGIS Valhalla service to compute a route. No other location data is transmitted.</li>
+          <li><strong>Turn-by-turn routing.</strong> When you tap "Navigate here", your current location and destination are sent to the FOSSGIS Valhalla service to compute a route. No location data is transmitted except as described above.</li>
           <li><strong>Stored items.</strong> The app stores a consent record and an anonymous install ID in localStorage.</li>
           <li><strong>Deletion.</strong> Clear your browser's site data for webmap.dev to remove everything.</li>
         </ul>


### PR DESCRIPTION
## Summary

- **ADR-006** documents the routed-guidance architecture: Valhalla over OSRM (multi-profile), heading-cone wedge over \`leaflet-rotate\` (GPL-3 license clash), and the privacy regression + mitigations.
- **Consent text** now explicitly discloses Valhalla / FOSSGIS as a third-party service receiving the user's location and destination on \`Navigate here\`. Drops obsolete recording references.
- \`CONSENT_VERSION\` bumped \`2.1 → 2.2\` to force re-acceptance from upgraded users.

Part of #154 (PR-5 of 5).

## Changes

- \`docs/adr/ADR-006-routed-guidance.md\` (new) — Service choice, license-clash rationale, privacy mitigations.
- \`docs/adr/README.md\` — Add ADR-006 to the index.
- \`src/consent.ts\` — Update Privacy Policy + Terms text; bump consent version.

## Out of scope

- Off-route tuning and arrived-UX polish from the original PR-5 wishlist — defer to follow-up issues if real-world iPhone smoke testing surfaces concrete issues.
- Version bump / CHANGELOG / release tag — handled by \`/release\` after this lands.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` clean (628 tests pass)
- [ ] Manual smoke: open the app fresh (clear localStorage), verify the new consent text renders correctly, accept, verify routing flow still works
- [ ] Existing user sees the consent prompt again after upgrade (CONSENT_VERSION bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)