### PR TITLE
feat(compass): device-orientation compass widget (#163)

### DIFF
--- a/src/compass.ts
+++ b/src/compass.ts
@@ -1,8 +1,4 @@
-/**
- * Intent: Compass widget showing where the device is facing relative to the (north-up) map
- * Context: Mounted top-right; first tap requests DeviceOrientation permission, then updates passively
- * Pattern: Leaflet control + inline SVG; rotation driven by --heading-deg CSS custom property
- */
+// Compass widget — top-right SVG rose that rotates by -deviceHeading so N points at true north.
 import L from 'leaflet';
 import type { AppState } from './types';
 import { requestOrientationPermission, subscribeOrientation } from './orientation';
@@ -15,6 +11,8 @@ const COMPASS_HTML = `<svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg
 </svg>`;
 
 export function addCompassControl(map: L.Map, state: AppState): void {
+  let unsubscribe: (() => void) | null = null;
+
   const Control = L.Control.extend({
     onAdd() {
       const button = L.DomUtil.create('button', 'compass-rose') as HTMLButtonElement;
@@ -26,7 +24,12 @@ export function addCompassControl(map: L.Map, state: AppState): void {
       L.DomEvent.disableClickPropagation(button);
       L.DomEvent.disableScrollPropagation(button);
 
-      let unsubscribe: (() => void) | null = null;
+      // Hide entirely if the platform doesn't expose orientation events at all (desktop).
+      if (typeof DeviceOrientationEvent === 'undefined') {
+        button.classList.add('compass-rose--unavailable');
+        state.compassPermission = 'unsupported';
+        return button;
+      }
 
       L.DomEvent.on(button, 'click', () => {
         if (state.compassPermission === 'granted') return;
@@ -37,7 +40,6 @@ export function addCompassControl(map: L.Map, state: AppState): void {
             button.title = 'Compass';
             button.setAttribute('aria-label', 'Compass');
             unsubscribe = subscribeOrientation((heading) => {
-              state.lastDeviceHeadingDeg = heading;
               button.style.setProperty('--heading-deg', `${-heading}deg`);
             });
           } else {
@@ -48,18 +50,13 @@ export function addCompassControl(map: L.Map, state: AppState): void {
         });
       });
 
-      // Hide the button entirely when the API isn't present (desktop without sensors)
-      if (typeof DeviceOrientationEvent === 'undefined') {
-        button.classList.add('compass-rose--unavailable');
-        state.compassPermission = 'unsupported';
-      }
-
-      // Bind cleanup to the map's remove event so we don't leak the listener if the map is torn down
-      map.on('unload', () => {
-        if (unsubscribe !== null) unsubscribe();
-      });
-
       return button;
+    },
+    onRemove() {
+      if (unsubscribe !== null) {
+        unsubscribe();
+        unsubscribe = null;
+      }
     },
   });
 

--- a/src/compass.ts
+++ b/src/compass.ts
@@ -1,0 +1,67 @@
+/**
+ * Intent: Compass widget showing where the device is facing relative to the (north-up) map
+ * Context: Mounted top-right; first tap requests DeviceOrientation permission, then updates passively
+ * Pattern: Leaflet control + inline SVG; rotation driven by --heading-deg CSS custom property
+ */
+import L from 'leaflet';
+import type { AppState } from './types';
+import { requestOrientationPermission, subscribeOrientation } from './orientation';
+
+const COMPASS_HTML = `<svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="20" cy="20" r="18" fill="rgba(255,255,255,0.92)" stroke="#444" stroke-width="1.5"/>
+  <polygon points="20,4 24,18 16,18" fill="#d33"/>
+  <polygon points="20,36 24,22 16,22" fill="#666"/>
+  <text x="20" y="14" font-size="9" font-weight="700" text-anchor="middle" fill="#222" font-family="sans-serif">N</text>
+</svg>`;
+
+export function addCompassControl(map: L.Map, state: AppState): void {
+  const Control = L.Control.extend({
+    onAdd() {
+      const button = L.DomUtil.create('button', 'compass-rose') as HTMLButtonElement;
+      button.type = 'button';
+      button.title = 'Compass — tap to enable';
+      button.setAttribute('aria-label', 'Compass — tap to enable');
+      button.innerHTML = COMPASS_HTML;
+
+      L.DomEvent.disableClickPropagation(button);
+      L.DomEvent.disableScrollPropagation(button);
+
+      let unsubscribe: (() => void) | null = null;
+
+      L.DomEvent.on(button, 'click', () => {
+        if (state.compassPermission === 'granted') return;
+        void requestOrientationPermission().then((permission) => {
+          state.compassPermission = permission;
+          if (permission === 'granted') {
+            button.classList.add('compass-rose--active');
+            button.title = 'Compass';
+            button.setAttribute('aria-label', 'Compass');
+            unsubscribe = subscribeOrientation((heading) => {
+              state.lastDeviceHeadingDeg = heading;
+              button.style.setProperty('--heading-deg', `${-heading}deg`);
+            });
+          } else {
+            button.classList.add('compass-rose--unavailable');
+            button.title = permission === 'denied' ? 'Compass permission denied' : 'Compass not supported';
+            button.setAttribute('aria-label', button.title);
+          }
+        });
+      });
+
+      // Hide the button entirely when the API isn't present (desktop without sensors)
+      if (typeof DeviceOrientationEvent === 'undefined') {
+        button.classList.add('compass-rose--unavailable');
+        state.compassPermission = 'unsupported';
+      }
+
+      // Bind cleanup to the map's remove event so we don't leak the listener if the map is torn down
+      map.on('unload', () => {
+        if (unsubscribe !== null) unsubscribe();
+      });
+
+      return button;
+    },
+  });
+
+  new Control({ position: 'topright' }).addTo(map);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { onLocationFound, onLocationError, clearLocationMarkers } from './locati
 import { startWatching, stopWatching } from './timer';
 import { addOfflineDownloadControl } from './offline-download';
 import { addGuidanceControl } from './guidance';
+import { addCompassControl } from './compass';
 import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
 
@@ -305,6 +306,7 @@ addOfflineDownloadControl(map, showToast);
 addSearchControl(map, state, showToast);
 addReverseGeocoding(map, state, showToast);
 addGuidanceControl(map, state, activatePolling, deactivatePolling);
+addCompassControl(map, state);
 
 // ── Version badge + changelog panel ───────────────────────────────────────────
 const versionBadge = document.createElement('button');

--- a/src/orientation.test.ts
+++ b/src/orientation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractHeading } from './orientation';
+
+function fakeEvent(props: Partial<DeviceOrientationEvent> & { webkitCompassHeading?: number }): DeviceOrientationEvent {
+  return props as DeviceOrientationEvent;
+}
+
+describe('extractHeading', () => {
+  it('prefers iOS webkitCompassHeading when present', () => {
+    const e = fakeEvent({ alpha: 200, webkitCompassHeading: 90 });
+    expect(extractHeading(e)).toBe(90);
+  });
+
+  it('falls back to (360 - alpha) when webkitCompassHeading is absent', () => {
+    expect(extractHeading(fakeEvent({ alpha: 90 }))).toBe(270);
+    expect(extractHeading(fakeEvent({ alpha: 0 }))).toBe(0);
+    expect(extractHeading(fakeEvent({ alpha: 359 }))).toBe(1);
+  });
+
+  it('normalises negative or out-of-range webkitCompassHeading into 0–360', () => {
+    expect(extractHeading(fakeEvent({ alpha: 0, webkitCompassHeading: -10 }))).toBe(350);
+    expect(extractHeading(fakeEvent({ alpha: 0, webkitCompassHeading: 720 }))).toBe(0);
+  });
+
+  it('returns null when neither field is usable', () => {
+    expect(extractHeading(fakeEvent({ alpha: null }))).toBeNull();
+    expect(extractHeading(fakeEvent({ alpha: NaN }))).toBeNull();
+    expect(extractHeading(fakeEvent({ alpha: NaN, webkitCompassHeading: NaN }))).toBeNull();
+  });
+
+  it('skips webkitCompassHeading if it is NaN and falls back to alpha', () => {
+    expect(extractHeading(fakeEvent({ alpha: 90, webkitCompassHeading: NaN }))).toBe(270);
+  });
+});

--- a/src/orientation.ts
+++ b/src/orientation.ts
@@ -1,0 +1,59 @@
+/**
+ * Intent: Wrap DeviceOrientationEvent with the iOS permission flow + heading extraction
+ * Context: Used by compass.ts; iOS 13+ requires DeviceOrientationEvent.requestPermission() from a user gesture
+ * Pattern: Permission is one-shot; subscribeOrientation returns an unsubscribe function for clean teardown
+ */
+
+export type OrientationPermission = 'unknown' | 'unsupported' | 'granted' | 'denied';
+
+interface DeviceOrientationEventStatic {
+  requestPermission?: () => Promise<'granted' | 'denied'>;
+}
+
+/**
+ * intent: Pull a compass heading (0–360°, clockwise from True North) out of a DeviceOrientationEvent
+ * method: Prefer iOS webkitCompassHeading (already true-north calibrated); fall back to W3C alpha (anti-clockwise around z)
+ * effect: Returns null when neither field is usable (NaN / unsupported)
+ */
+export function extractHeading(event: DeviceOrientationEvent): number | null {
+  const ios = (event as DeviceOrientationEvent & { webkitCompassHeading?: number }).webkitCompassHeading;
+  if (typeof ios === 'number' && !isNaN(ios)) {
+    return ((ios % 360) + 360) % 360;
+  }
+  if (event.alpha !== null && !isNaN(event.alpha)) {
+    return ((360 - event.alpha) % 360 + 360) % 360;
+  }
+  return null;
+}
+
+/**
+ * intent: Resolve to the current OrientationPermission state, prompting iOS if needed
+ * method: iOS exposes a static requestPermission; non-iOS browsers grant by default
+ * effect: Must be called inside a user-gesture handler on iOS or the prompt is suppressed
+ */
+export async function requestOrientationPermission(): Promise<OrientationPermission> {
+  if (typeof DeviceOrientationEvent === 'undefined') return 'unsupported';
+  const cls = DeviceOrientationEvent as unknown as DeviceOrientationEventStatic;
+  if (typeof cls.requestPermission !== 'function') return 'granted';
+  try {
+    const result = await cls.requestPermission();
+    return result;
+  } catch {
+    return 'denied';
+  }
+}
+
+/**
+ * intent: Stream compass headings until the returned unsubscribe is called
+ * method: Listen for deviceorientationabsolute when available (true-north without calibration), fall back to deviceorientation
+ * effect: Caller is responsible for invoking the returned function to detach the listener
+ */
+export function subscribeOrientation(onHeading: (heading: number) => void): () => void {
+  const handler = (event: Event): void => {
+    const heading = extractHeading(event as DeviceOrientationEvent);
+    if (heading !== null) onHeading(heading);
+  };
+  const eventName = 'ondeviceorientationabsolute' in window ? 'deviceorientationabsolute' : 'deviceorientation';
+  window.addEventListener(eventName, handler);
+  return () => window.removeEventListener(eventName, handler);
+}

--- a/src/orientation.ts
+++ b/src/orientation.ts
@@ -1,8 +1,4 @@
-/**
- * Intent: Wrap DeviceOrientationEvent with the iOS permission flow + heading extraction
- * Context: Used by compass.ts; iOS 13+ requires DeviceOrientationEvent.requestPermission() from a user gesture
- * Pattern: Permission is one-shot; subscribeOrientation returns an unsubscribe function for clean teardown
- */
+// DeviceOrientationEvent wrapper: iOS-13+ permission gate + heading extraction. Used by compass.ts.
 
 export type OrientationPermission = 'unknown' | 'unsupported' | 'granted' | 'denied';
 
@@ -10,11 +6,7 @@ interface DeviceOrientationEventStatic {
   requestPermission?: () => Promise<'granted' | 'denied'>;
 }
 
-/**
- * intent: Pull a compass heading (0–360°, clockwise from True North) out of a DeviceOrientationEvent
- * method: Prefer iOS webkitCompassHeading (already true-north calibrated); fall back to W3C alpha (anti-clockwise around z)
- * effect: Returns null when neither field is usable (NaN / unsupported)
- */
+// iOS webkitCompassHeading is already true-north clockwise; W3C alpha is anti-clockwise so flip it.
 export function extractHeading(event: DeviceOrientationEvent): number | null {
   const ios = (event as DeviceOrientationEvent & { webkitCompassHeading?: number }).webkitCompassHeading;
   if (typeof ios === 'number' && !isNaN(ios)) {
@@ -26,11 +18,7 @@ export function extractHeading(event: DeviceOrientationEvent): number | null {
   return null;
 }
 
-/**
- * intent: Resolve to the current OrientationPermission state, prompting iOS if needed
- * method: iOS exposes a static requestPermission; non-iOS browsers grant by default
- * effect: Must be called inside a user-gesture handler on iOS or the prompt is suppressed
- */
+// Must be called from inside a user-gesture handler on iOS or the prompt is suppressed.
 export async function requestOrientationPermission(): Promise<OrientationPermission> {
   if (typeof DeviceOrientationEvent === 'undefined') return 'unsupported';
   const cls = DeviceOrientationEvent as unknown as DeviceOrientationEventStatic;
@@ -43,11 +31,7 @@ export async function requestOrientationPermission(): Promise<OrientationPermiss
   }
 }
 
-/**
- * intent: Stream compass headings until the returned unsubscribe is called
- * method: Listen for deviceorientationabsolute when available (true-north without calibration), fall back to deviceorientation
- * effect: Caller is responsible for invoking the returned function to detach the listener
- */
+// 'deviceorientationabsolute' yields true-north headings without calibration when available.
 export function subscribeOrientation(onHeading: (heading: number) => void): () => void {
   const handler = (event: Event): void => {
     const heading = extractHeading(event as DeviceOrientationEvent);

--- a/src/style.css
+++ b/src/style.css
@@ -1714,3 +1714,28 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   margin: 8px 24px;
 }
 
+/* Device-orientation compass (top-right). Initial state is muted; first tap requests permission
+   on iOS, after which .compass-rose--active rotates the SVG by --heading-deg. */
+.compass-rose {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.2s ease;
+  display: block;
+}
+.compass-rose:hover,
+.compass-rose:focus-visible { opacity: 0.9; }
+.compass-rose svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  transform: rotate(var(--heading-deg, 0deg));
+  transition: transform 0.12s linear;
+}
+.compass-rose--active { opacity: 1; }
+.compass-rose--unavailable { display: none; }
+

--- a/src/style.css
+++ b/src/style.css
@@ -1736,6 +1736,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   transform: rotate(var(--heading-deg, 0deg));
   transition: transform 0.12s linear;
 }
-.compass-rose--active { opacity: 1; }
+.compass-rose--active { opacity: 1; cursor: default; }
 .compass-rose--unavailable { display: none; }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,7 @@ export interface AppState {
   lastValidHeadingDeg: number | null;
   lastValidHeadingMs: number;
 
-  // Device-orientation compass: most recent heading from DeviceOrientationEvent (true-north clockwise)
-  lastDeviceHeadingDeg: number | null;
+  // Device-orientation compass: permission state cached so subsequent taps skip the prompt
   compassPermission: OrientationPermission;
 
   // Hysteresis state for GPS weak-signal badge — prevents flicker in marginal signal
@@ -103,7 +102,6 @@ export function createInitialState(): AppState {
     lastGpsAccuracy: null,
     lastValidHeadingDeg: null,
     lastValidHeadingMs: 0,
-    lastDeviceHeadingDeg: null,
     compassPermission: 'unknown',
     gpsWeakStreak: 0,
     gpsStrongStreak: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@
 import type L from 'leaflet';
 import type { Keepalive } from './keepalive';
 import type { Costing, Route } from './routing';
+import type { OrientationPermission } from './orientation';
 
 // Three-state location button: off → active (following) → passive (dot visible, not following)
 export type LocateState = 'off' | 'active' | 'passive';
@@ -58,6 +59,10 @@ export interface AppState {
   lastValidHeadingDeg: number | null;
   lastValidHeadingMs: number;
 
+  // Device-orientation compass: most recent heading from DeviceOrientationEvent (true-north clockwise)
+  lastDeviceHeadingDeg: number | null;
+  compassPermission: OrientationPermission;
+
   // Hysteresis state for GPS weak-signal badge — prevents flicker in marginal signal
   gpsWeakStreak: number;        // consecutive fixes with accuracy > TRAIL_MAX_ACCURACY_M
   gpsStrongStreak: number;      // consecutive fixes with accuracy < (TRAIL_MAX_ACCURACY_M - 5)
@@ -98,6 +103,8 @@ export function createInitialState(): AppState {
     lastGpsAccuracy: null,
     lastValidHeadingDeg: null,
     lastValidHeadingMs: 0,
+    lastDeviceHeadingDeg: null,
+    compassPermission: 'unknown',
     gpsWeakStreak: 0,
     gpsStrongStreak: 0,
     gpsWeakBadgeVisible: false,


### PR DESCRIPTION
## Summary

- Top-right compass widget that shows where the device is physically facing relative to the (always-north-up) map.
- Most useful at low speed / stationary at a junction, where GPS course is `NaN` and the existing heading-cone wedge fades. Lets the user rotate themselves until the compass N points up — at that point their physical orientation matches the map.
- iOS-13+ `DeviceOrientationEvent.requestPermission()` is handled inside the click handler; non-iOS browsers grant immediately. Hidden entirely when the API is unavailable.

Closes #163

## Files

**New:**
- `src/orientation.ts` — `extractHeading()`, `requestOrientationPermission()`, `subscribeOrientation()`.
- `src/compass.ts` — Leaflet control with an inline SVG rose; rotation driven by a `--heading-deg` CSS custom property.
- `src/orientation.test.ts` — 5 vitest tests for heading-extraction edge cases (iOS preference, normalisation, NaN fallback).

**Modified:**
- `src/types.ts` — `compassPermission` on `AppState` (cached so subsequent taps skip the prompt).
- `src/main.ts` — mounts the control after the existing top-right cluster.
- `src/style.css` — `.compass-rose` + `--active` / `--unavailable` variants, 0.12 s rotation transition, `cursor: default` once active.

## Behaviour

| State | Visual | Behaviour |
|---|---|---|
| Initial (after page load) | Muted (opacity 0.55) compass with "Tap to enable" tooltip | First click triggers `requestOrientationPermission()` |
| Granted | Full opacity, `cursor: default`, rose rotates with device | Subscribed to `deviceorientationabsolute` (or fall back to `deviceorientation`) |
| Denied / unsupported | Hidden via `display: none` | No further prompts |

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` clean (633 tests, 5 new for `extractHeading`)
- [x] `npm run size` clean (97.86 kB / 100 kB; +0.75 kB for the widget)
- [ ] Manual on a real iPhone: tap the compass, accept the prompt, rotate the device — N should track True North; rotate 90° clockwise, N should rotate 90° counter-clockwise on screen
- [ ] Manual on Android Chrome: compass should rotate without an explicit prompt
- [ ] Desktop without sensors: compass hidden

## Notes

- W3C `alpha` is anti-clockwise around the device's z-axis. We flip it to clockwise (`360 - alpha`) for compass-bearing semantics. iOS `webkitCompassHeading` is already clockwise from True North so we use it directly when present.
- The 0.12 s CSS transition smooths jitter from the magnetometer; faster values look twitchy on cheap sensors.
- `lastDeviceHeadingDeg` was considered for `AppState` but dropped — no module currently reads it and visual rotation goes straight to a CSS custom property. Reintroduce if a future feature needs the numeric value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)