### PR TITLE
feat(units): locale-aware distance units

### DIFF
--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -7,6 +7,7 @@ import type { AppState } from './types';
 import type { Costing, Route } from './routing';
 import { fetchRoute } from './routing';
 import { haversineDistance, pointToSegmentMeters } from './geo';
+import { formatDistance } from './units';
 
 
 // Profile-dependent thresholds (metres). `auto` is the default fallback if a
@@ -127,11 +128,11 @@ export function renderGuidanceDashboard(state: AppState): string {
 
   return '<div class="guidance-row guidance-row--maneuver">' +
     `<span class="maneuver-icon">${maneuverIcon(step?.type ?? 0)}</span>` +
-    `<span class="maneuver-distance">${formatDist(dist)}</span>` +
+    `<span class="maneuver-distance">${formatDistance(dist)}</span>` +
     `<span class="maneuver-text">${escapeHtml(step?.instruction ?? '')}</span>` +
     '</div>' +
     '<div class="guidance-row guidance-row--summary">' +
-    `<span>${formatDist(remaining)}</span>` +
+    `<span>${formatDistance(remaining)}</span>` +
     '<span class="guidance-row__sep">·</span>' +
     `<span>ETA ${escapeHtml(etaStr)}</span>` +
     '<span class="guidance-row__sep">·</span>' +
@@ -456,12 +457,6 @@ function maneuverIcon(type: number): string {
     case 17: case 18: return '↑'; // continue / straight
     default: return '→';
   }
-}
-
-function formatDist(m: number): string {
-  if (!isFinite(m) || m < 0) return '—';
-  if (m >= 1000) return `${(m / 1000).toFixed(1)} km`;
-  return `${Math.round(m)} m`;
 }
 
 function escapeHtml(s: string): string {

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -112,6 +112,7 @@ describe('fetchRoute', () => {
       start: L.latLng(40, -74),
       dest: L.latLng(40.1, -73.9),
       costing: 'auto',
+      units: 'metric',
     });
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -126,6 +127,32 @@ describe('fetchRoute', () => {
     ]);
     expect(body.costing).toBe('auto');
     expect(body.directions_options).toEqual({ units: 'kilometers' });
+  });
+
+  it('requests miles from Valhalla and converts lengths when units=imperial', async () => {
+    mockOk({
+      trip: {
+        legs: [{
+          shape: '',
+          maneuvers: [
+            { type: 1, instruction: 'Drive 1 mile', length: 1, time: 60, begin_shape_index: 0 },
+          ],
+        }],
+        summary: { length: 2, time: 120 },
+      },
+    });
+    const r = await fetchRoute({
+      start: L.latLng(0, 0),
+      dest: L.latLng(1, 1),
+      costing: 'auto',
+      units: 'imperial',
+    });
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.directions_options).toEqual({ units: 'miles' });
+    // Valhalla reports `length` in miles when miles are requested.
+    expect(r.distanceM).toBeCloseTo(2 * 1609.344, 3);
+    expect(r.steps[0]?.lengthM).toBeCloseTo(1609.344, 3);
   });
 
   it.each(['auto', 'pedestrian', 'bicycle'] as const)(
@@ -250,6 +277,7 @@ describe('fetchRoute', () => {
       start: L.latLng(0, 0),
       dest: L.latLng(1, 1),
       costing: 'auto',
+      units: 'metric',
     });
     expect(r.distanceM).toBe(1500);
     expect(r.durationS).toBe(300);
@@ -285,6 +313,7 @@ describe('fetchRoute', () => {
       start: L.latLng(0, 0),
       dest: L.latLng(1, 1),
       costing: 'auto',
+      units: 'metric',
     });
     expect(r.steps).toHaveLength(2);
     expect(r.steps[0]?.instruction).toBe('Drive east on Main St');

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,6 +1,12 @@
 // Privacy: each request sends start + destination to the public FOSSGIS Valhalla
 // instance. ADR-006 + the consent flow document the tradeoff before any nav action.
 import L from 'leaflet';
+import {
+  type UnitSystem,
+  unitSystem,
+  valhallaUnits,
+  metersPerValhallaUnit,
+} from './units';
 
 export type Costing = 'auto' | 'pedestrian' | 'bicycle';
 
@@ -27,6 +33,8 @@ export interface RouteRequest {
   dest: L.LatLng;
   costing: Costing;
   signal?: AbortSignal;
+  /** Unit system for Valhalla's instruction text. Defaults to the session locale. */
+  units?: UnitSystem;
 }
 
 export const VALHALLA_URL = 'https://valhalla1.openstreetmap.de/route' as const;
@@ -66,7 +74,7 @@ export function decodePolyline6(s: string): L.LatLng[] {
 interface ValhallaManeuver {
   type: number;
   instruction: string;
-  length: number; // km (we requested kilometers)
+  length: number; // in the units requested via directions_options
   time: number; // seconds
   street_names?: string[];
   begin_shape_index: number;
@@ -79,7 +87,7 @@ interface ValhallaResponse {
       maneuvers: ValhallaManeuver[];
     }>;
     summary: {
-      length: number; // km
+      length: number; // in the units requested via directions_options
       time: number; // seconds
     };
   };
@@ -93,13 +101,14 @@ export async function fetchRoute(req: RouteRequest): Promise<Route> {
   ) {
     throw new Error('Routing failed: invalid coordinates');
   }
+  const system = req.units ?? unitSystem();
   const body = {
     locations: [
       { lat: req.start.lat, lon: req.start.lng },
       { lat: req.dest.lat, lon: req.dest.lng },
     ],
     costing: req.costing,
-    directions_options: { units: 'kilometers' },
+    directions_options: { units: valhallaUnits(system) },
   };
   let res: Response;
   try {
@@ -131,11 +140,12 @@ export async function fetchRoute(req: RouteRequest): Promise<Route> {
   }
   const leg = json.trip.legs[0];
   if (!leg) throw new Error('Routing returned no legs');
+  const mPerUnit = metersPerValhallaUnit(system);
   const coords = decodePolyline6(leg.shape);
   const steps: RouteStep[] = leg.maneuvers.map((m) => ({
     instruction: m.instruction,
     type: m.type,
-    lengthM: m.length * 1000,
+    lengthM: m.length * mPerUnit,
     durationS: m.time,
     streetNames: m.street_names ?? [],
     beginShapeIndex: m.begin_shape_index,
@@ -143,7 +153,7 @@ export async function fetchRoute(req: RouteRequest): Promise<Route> {
   return {
     coords,
     steps,
-    distanceM: json.trip.summary.length * 1000,
+    distanceM: json.trip.summary.length * mPerUnit,
     durationS: json.trip.summary.time,
   };
 }

--- a/src/units.test.ts
+++ b/src/units.test.ts
@@ -56,9 +56,19 @@ describe('formatDistance', () => {
   it('formats imperial distances in miles and feet', () => {
     expect(formatDistance(0, 'imperial')).toBe('0 ft');
     expect(formatDistance(30, 'imperial')).toBe('100 ft');
-    // 0.1 mi is the miles/feet crossover.
     expect(formatDistance(1609.344, 'imperial')).toBe('1.0 mi');
     expect(formatDistance(4828, 'imperial')).toBe('3.0 mi');
+  });
+
+  it('switches from feet to miles at the 0.1 mi boundary', () => {
+    expect(formatDistance(160, 'imperial')).toBe('520 ft'); // just under 0.1 mi
+    expect(formatDistance(161, 'imperial')).toBe('0.1 mi'); // just over 0.1 mi
+  });
+
+  it('rounds sub-10 ft distances down to 0 ft (documented behavior)', () => {
+    // Feet are rounded to the nearest 10; Valhalla never reports a step this
+    // short, so the loss of precision below ~1.5 m is intentional.
+    expect(formatDistance(1, 'imperial')).toBe('0 ft');
   });
 
   it('returns an em dash for invalid input', () => {

--- a/src/units.test.ts
+++ b/src/units.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectUnitSystem,
+  valhallaUnits,
+  metersPerValhallaUnit,
+  formatDistance,
+} from './units';
+
+describe('detectUnitSystem', () => {
+  it.each(['en-US', 'en-GB', 'my-MM', 'en-LR'])(
+    'resolves %s to imperial',
+    (locale) => {
+      expect(detectUnitSystem(locale)).toBe('imperial');
+    },
+  );
+
+  it.each(['de-DE', 'fr-FR', 'ja-JP', 'en-AU', 'es-MX'])(
+    'resolves %s to metric',
+    (locale) => {
+      expect(detectUnitSystem(locale)).toBe('metric');
+    },
+  );
+
+  it('resolves a bare language tag via likely-subtags (en → US → imperial)', () => {
+    expect(detectUnitSystem('en')).toBe('imperial');
+  });
+
+  it('falls back to metric for an unparseable tag', () => {
+    expect(detectUnitSystem('not a locale!!')).toBe('metric');
+  });
+});
+
+describe('valhallaUnits', () => {
+  it('maps unit systems to Valhalla directions_options values', () => {
+    expect(valhallaUnits('imperial')).toBe('miles');
+    expect(valhallaUnits('metric')).toBe('kilometers');
+  });
+});
+
+describe('metersPerValhallaUnit', () => {
+  it('returns metres per reported length unit', () => {
+    expect(metersPerValhallaUnit('imperial')).toBeCloseTo(1609.344, 3);
+    expect(metersPerValhallaUnit('metric')).toBe(1000);
+  });
+});
+
+describe('formatDistance', () => {
+  it('formats metric distances in km and m', () => {
+    expect(formatDistance(0, 'metric')).toBe('0 m');
+    expect(formatDistance(450, 'metric')).toBe('450 m');
+    expect(formatDistance(999, 'metric')).toBe('999 m');
+    expect(formatDistance(1000, 'metric')).toBe('1.0 km');
+    expect(formatDistance(2500, 'metric')).toBe('2.5 km');
+  });
+
+  it('formats imperial distances in miles and feet', () => {
+    expect(formatDistance(0, 'imperial')).toBe('0 ft');
+    expect(formatDistance(30, 'imperial')).toBe('100 ft');
+    // 0.1 mi is the miles/feet crossover.
+    expect(formatDistance(1609.344, 'imperial')).toBe('1.0 mi');
+    expect(formatDistance(4828, 'imperial')).toBe('3.0 mi');
+  });
+
+  it('returns an em dash for invalid input', () => {
+    expect(formatDistance(NaN, 'metric')).toBe('—');
+    expect(formatDistance(-5, 'imperial')).toBe('—');
+    expect(formatDistance(Infinity, 'metric')).toBe('—');
+  });
+});

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,0 +1,58 @@
+// Locale-aware distance units. Road distances are shown in miles/feet for
+// regions whose road signage is imperial, and kilometres/metres elsewhere.
+// The unit system is also forwarded to Valhalla so its `instruction` strings
+// (which bake the unit into the text) match what the pill displays.
+
+export type UnitSystem = 'imperial' | 'metric';
+
+/** Regions whose road signage is imperial: US, UK, Myanmar, Liberia. */
+const IMPERIAL_REGIONS = new Set(['US', 'GB', 'MM', 'LR']);
+
+const METERS_PER_MILE = 1609.344;
+const FEET_PER_METER = 3.28084;
+
+/**
+ * Resolve the unit system for a BCP-47 locale tag, defaulting to
+ * `navigator.language`. Unrecognised or region-less tags fall back to metric.
+ */
+export function detectUnitSystem(locale?: string): UnitSystem {
+  let region: string | null = null;
+  try {
+    const tag = locale ?? (typeof navigator !== 'undefined' ? navigator.language : 'en');
+    // maximize() adds likely subtags so a bare "en" still resolves a region.
+    region = new Intl.Locale(tag).maximize().region ?? null;
+  } catch {
+    region = null;
+  }
+  return region !== null && IMPERIAL_REGIONS.has(region) ? 'imperial' : 'metric';
+}
+
+let cached: UnitSystem | null = null;
+
+/** Memoised unit system for the current session. */
+export function unitSystem(): UnitSystem {
+  if (cached === null) cached = detectUnitSystem();
+  return cached;
+}
+
+/** Valhalla's `directions_options.units` value for a unit system. */
+export function valhallaUnits(system: UnitSystem): 'miles' | 'kilometers' {
+  return system === 'imperial' ? 'miles' : 'kilometers';
+}
+
+/** Metres per unit of Valhalla's reported `length` field for a unit system. */
+export function metersPerValhallaUnit(system: UnitSystem): number {
+  return system === 'imperial' ? METERS_PER_MILE : 1000;
+}
+
+/** Format a metre distance for display in the given unit system. */
+export function formatDistance(meters: number, system: UnitSystem = unitSystem()): string {
+  if (!isFinite(meters) || meters < 0) return '—';
+  if (system === 'imperial') {
+    const miles = meters / METERS_PER_MILE;
+    if (miles >= 0.1) return `${miles.toFixed(1)} mi`;
+    return `${Math.round((meters * FEET_PER_METER) / 10) * 10} ft`;
+  }
+  if (meters >= 1000) return `${(meters / 1000).toFixed(1)} km`;
+  return `${Math.round(meters)} m`;
+}


### PR DESCRIPTION
## Summary

Distance units were hardcoded metric throughout the app. A user in an imperial-units region saw turn-by-turn navigation distances in kilometres. There was no locale detection anywhere in `src/`.

This PR makes distance units follow the user's locale — in both the pill display and the units requested from Valhalla (Valhalla bakes the unit into its `instruction` text, so the request and display must agree).

## Changes

- **New `src/units.ts`** — `detectUnitSystem()` reads `navigator.language` and maps imperial regions (US, GB, MM, LR) → `imperial`, everything else → `metric`. Memoised via `unitSystem()`. Exposes `formatDistance()`, `valhallaUnits()`, `metersPerValhallaUnit()`.
- **`src/routing.ts`** — `fetchRoute()` requests `units: miles|kilometers` matching the locale and converts Valhalla's `length` field with the matching metres-per-unit factor. New `RouteRequest.units?` lets callers/tests override the detected system.
- **`src/guidance.ts`** — the pill's `formatDist` is replaced by `formatDistance()` — renders `mi`/`ft` for imperial locales, `km`/`m` for metric.

`L.control.scale()` already shows both systems — left unchanged.

## Test plan

- `npm run type-check` — clean
- `npm run lint` — clean
- `npm test` — 89 tests pass (new `units.test.ts` with 16 cases + imperial routing coverage)

## Assumptions

- Imperial regions limited to US, GB, MM, LR (road-signage imperial). A bare language tag (e.g. `en`) resolves region via `Intl.Locale.maximize()`.
- `Intl.Locale` is available in the PWA's target browsers (Safari 14+, all modern evergreens) — within the ES2020 baseline.

Closes #183