### PR TITLE
fix(guidance): hide geocode-bar when starting navigation so Stop is tappable (#175)

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -481,10 +481,7 @@ export function addReverseGeocoding(
       showToast('No destination set');
       return;
     }
-    // Hide the geocode-bar before starting guidance: the bar's drag-handle has
-    // pointer-events: auto and sits at the top of its 130px peek area, which
-    // overlaps the guidance pill's Stop button at the bottom-left and steals
-    // the tap (#175).
+    // Bar's drag-handle overlaps the guidance pill's Stop button at this y-coord (#175).
     hideGeocodeBar();
     void startGuidance(
       state,

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -481,6 +481,11 @@ export function addReverseGeocoding(
       showToast('No destination set');
       return;
     }
+    // Hide the geocode-bar before starting guidance: the bar's drag-handle has
+    // pointer-events: auto and sits at the top of its 130px peek area, which
+    // overlaps the guidance pill's Stop button at the bottom-left and steals
+    // the tap (#175).
+    hideGeocodeBar();
     void startGuidance(
       state,
       map,


### PR DESCRIPTION
## Summary

- The geocode-bar (`position: fixed; bottom: 0; height: 60vh; z-index: 1500`) in peek state covers the bottom ~130 px of the viewport above all Leaflet controls.
- The bar's **drag handle** has `pointer-events: auto` and spans the bar's full width, sitting at the top of the visible peek area — at the same y-coordinate as the guidance pill's Stop button at the bottom of the bottom-left control cluster.
- Result: every tap intended for Stop hits the handle instead. User reported the button "doesn't respond like it's not a button".

## Fix

Call `hideGeocodeBar()` from the geocode-bar's Navigate click handler before `startGuidance()` runs. Once guidance starts, the bar's information is redundant (the pill shows the destination) and keeping it open just blocks taps on the pill's controls.

## Why this is the right scope

The other entry points to guidance don't have the overlap:
- Search dropdown's "Navigate here" (`sheet-result__nav-btn`) starts guidance directly without showing the bar.
- The compass / hillshade / locate buttons are unrelated.

So narrowly hiding the bar from its own Navigate click handler addresses every flow that reaches the bug.

Closes #175.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` clean (633 tests)
- [ ] Manual: long-press → tap Navigate (in bar) → guiding state → Stop button responds
- [ ] Manual: search → "Go to location" → bar opens → tap Navigate → Stop responds
- [ ] Regression: tapping Copy / drag-handle still works in peek state when no guidance is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)