### PR TITLE
fix(hillshade): revert per-tile blend, use isolation: isolate on #map (#171)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -6,10 +6,16 @@
 
 html { height: 100%; width: 100%; padding: 0; margin: 0; }
 body { height: 100%; width: 100%; padding: 0; margin: 0; }
-#map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
+/* isolation: isolate establishes a clean stacking context root for the map so .hillshade-blend's
+   mix-blend-mode reliably composites against the base-layer tiles below it (without this the blend
+   can sometimes leak out to the page-level backdrop or be isolated by ancestor compositing layers). */
+#map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; isolation: isolate; }
 
-/* Per-tile multiply — a container-level blend can isolate under .leaflet-tile-container's translate3d. */
-.hillshade-blend img.leaflet-tile { mix-blend-mode: multiply; }
+/* Multiply at the Leaflet layer container — peer of the base-layer container in the tile pane,
+   so the blend has the base map below it as the backdrop. (Per-tile blending at img.leaflet-tile
+   was tried in PR #169 and reverted: it moves the blend INTO the transformed tile-container's
+   stacking context, where there is nothing behind to multiply against, so hillshade renders opaque.) */
+.hillshade-blend { mix-blend-mode: multiply; }
 
 /* Icon state classes for GPS accuracy filter visual feedback */
 #disabled {

--- a/src/style.css
+++ b/src/style.css
@@ -6,15 +6,10 @@
 
 html { height: 100%; width: 100%; padding: 0; margin: 0; }
 body { height: 100%; width: 100%; padding: 0; margin: 0; }
-/* isolation: isolate establishes a clean stacking context root for the map so .hillshade-blend's
-   mix-blend-mode reliably composites against the base-layer tiles below it (without this the blend
-   can sometimes leak out to the page-level backdrop or be isolated by ancestor compositing layers). */
+/* isolation: isolate keeps mix-blend-mode contained to the map's own stacking context. */
 #map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; isolation: isolate; }
 
-/* Multiply at the Leaflet layer container — peer of the base-layer container in the tile pane,
-   so the blend has the base map below it as the backdrop. (Per-tile blending at img.leaflet-tile
-   was tried in PR #169 and reverted: it moves the blend INTO the transformed tile-container's
-   stacking context, where there is nothing behind to multiply against, so hillshade renders opaque.) */
+/* Blend at the layer container so multiply composites against the base-layer sibling below. */
 .hillshade-blend { mix-blend-mode: multiply; }
 
 /* Icon state classes for GPS accuracy filter visual feedback */


### PR DESCRIPTION
## Summary

- PR #169 moved \`mix-blend-mode: multiply\` from \`.hillshade-blend\` (Leaflet layer container) to \`.hillshade-blend img.leaflet-tile\` (individual tile images). My stacking-context reasoning was backwards.
- Applying the blend AT the tile image places it INSIDE the transformed \`.leaflet-tile-container\`'s stacking context. That context contains only hillshade tiles — there is nothing to multiply against — so the blend renders source pixels opaque and the base map is completely hidden.
- The user reported v0.31.0-beta showing "the hillshade is all that is visible when it's enabled".

## Fix

1. Revert the selector to \`.hillshade-blend\` (the layer container, peer of the base layer's container under \`.leaflet-tile-pane\` — has the base map as sibling backdrop).
2. Add \`isolation: isolate\` to \`#map\` so the map is a clean stacking-context root — addresses the *actual* root cause of the original "sometimes not applied" issue from #168 by preventing ancestor compositing layers from isolating the blend.

Closes #171.

## Why this is the right level

\`isolation: isolate\` on the map root creates a self-contained stacking context. Inside it, every Leaflet pane and layer composites against the map's backdrop, so \`mix-blend-mode\` on \`.hillshade-blend\` has a stable, predictable backdrop (the base layer below it in the tile pane).

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: enable Hillshade with the Topographic basemap — slopes shaded, flat-area base-map color preserved
- [ ] Manual: zoom to max — blend stays consistent without dropouts
- [ ] Manual: switch basemaps with Hillshade enabled — blend re-applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)