### PR TITLE
fix(geocoding): Navigate button silently fails for search results and drag-moved pins (#173)

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -63,7 +63,7 @@ function zoomForAddrType(addrType: string): number {
 // Shared references so addSearchControl can clear the drop pin / geocode bar on marker click.
 let _pinLayer: L.LayerGroup | null = null;
 let _clearSearchSelection: (() => void) | null = null;
-let _showGeocodeBar: ((label: string, copyText: string) => void) | null = null;
+let _showGeocodeBar: ((label: string, copyText: string, latlng: L.LatLng) => void) | null = null;
 
 export function addSearchControl(map: L.Map, state: AppState, onNoResults: (message: string) => void): void {
   // state is read in the results callback (for future extensibility)
@@ -266,7 +266,7 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
       const coordText = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
       const label = resultName !== '' ? resultName : coordText;
       const copyText = resultName !== '' ? `${resultName}\n${coordText}` : coordText;
-      _showGeocodeBar?.(label, copyText);
+      _showGeocodeBar?.(label, copyText, L.latLng(lat, lng));
       clearSelection();
       li.classList.add('sheet-result--active');
       li.classList.remove('sheet-result--expanded');
@@ -471,29 +471,22 @@ export function addReverseGeocoding(
   const barNavBtn  = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__nav')!;
   const barHandle  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__handle')!;
 
-  // "Navigate" button on the geocode-bar — start guidance to the dropped pin's
-  // current latlng. The pin location is on whichever marker is in pinLayer
-  // (there's always at most one when the bar is visible).
+  // "Navigate" button on the geocode-bar — start guidance to the destination
+  // associated with the currently-shown bar. showGeocodeBar() is the single
+  // setter so search-results, long-press, and pin-drag all stay in sync.
   let currentPinLatLng: L.LatLng | null = null;
   let currentPinLabel = '';
   barNavBtn.addEventListener('click', () => {
-    if (currentPinLatLng === null) return;
+    if (currentPinLatLng === null) {
+      showToast('No destination set');
+      return;
+    }
     void startGuidance(
       state,
       map,
       { lat: currentPinLatLng.lat, lng: currentPinLatLng.lng, label: currentPinLabel },
       showToast,
     );
-  });
-
-  // Expose pin position to the Navigate button via closure-captured ref.
-  // Updated by showGeocodeBar through pinLayer inspection on each open.
-  pinLayer.on('layeradd', () => {
-    const layers = pinLayer.getLayers();
-    const pin = layers[layers.length - 1];
-    if (pin instanceof L.Marker) {
-      currentPinLatLng = pin.getLatLng();
-    }
   });
 
   // Tap-to-expand: tapping a truncated address shows the full text for 3s
@@ -589,7 +582,7 @@ export function addReverseGeocoding(
     }
   }
 
-  function showGeocodeBar(label: string, copyText: string): void {
+  function showGeocodeBar(label: string, copyText: string, latlng: L.LatLng): void {
     collapseAddr();
     barAddrEl.textContent = label;
     barAddrEl.title = label;
@@ -597,6 +590,7 @@ export function addReverseGeocoding(
     barCopyBtn.textContent = 'Copy';
     barCopyBtn.classList.remove('geocode-bar__copy--copied');
     currentPinLabel = label;
+    currentPinLatLng = latlng;
 
     if (sheetState === 'hidden') {
       // Render off-screen first so offsetHeight is available, then use double-rAF
@@ -780,12 +774,12 @@ export function addReverseGeocoding(
         if (error || !result) {
           // Geocoding failed — fall back to coordinates.
           document.title = coordLabel;
-          showGeocodeBar(coordLabel, coordLabel);
+          showGeocodeBar(coordLabel, coordLabel, latlng);
           return;
         }
         const addr = result.address.Match_addr;
         document.title = addr;
-        showGeocodeBar(addr, addr);
+        showGeocodeBar(addr, addr, latlng);
       });
   }
 


### PR DESCRIPTION
## Summary

- The "Navigate" button next to Copy in the geocode-bar tracked its destination via a `pinLayer.on('layeradd')` listener — fires only when a new layer is *added* to the group.
- That misses two flows:
  - **Search → Go to location**: handler calls `pinLayer.clearLayers()` and never adds a new pin → `currentPinLatLng` stays `null` (silent fail) or stale (worse — navigates to a previous long-press pin).
  - **Pin drag**: the marker moves but isn't re-added → listener doesn't fire → Navigate goes to the original drop location, not the dragged one.

## Fix

Thread the destination `L.LatLng` through `showGeocodeBar(label, copyText, latlng)`. That function is the single setter all three flows (search, long-press, drag) already converge on, so capturing the destination there is reliable. Removed the unreliable `layeradd` listener.

Also replaced the silent-return guard with a `"No destination set"` toast so any future regression surfaces visibly instead of vanishing.

Closes #173.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` clean (633 tests)
- [ ] Manual: search → Go to location → Navigate goes to that result
- [ ] Manual: long-press → Navigate goes to the pin
- [ ] Manual: long-press → drag pin → Navigate goes to the **dragged** location
- [ ] Manual: tap Navigate before any destination is set → "No destination set" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)