### PR TITLE
fix(ci): deploy only on releases, not every mainline push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,13 @@ jobs:
             exit 1
           fi
           git checkout --quiet "refs/tags/$TAG"
+          # The tag and package.json version must agree, or the deployed
+          # version metadata would be wrong. Read without node (not set up yet).
+          PKG_VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -n1)
+          if [ "$TAG" != "v$PKG_VERSION" ]; then
+            echo "::error::Release tag $TAG does not match package.json version (v$PKG_VERSION)"
+            exit 1
+          fi
           echo "Deploying release tag: $TAG ($(git rev-parse --short HEAD))"
 
       - name: Setup Node.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,15 @@ jobs:
 
       - name: Resolve and check out release tag
         id: release
+        # Pass trigger context via env, never interpolate ${{ }} into the
+        # shell — a crafted tag name would otherwise be executed.
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GH_EVENT" = "push" ]; then
             # Tag push — deploy exactly the tag that was pushed.
-            TAG="${{ github.ref_name }}"
+            TAG="$GH_REF_NAME"
           else
             # Manual dispatch — deploy the latest version tag.
             TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve and check out release tag
-        id: release
         # Pass trigger context via env, never interpolate ${{ }} into the
         # shell — a crafted tag name would otherwise be executed.
         env:
@@ -51,7 +50,6 @@ jobs:
           fi
           git checkout --quiet "refs/tags/$TAG"
           echo "Deploying release tag: $TAG ($(git rev-parse --short HEAD))"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,14 @@
 name: Deploy to Production
 
+# Deploy runs ONLY for releases — never on plain pushes to mainline:
+#   - automatically when a version tag (v*) is pushed
+#   - manually via workflow_dispatch (the /deploy skill), which deploys the
+#     latest version tag
+# In both cases the full CI quality gate runs against the release tag's
+# code first; the deploy steps run only if every check passes.
 on:
   push:
-    branches: [mainline]
+    tags: ['v*']
   workflow_dispatch:
 
 # Only one deployment at a time
@@ -17,8 +23,30 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and check out release tag
+        id: release
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tag push — deploy exactly the tag that was pushed.
+            TAG="${{ github.ref_name }}"
+          else
+            # Manual dispatch — deploy the latest version tag.
+            TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::No version tag found to deploy"
+            exit 1
+          fi
+          git checkout --quiet "refs/tags/$TAG"
+          echo "Deploying release tag: $TAG ($(git rev-parse --short HEAD))"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -29,12 +57,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # ── CI quality gate — deploy proceeds only if all of these pass ──
+      # Mirrors ci.yml; kept inline so the gate runs against the release
+      # tag's code rather than whatever ref triggered the workflow.
+      - name: Test
+        run: npm test
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         env:
           VITE_MAPBOX_TOKEN: ${{ secrets.VITE_MAPBOX_TOKEN }}
           VITE_ESRI_API_KEY: ${{ secrets.VITE_ESRI_API_KEY }}
         run: npm run build
 
+      - name: Verify build output
+        run: |
+          test -f dist/index.html || { echo "ERROR: dist/index.html not found"; exit 1; }
+          grep -q 'type="module"' dist/index.html || { echo "ERROR: Missing type=module in dist/index.html"; exit 1; }
+          echo "Build verification passed"
+
+      - name: Bundle size check
+        run: npm run size
+
+      # ── Deploy — only reached when every gate step above passed ──
       - name: Create deployment package
         run: tar -czf webmap-deploy.tar.gz -C dist .
 
@@ -50,11 +100,12 @@ jobs:
           SSH_OPTS="-i ~/.ssh/deploy_key -o ConnectTimeout=60 -o ServerAliveInterval=30"
           SSH_TARGET="${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}"
           VERSION=$(node -p "require('./package.json').version")
+          DEPLOY_SHA=$(git rev-parse HEAD)
 
           source "$GITHUB_WORKSPACE/scripts/ssh-retry.sh"
 
           ssh_retry "scp $SSH_OPTS scripts/deploy-webmap.sh $SSH_TARGET:/tmp/deploy-webmap.sh"
-          ssh_retry "cat webmap-deploy.tar.gz | ssh $SSH_OPTS $SSH_TARGET 'DEPLOY_SHA=${{ github.sha }} DEPLOY_VERSION=$VERSION bash /tmp/deploy-webmap.sh'"
+          ssh_retry "cat webmap-deploy.tar.gz | ssh $SSH_OPTS $SSH_TARGET 'DEPLOY_SHA=$DEPLOY_SHA DEPLOY_VERSION=$VERSION bash /tmp/deploy-webmap.sh'"
 
       - name: Cleanup SSH key
         if: always()


### PR DESCRIPTION
## Summary

`deploy.yml` triggered on `push: branches: [mainline]` — so every mainline commit deployed to production, independently of CI. During the v0.32.0-beta release the intermediate commit deployed despite red CI.

## Changes

`.github/workflows/deploy.yml`:

- **Triggers** — replaced `push: branches: [mainline]` with `push: tags: ['v*']`; kept `workflow_dispatch`.
- **Release-tag resolution** — on a tag push, deploys that tag; on manual dispatch, resolves and deploys the latest `v*` tag (so the `/deploy` skill works without changes, regardless of the ref it dispatches against).
- **CI gate** — the full quality gate (test, type-check, lint, build, verify-output, size) runs against the release tag's code *before* the deploy steps; deploy proceeds only if every check passes.
- `DEPLOY_SHA` now comes from `git rev-parse HEAD` (the checked-out release commit) rather than `github.sha` (the trigger ref).

## Test plan

- Workflow is YAML-valid; no tabs; 2-space indentation consistent with the prior file.
- Behavioural verification happens on first use: next `v*` tag push should run the gate then deploy; pushes to `mainline` should produce **no** Deploy run.

## Assumptions

- The CI gate is inlined (mirrors `ci.yml`) rather than reused via `workflow_call`, because a reusable workflow runs against the caller's ref and cannot be retargeted to the release tag. The ~6 duplicated steps are the accepted tradeoff for gating against the correct ref.

Closes #185