### PR TITLE
fix(routing): surface actionable error on network failure

### DIFF
--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -154,7 +154,33 @@ describe('fetchRoute', () => {
         dest: L.latLng(1, 1),
         costing: 'auto',
       }),
-    ).rejects.toThrow(/^Routing failed: HTTP 500$/);
+    ).rejects.toThrow(/^HTTP 500$/);
+  });
+
+  it('converts a network-level fetch failure into an actionable message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    );
+    await expect(
+      fetchRoute({
+        start: L.latLng(0, 0),
+        dest: L.latLng(1, 1),
+        costing: 'auto',
+      }),
+    ).rejects.toThrow(/routing service unavailable/);
+  });
+
+  it('propagates an AbortError unchanged', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new DOMException('aborted', 'AbortError'),
+    );
+    await expect(
+      fetchRoute({
+        start: L.latLng(0, 0),
+        dest: L.latLng(1, 1),
+        costing: 'auto',
+      }),
+    ).rejects.toThrow(/aborted/);
   });
 
   it('throws before fetch when coordinates are not finite', async () => {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -101,14 +101,26 @@ export async function fetchRoute(req: RouteRequest): Promise<Route> {
     costing: req.costing,
     directions_options: { units: 'kilometers' },
   };
-  const res = await fetch(VALHALLA_URL, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: req.signal,
-  });
+  let res: Response;
+  try {
+    res = await fetch(VALHALLA_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: req.signal,
+    });
+  } catch (err) {
+    // An aborted request must propagate unchanged so callers can detect it.
+    if (err instanceof DOMException && err.name === 'AbortError') throw err;
+    // fetch() rejects with a TypeError for any network-level failure (DNS,
+    // connection refused, TLS, blocked CORS preflight). The browser surfaces
+    // these in the console as an opaque "CORS request did not succeed" with a
+    // null status — there is no HTTP response to inspect. Convert it into a
+    // message a user can act on instead of leaking the raw TypeError.
+    throw new Error('routing service unavailable — check your connection or try again later');
+  }
   if (!res.ok) {
-    throw new Error(`Routing failed: HTTP ${res.status}`);
+    throw new Error(`HTTP ${res.status}`);
   }
   const json = (await res.json()) as ValhallaResponse;
   if (json.trip.legs.length > 1) {


### PR DESCRIPTION
## Summary

When the FOSSGIS Valhalla server is unreachable, routing failed with an opaque `CORS request did not succeed / Status (null)` console error and a cryptic `Routing failed: Failed to fetch` toast. `fetch()` rejects with a raw `TypeError` on any network-level failure (DNS, connection refused, TLS, blocked CORS preflight) — the browser just labels all of them "CORS".

This is error-handling only — no provider change. The FOSSGIS outage itself is upstream.

## Changes

- `src/routing.ts` — `fetchRoute()` wraps the `fetch` call in try/catch:
  - `AbortError` propagates unchanged so in-flight-cancel logic still works.
  - All other network failures → `routing service unavailable — check your connection or try again later`.
  - Drops the `Routing failed: ` prefix from the HTTP-error message (callers already re-prefix it — was `Routing failed: Routing failed: HTTP NNN`).
- `src/routing.test.ts` — added coverage for the network-failure conversion and the AbortError pass-through.

## Test plan

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm test` — 72 tests pass

## Assumptions

- The browser console's `Cross-Origin Request Blocked` line cannot be suppressed from JS — this PR improves the user-facing toast, not the console log.

Closes #181