### PR TITLE
fix(geocoding): tap targets for Navigate (peek state) + close dropdown on Navigate here (#177)

### DIFF
--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -249,7 +249,7 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
       const lng = parseFloat(li.dataset['lng'] ?? '');
       if (isNaN(lat) || isNaN(lng)) return;
       const label = li.dataset['name'] ?? `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
-      // Hide the search dropdown so it can't overlap the guidance pill (#177).
+      // Dropdown is z-index 2000; close it before the guidance pill appears.
       hideDropdown();
       void startGuidance(state, map, { lat, lng, label }, onNoResults);
       return;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -249,6 +249,8 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
       const lng = parseFloat(li.dataset['lng'] ?? '');
       if (isNaN(lat) || isNaN(lng)) return;
       const label = li.dataset['name'] ?? `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+      // Hide the search dropdown so it can't overlap the guidance pill (#177).
+      hideDropdown();
       void startGuidance(state, map, { lat, lng, label }, onNoResults);
       return;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -657,6 +657,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 .geocode-bar--peek .geocode-bar__handle,
+.geocode-bar--peek .geocode-bar__nav,
 .geocode-bar--peek .geocode-bar__copy,
 .geocode-bar--peek .geocode-bar__close,
 .geocode-bar--peek .geocode-bar__addr {


### PR DESCRIPTION
## Summary

Two silently-swallowed taps that combine to make both Navigate and Stop appear broken on mobile.

### 1. Geocode-bar Navigate missing from peek opt-in (long-press flow)

\`\`\`css
.geocode-bar--peek { pointer-events: none; }
.geocode-bar--peek .geocode-bar__handle,
.geocode-bar--peek .geocode-bar__copy,
.geocode-bar--peek .geocode-bar__close,
.geocode-bar--peek .geocode-bar__addr { pointer-events: auto; }
\`\`\`

\`.geocode-bar__nav\` is missing from this list. The CSS spec says descendants of \`pointer-events: none\` still receive events, but mobile Safari has long-standing quirks here — the existing opt-in for the other interactive children was already a workaround for this. Add Navigate to it.

This also explains why the Stop fix from #176 didn't help: \`hideGeocodeBar()\` is called from Navigate's click handler. If Navigate never fires, the bar never hides, and the bar's drag handle keeps eating Stop taps.

### 2. Search dropdown stays open after Navigate here

The \`.sheet-result__nav-btn\` handler at \`geocoding.ts:246\` calls \`startGuidance()\` without closing the dropdown. \`.search-dropdown\` is \`z-index: 2000\` (above the guidance pill at Leaflet's default ~800), and on small viewports can overlap the pill. Add \`hideDropdown()\` before guidance starts.

Closes #177.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` clean (633)
- [ ] Manual: long-press → Navigate (bar) → button responds, bar hides, guidance starts
- [ ] Manual: long-press → Navigate → Stop responds
- [ ] Manual: search → Navigate here (dropdown) → dropdown closes, guidance starts
- [ ] Manual: search → Navigate here → Stop responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)