### PR TITLE
fix(guidance): Stop button drops taps because render() rebuilds it on every GPS fix (#179)

### DIFF
--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -76,6 +76,11 @@ export function addGuidanceControl(
       panelEl = c;
       L.DomEvent.disableClickPropagation(c);
       L.DomEvent.disableScrollPropagation(c);
+      // Delegate clicks on .guidance-btn to a single persistent listener so
+      // every-GPS-fix re-renders don't destroy the button mid-tap.
+      L.DomEvent.on(c, 'click', (e: Event) => {
+        if ((e.target as HTMLElement).closest('.guidance-btn')) onStop();
+      });
       render();
       return c;
     },
@@ -386,10 +391,11 @@ function render(): void {
 function appendButton(label: string, modifier: string, ariaLabel: string): void {
   if (!panelEl) return;
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.className = `guidance-btn ${modifier}`;
   btn.textContent = label;
   btn.setAttribute('aria-label', ariaLabel);
-  btn.addEventListener('click', onStop);
+  // Click handling lives on panelEl via delegation — see addGuidanceControl.
   panelEl.appendChild(btn);
 }
 


### PR DESCRIPTION
## Summary

- `updateGuidance()` is called from `onLocationFound` on **every accepted GPS fix** (~1 Hz on a moving phone). Its last action is `render()`, which does `panelEl.innerHTML = ''` and re-creates the Stop button (via `appendButton`).
- iOS Safari's touch-to-click synthesis tracks the specific DOM element that received `touchstart`. If that element is destroyed before `touchend` arrives, no `click` is fired. With GPS fixes faster than typical tap-and-release timing, almost every tap on the Stop button lands in the rebuild window and is silently dropped.

## Fix

Switch to **event delegation**: a single persistent `click` listener attached once to `panelEl` at control creation. The listener checks `event.target.closest('.guidance-btn')` and calls `onStop` when matched. Because `panelEl` itself never gets destroyed (only its inner HTML), the listener survives every render and the button can come and go freely.

Also adds `type="button"` to the buttons defensively.

Closes #179.

## Why event delegation is the right shape

- The panel re-renders aren't going away — distance, ETA, current step legitimately change every fix.
- A surgical "update text content but keep buttons" refactor would work but is more code than the bug warrants.
- Delegation is one line, lives in `addGuidanceControl` once, and can never desynchronise.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` clean (633 tests)
- [ ] Manual: long-press → Navigate → guiding state → Stop responds reliably (no need to tap multiple times)
- [ ] Manual: search → "Navigate here" → guiding state → Stop responds reliably
- [ ] Regression: routing-state Cancel still works (delegation covers both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)