### PR TITLE
fix(guidance): show routing failures in a dialog, not an obscured toast

### DIFF
--- a/src/dialog.test.ts
+++ b/src/dialog.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { showAlertDialog } from './dialog';
+
+describe('showAlertDialog', () => {
+  afterEach(() => {
+    document.getElementById('app-dialog-overlay')?.remove();
+  });
+
+  it('renders an overlay with the given title and message', () => {
+    showAlertDialog({ title: 'Routing unavailable', message: 'Service is down' });
+    const overlay = document.getElementById('app-dialog-overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.querySelector('.app-dialog-title')?.textContent).toBe('Routing unavailable');
+    expect(overlay?.querySelector('.app-dialog-message')?.textContent).toBe('Service is down');
+    expect(overlay?.querySelector('[role="alertdialog"]')).not.toBeNull();
+  });
+
+  it('dismisses on the OK button', () => {
+    showAlertDialog({ title: 'T', message: 'M' });
+    (document.querySelector('.app-dialog-ok') as HTMLButtonElement).click();
+    expect(document.getElementById('app-dialog-overlay')).toBeNull();
+  });
+
+  it('dismisses on Escape', () => {
+    showAlertDialog({ title: 'T', message: 'M' });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.getElementById('app-dialog-overlay')).toBeNull();
+  });
+
+  it('replaces an existing dialog instead of stacking', () => {
+    showAlertDialog({ title: 'First', message: 'one' });
+    showAlertDialog({ title: 'Second', message: 'two' });
+    expect(document.querySelectorAll('.app-dialog-overlay')).toHaveLength(1);
+    expect(document.querySelector('.app-dialog-title')?.textContent).toBe('Second');
+  });
+
+  it('uses a custom button label when given', () => {
+    showAlertDialog({ title: 'T', message: 'M', buttonLabel: 'Got it' });
+    expect(document.querySelector('.app-dialog-ok')?.textContent).toBe('Got it');
+  });
+});

--- a/src/dialog.test.ts
+++ b/src/dialog.test.ts
@@ -53,4 +53,22 @@ describe('showAlertDialog', () => {
     showAlertDialog({ title: 'T', message: 'M', buttonLabel: 'Got it' });
     expect(document.querySelector('.app-dialog-ok')?.textContent).toBe('Got it');
   });
+
+  it('wires aria-labelledby and aria-describedby to the title and message', () => {
+    showAlertDialog({ title: 'Heads up', message: 'Details here' });
+    const panel = document.querySelector('[role="alertdialog"]')!;
+    const titleId = panel.getAttribute('aria-labelledby')!;
+    const msgId = panel.getAttribute('aria-describedby')!;
+    expect(document.getElementById(titleId)?.textContent).toBe('Heads up');
+    expect(document.getElementById(msgId)?.textContent).toBe('Details here');
+    expect(panel.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('traps Tab focus on the OK button', () => {
+    showAlertDialog({ title: 'T', message: 'M' });
+    const okBtn = document.querySelector('.app-dialog-ok') as HTMLButtonElement;
+    okBtn.blur();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    expect(document.activeElement).toBe(okBtn);
+  });
 });

--- a/src/dialog.test.ts
+++ b/src/dialog.test.ts
@@ -27,6 +27,21 @@ describe('showAlertDialog', () => {
     expect(document.getElementById('app-dialog-overlay')).toBeNull();
   });
 
+  it('dismisses on backdrop click', () => {
+    showAlertDialog({ title: 'T', message: 'M' });
+    const overlay = document.getElementById('app-dialog-overlay')!;
+    overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(document.getElementById('app-dialog-overlay')).toBeNull();
+  });
+
+  it('does not leave a stale Escape listener after replacement', () => {
+    showAlertDialog({ title: 'First', message: 'one' });
+    showAlertDialog({ title: 'Second', message: 'two' });
+    // One Escape closes the live dialog; no orphaned listener from the first.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.getElementById('app-dialog-overlay')).toBeNull();
+  });
+
   it('replaces an existing dialog instead of stacking', () => {
     showAlertDialog({ title: 'First', message: 'one' });
     showAlertDialog({ title: 'Second', message: 'two' });

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,11 +1,9 @@
-/**
- * Intent: Modal alert dialog for notifications that must not be missed.
- * Context: Use instead of showToast() when the message is important and a
- *   toast would be obscured by other UI — the geocode-bar tray (z-index 1500)
- *   covers the toast (z-index 1000). The dialog sits at the consent-overlay
- *   layer (z-index 3000), above all app chrome.
- * Pattern: Single message, single acknowledge button; no AppState dependency.
- */
+// Modal alert dialog for messages a toast can't reliably surface — the
+// geocode-bar tray (z-index 1500) covers the toast (z-index 1000); this
+// sits at z-index 3000, above all app chrome.
+
+const TITLE_ID = 'app-dialog-title';
+const MESSAGE_ID = 'app-dialog-message';
 
 interface AlertDialogOptions {
   title: string;
@@ -33,13 +31,16 @@ export function showAlertDialog(opts: AlertDialogOptions): void {
   panel.className = 'app-dialog-panel';
   panel.setAttribute('role', 'alertdialog');
   panel.setAttribute('aria-modal', 'true');
-  panel.setAttribute('aria-label', opts.title);
+  panel.setAttribute('aria-labelledby', TITLE_ID);
+  panel.setAttribute('aria-describedby', MESSAGE_ID);
 
   const heading = document.createElement('h2');
+  heading.id = TITLE_ID;
   heading.className = 'app-dialog-title';
   heading.textContent = opts.title;
 
   const body = document.createElement('p');
+  body.id = MESSAGE_ID;
   body.className = 'app-dialog-message';
   body.textContent = opts.message;
 
@@ -62,7 +63,14 @@ export function showAlertDialog(opts: AlertDialogOptions): void {
     previouslyFocused?.focus();
   }
   function onKey(e: KeyboardEvent): void {
-    if (e.key === 'Escape') cleanup();
+    if (e.key === 'Escape') {
+      cleanup();
+    } else if (e.key === 'Tab') {
+      // Focus trap: the OK button is the only focusable element, so honour
+      // aria-modal by keeping focus on it.
+      e.preventDefault();
+      okBtn.focus();
+    }
   }
 
   okBtn.addEventListener('click', cleanup);

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -66,8 +66,8 @@ export function showAlertDialog(opts: AlertDialogOptions): void {
     if (e.key === 'Escape') {
       cleanup();
     } else if (e.key === 'Tab') {
-      // Focus trap: the OK button is the only focusable element, so honour
-      // aria-modal by keeping focus on it.
+      // Focus trap: keep Tab and Shift+Tab on the OK button (the only
+      // focusable element) to honour aria-modal.
       e.preventDefault();
       okBtn.focus();
     }

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,0 +1,68 @@
+/**
+ * Intent: Modal alert dialog for notifications that must not be missed.
+ * Context: Use instead of showToast() when the message is important and a
+ *   toast would be obscured by other UI — the geocode-bar tray (z-index 1500)
+ *   covers the toast (z-index 1000). The dialog sits at the consent-overlay
+ *   layer (z-index 3000), above all app chrome.
+ * Pattern: Single message, single acknowledge button; no AppState dependency.
+ */
+
+interface AlertDialogOptions {
+  title: string;
+  message: string;
+  /** Acknowledge-button label. Defaults to "OK". */
+  buttonLabel?: string;
+}
+
+/** Show a modal alert dialog. Replaces any dialog already open. */
+export function showAlertDialog(opts: AlertDialogOptions): void {
+  // Never stack dialogs — a newer message supersedes an unacknowledged one.
+  document.getElementById('app-dialog-overlay')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'app-dialog-overlay';
+  overlay.className = 'app-dialog-overlay';
+
+  const panel = document.createElement('div');
+  panel.className = 'app-dialog-panel';
+  panel.setAttribute('role', 'alertdialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-label', opts.title);
+
+  const heading = document.createElement('h2');
+  heading.className = 'app-dialog-title';
+  heading.textContent = opts.title;
+
+  const body = document.createElement('p');
+  body.className = 'app-dialog-message';
+  body.textContent = opts.message;
+
+  const actions = document.createElement('div');
+  actions.className = 'app-dialog-actions';
+
+  const okBtn = document.createElement('button');
+  okBtn.className = 'app-dialog-ok';
+  okBtn.textContent = opts.buttonLabel ?? 'OK';
+
+  actions.appendChild(okBtn);
+  panel.append(heading, body, actions);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  function cleanup(): void {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === 'Escape') cleanup();
+  }
+
+  okBtn.addEventListener('click', cleanup);
+  // Tap outside the panel dismisses, matching the consent modal.
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) cleanup();
+  });
+  document.addEventListener('keydown', onKey);
+
+  okBtn.focus();
+}

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -14,10 +14,16 @@ interface AlertDialogOptions {
   buttonLabel?: string;
 }
 
+// Cleanup for the dialog currently open, if any. Lets a replacement fully
+// tear down the previous dialog — including its document keydown listener.
+let activeCleanup: (() => void) | null = null;
+
 /** Show a modal alert dialog. Replaces any dialog already open. */
 export function showAlertDialog(opts: AlertDialogOptions): void {
   // Never stack dialogs — a newer message supersedes an unacknowledged one.
-  document.getElementById('app-dialog-overlay')?.remove();
+  activeCleanup?.();
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
 
   const overlay = document.createElement('div');
   overlay.id = 'app-dialog-overlay';
@@ -50,8 +56,10 @@ export function showAlertDialog(opts: AlertDialogOptions): void {
   document.body.appendChild(overlay);
 
   function cleanup(): void {
+    if (activeCleanup === cleanup) activeCleanup = null;
     overlay.remove();
     document.removeEventListener('keydown', onKey);
+    previouslyFocused?.focus();
   }
   function onKey(e: KeyboardEvent): void {
     if (e.key === 'Escape') cleanup();
@@ -63,6 +71,7 @@ export function showAlertDialog(opts: AlertDialogOptions): void {
     if (e.target === overlay) cleanup();
   });
   document.addEventListener('keydown', onKey);
+  activeCleanup = cleanup;
 
   okBtn.focus();
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -13,10 +13,10 @@ import { showAlertDialog } from './dialog';
 // Surface a routing failure in a dialog — a toast is hidden behind the tray.
 function showRoutingError(err: unknown, title = 'Routing unavailable'): void {
   const detail = err instanceof Error ? err.message : String(err);
-  showAlertDialog({
-    title,
-    message: detail.charAt(0).toUpperCase() + detail.slice(1),
-  });
+  const message = detail
+    ? detail.charAt(0).toUpperCase() + detail.slice(1)
+    : 'Could not reach the routing service. Please try again.';
+  showAlertDialog({ title, message });
 }
 
 

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -10,15 +10,11 @@ import { haversineDistance, pointToSegmentMeters } from './geo';
 import { formatDistance } from './units';
 import { showAlertDialog } from './dialog';
 
-/**
- * Surface a routing failure in a modal dialog rather than a toast. The
- * geocode-bar tray (z-index 1500) covers the toast (z-index 1000), so a
- * "routing service unavailable" toast goes unseen exactly when it matters.
- */
-function showRoutingError(err: unknown): void {
+// Surface a routing failure in a dialog — a toast is hidden behind the tray.
+function showRoutingError(err: unknown, title = 'Routing unavailable'): void {
   const detail = err instanceof Error ? err.message : String(err);
   showAlertDialog({
-    title: 'Routing unavailable',
+    title,
     message: detail.charAt(0).toUpperCase() + detail.slice(1),
   });
 }
@@ -252,7 +248,7 @@ export async function setGuidanceCosting(
     state.guidance.costing = previousCosting;
     applyRouteStyle(state);
     render();
-    showRoutingError(err);
+    showRoutingError(err, "Couldn't change route type");
     return false;
   }
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -8,6 +8,20 @@ import type { Costing, Route } from './routing';
 import { fetchRoute } from './routing';
 import { haversineDistance, pointToSegmentMeters } from './geo';
 import { formatDistance } from './units';
+import { showAlertDialog } from './dialog';
+
+/**
+ * Surface a routing failure in a modal dialog rather than a toast. The
+ * geocode-bar tray (z-index 1500) covers the toast (z-index 1000), so a
+ * "routing service unavailable" toast goes unseen exactly when it matters.
+ */
+function showRoutingError(err: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err);
+  showAlertDialog({
+    title: 'Routing unavailable',
+    message: detail.charAt(0).toUpperCase() + detail.slice(1),
+  });
+}
 
 
 // Profile-dependent thresholds (metres). `auto` is the default fallback if a
@@ -178,7 +192,7 @@ export async function startGuidance(
     state.guidance.status = 'idle';
     state.guidance.destination = null;
     render();
-    showToast?.(`Routing failed: ${err instanceof Error ? err.message : String(err)}`, 5000);
+    showRoutingError(err);
   }
 }
 
@@ -238,7 +252,7 @@ export async function setGuidanceCosting(
     state.guidance.costing = previousCosting;
     applyRouteStyle(state);
     render();
-    showToast?.(`Route type failed: ${err instanceof Error ? err.message : String(err)}`, 5000);
+    showRoutingError(err);
     return false;
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1834,6 +1834,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   background: #2f6fd8;
 }
 
+.app-dialog-ok:focus-visible {
+  outline: 2px solid #1b4fa8;
+  outline-offset: 2px;
+}
+
 /* Device-orientation compass (top-right). Initial state is muted; first tap requests permission
    on iOS, after which .compass-rose--active rotates the SVG by --heading-deg. */
 .compass-rose {

--- a/src/style.css
+++ b/src/style.css
@@ -1775,6 +1775,65 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   margin: 8px 24px;
 }
 
+/* Modal alert dialog (dialog.ts) — for important messages a toast can't
+   reliably surface because the geocode-bar tray (z-index 1500) covers it. */
+.app-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+}
+
+.app-dialog-panel {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  max-width: 420px;
+  width: calc(100% - 32px);
+  font-family: system-ui, sans-serif;
+  color: #222;
+  line-height: 1.5;
+}
+
+.app-dialog-title {
+  margin: 0;
+  padding: 20px 24px 8px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #111;
+}
+
+.app-dialog-message {
+  margin: 0;
+  padding: 0 24px 4px;
+  font-size: 14px;
+}
+
+.app-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 24px 20px;
+}
+
+.app-dialog-ok {
+  padding: 10px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  background: #4287f5;
+  color: #fff;
+  cursor: pointer;
+}
+
+.app-dialog-ok:hover {
+  background: #2f6fd8;
+}
+
 /* Device-orientation compass (top-right). Initial state is muted; first tap requests permission
    on iOS, after which .compass-rose--active rotates the SVG by --heading-deg. */
 .compass-rose {


### PR DESCRIPTION
## Summary

Routing failures (e.g. the Valhalla service being unreachable) were surfaced via `showToast()` at `z-index: 1000`. The geocode-bar tray sits at `z-index: 1500` and covers the toast — so the failure message was hidden exactly when the user was attempting navigation from the tray.

## Changes

- **New `src/dialog.ts`** — `showAlertDialog({ title, message, buttonLabel? })`: a modal alert dialog at the consent-overlay layer (`z-index: 3000`), above all app chrome. Dismisses on OK / Escape / backdrop tap; replaces (never stacks) an existing dialog; `role="alertdialog"`.
- **`src/guidance.ts`** — `startGuidance()` and `setGuidanceCosting()` route routing-failure messages through the dialog. Non-error guidance toasts ("Stop current navigation first", "Enable location to navigate", etc.) are unchanged.
- **`src/style.css`** — `.app-dialog-*` styles, mirroring the consent-modal layout.

## Test plan

- `npm run type-check` / `npm run lint` — clean
- `npm test` — 96 tests pass (new `dialog.test.ts`: render, OK/Escape/backdrop dismiss, replace-not-stack, custom label)
- Manual: trigger a routing failure with the geocode-bar tray open — the message now appears in a centered dialog above the tray.

## Assumptions

- Only routing *failures* move to the dialog; informational guidance toasts stay as toasts since they are not obscured in the same way and are non-critical.

Closes #186