### PR TITLE
fix(pwa): make SW update reload visibility-aware and post-paint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import { addGuidanceControl } from './guidance';
 import { addCompassControl } from './compass';
 import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
+import { scheduleSwUpdate } from './sw-update';
 
 // ── Consent gate — block all interaction until terms are accepted ─────────────
 if (!hasConsent()) {
@@ -416,21 +417,26 @@ document.addEventListener('visibilitychange', () => {
 // ── Battery monitoring ────────────────────────────────────────────────────────
 initBattery(state);
 
-function applyUpdateWhenSafe(update: () => void): void {
-  update();
-}
-
 // Note: vite-plugin-pwa also exposes onOfflineReady for first-install caching.
 // Not wired here — silent first-install caching is acceptable.
 const updateSW = registerSW({
   onNeedRefresh() {
-    // Defer SW update until after first paint — immediate reload during init
-    // causes a blank page on iOS Safari (new SW activates + clientsClaim
-    // triggers location.reload() before Leaflet has rendered anything).
-    // rAF is also suspended in background tabs, which further protects active
-    // recordings from an unintended mid-session reload (intentional benefit).
-    requestAnimationFrame(() => {
-      applyUpdateWhenSafe(() => updateSW(true));
+    // Apply the update only after the page is visible AND a real paint has
+    // happened — otherwise workbox-window's reload races first paint and leaves
+    // a blank page (the user then has to reload manually). scheduleSwUpdate owns
+    // the visibility + post-paint gating so the logic stays unit-testable.
+    scheduleSwUpdate({
+      isHidden: () => document.hidden,
+      onVisible: (cb) => {
+        const onChange = (): void => {
+          if (document.hidden) return;
+          document.removeEventListener('visibilitychange', onChange);
+          cb();
+        };
+        document.addEventListener('visibilitychange', onChange);
+      },
+      raf: (cb) => { requestAnimationFrame(cb); },
+      apply: () => { updateSW(true); },
     });
   },
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,7 +435,7 @@ const updateSW = registerSW({
         };
         document.addEventListener('visibilitychange', onChange);
       },
-      raf: (cb) => { requestAnimationFrame(cb); },
+      raf: (cb) => requestAnimationFrame(cb),
       apply: () => { updateSW(true); },
     });
   },

--- a/src/sw-update.test.ts
+++ b/src/sw-update.test.ts
@@ -56,6 +56,7 @@ describe('scheduleSwUpdate', () => {
     h.becomeVisible();
     expect(h.pendingFrames()).toBe(1);
     h.flushFrame();
+    expect(h.apply).not.toHaveBeenCalled(); // still pre-paint after one frame
     h.flushFrame();
     expect(h.apply).toHaveBeenCalledTimes(1);
   });

--- a/src/sw-update.test.ts
+++ b/src/sw-update.test.ts
@@ -62,6 +62,8 @@ describe('scheduleSwUpdate', () => {
   });
 
   it('applies at most once even if frame callbacks fire repeatedly', () => {
+    // Inline deps (not harness()) because this test needs a pathological rAF
+    // that re-invokes each callback, which the shared harness doesn't model.
     const state = { hidden: false };
     const rafQueue: Array<() => void> = [];
     const apply = vi.fn();

--- a/src/sw-update.test.ts
+++ b/src/sw-update.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { scheduleSwUpdate, type SwUpdateScheduler } from './sw-update';
+
+/** Test harness with controllable visibility, a manual rAF queue, and a spy apply(). */
+function harness(startHidden: boolean) {
+  const state = { hidden: startHidden };
+  let visibleCb: (() => void) | null = null;
+  const rafQueue: Array<() => void> = [];
+  const apply = vi.fn();
+
+  const deps: SwUpdateScheduler = {
+    isHidden: () => state.hidden,
+    onVisible: (cb) => { visibleCb = cb; },
+    raf: (cb) => { rafQueue.push(cb); },
+    apply,
+  };
+
+  return {
+    deps,
+    apply,
+    pendingFrames: () => rafQueue.length,
+    /** Run every currently-queued frame callback (callbacks may enqueue more). */
+    flushFrame: () => rafQueue.splice(0).forEach((cb) => cb()),
+    becomeVisible: () => { state.hidden = false; visibleCb?.(); },
+  };
+}
+
+describe('scheduleSwUpdate', () => {
+  it('applies only after two animation frames when visible', () => {
+    const h = harness(false);
+    scheduleSwUpdate(h.deps);
+
+    // First frame scheduled, nothing applied yet.
+    expect(h.pendingFrames()).toBe(1);
+    expect(h.apply).not.toHaveBeenCalled();
+
+    // After the first frame runs, a second frame is scheduled (still pre-paint).
+    h.flushFrame();
+    expect(h.apply).not.toHaveBeenCalled();
+    expect(h.pendingFrames()).toBe(1);
+
+    // After the second frame — a real paint has happened — the update applies.
+    h.flushFrame();
+    expect(h.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for visibility before scheduling frames when hidden', () => {
+    const h = harness(true);
+    scheduleSwUpdate(h.deps);
+
+    // Hidden: no frames scheduled (rAF is paused), nothing applied.
+    expect(h.pendingFrames()).toBe(0);
+    expect(h.apply).not.toHaveBeenCalled();
+
+    // Once visible, the post-paint frame gating kicks in.
+    h.becomeVisible();
+    expect(h.pendingFrames()).toBe(1);
+    h.flushFrame();
+    h.flushFrame();
+    expect(h.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies at most once even if frame callbacks fire repeatedly', () => {
+    const state = { hidden: false };
+    const rafQueue: Array<() => void> = [];
+    const apply = vi.fn();
+    const deps: SwUpdateScheduler = {
+      isHidden: () => state.hidden,
+      onVisible: () => undefined,
+      // Pathological rAF that invokes each callback twice.
+      raf: (cb) => { rafQueue.push(cb); },
+      apply,
+    };
+
+    scheduleSwUpdate(deps);
+    // Drain, double-invoking every callback to simulate a misbehaving loop.
+    while (rafQueue.length > 0) {
+      const cb = rafQueue.shift()!;
+      cb();
+      cb();
+    }
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/sw-update.ts
+++ b/src/sw-update.ts
@@ -1,0 +1,55 @@
+/**
+ * Intent: Reliably apply a pending service-worker update without blanking the page
+ * Context: Called from main.ts onNeedRefresh; the actual location.reload() is performed by
+ *   workbox-window once the new SW takes control after we trigger skip-waiting (apply())
+ * Pattern: Pure scheduler with injectable timing primitives so the gating logic is unit-testable
+ *   without a real DOM, service worker, or browser paint loop
+ * Future: If a stuck waiting-SW ever needs a hard timeout fallback, add it here behind a dep
+ *   rather than reintroducing inline timing logic in main.ts
+ */
+
+export interface SwUpdateScheduler {
+  /** True when the document is currently hidden (backgrounded tab / PWA). */
+  isHidden: () => boolean;
+  /** Register a one-shot callback fired the next time the document becomes visible. */
+  onVisible: (cb: () => void) => void;
+  /** Schedule a callback on the next animation frame. */
+  raf: (cb: () => void) => void;
+  /** Trigger the update (sends skip-waiting → workbox-window reloads the page). */
+  apply: () => void;
+}
+
+/**
+ * Schedule a service-worker update so the ensuing reload never races first paint.
+ *
+ * Two failure modes this guards against — both surface as "the page doesn't load
+ * until the user manually reloads":
+ *
+ *  1. A single requestAnimationFrame fires *before* the frame's paint, so applying
+ *     the update there lets workbox-window reload the page before Leaflet has
+ *     painted → a blank page on iOS Safari. We wait for two frames so a real paint
+ *     has completed before the reload is triggered.
+ *  2. requestAnimationFrame is paused while the document is hidden, so an update
+ *     that lands in a backgrounded tab/PWA would never apply. We defer to the next
+ *     visibility change before scheduling the frames.
+ *
+ * apply() is invoked at most once.
+ */
+export function scheduleSwUpdate(deps: SwUpdateScheduler): void {
+  let applied = false;
+  const applyOnce = (): void => {
+    if (applied) return;
+    applied = true;
+    deps.apply();
+  };
+
+  // Two frames: the first rAF runs before the upcoming paint; the second runs
+  // after it, guaranteeing the page has actually rendered before we reload.
+  const applyAfterPaint = (): void => deps.raf(() => deps.raf(applyOnce));
+
+  if (deps.isHidden()) {
+    deps.onVisible(applyAfterPaint);
+  } else {
+    applyAfterPaint();
+  }
+}

--- a/src/sw-update.ts
+++ b/src/sw-update.ts
@@ -19,22 +19,9 @@ export interface SwUpdateScheduler {
   apply: () => void;
 }
 
-/**
- * Schedule a service-worker update so the ensuing reload never races first paint.
- *
- * Two failure modes this guards against — both surface as "the page doesn't load
- * until the user manually reloads":
- *
- *  1. A single requestAnimationFrame fires *before* the frame's paint, so applying
- *     the update there lets workbox-window reload the page before Leaflet has
- *     painted → a blank page on iOS Safari. We wait for two frames so a real paint
- *     has completed before the reload is triggered.
- *  2. requestAnimationFrame is paused while the document is hidden, so an update
- *     that lands in a backgrounded tab/PWA would never apply. We defer to the next
- *     visibility change before scheduling the frames.
- *
- * apply() is invoked at most once.
- */
+// Apply a waiting SW update only once the page is visible and a real paint has
+// completed — otherwise workbox-window's reload races first paint (blank page on
+// iOS Safari) or never fires at all in a hidden tab (rAF is paused while hidden).
 export function scheduleSwUpdate(deps: SwUpdateScheduler): void {
   let applied = false;
   const applyOnce = (): void => {


### PR DESCRIPTION
## Summary

Fixes #192 — "Page doesn't actually load until the user explicitly reloads the page."

The root cause is the service-worker update reload in `src/main.ts` `onNeedRefresh`, which gated the update behind a **single** `requestAnimationFrame`. Two real defects:

1. **A single `requestAnimationFrame` fires _before_ that frame's paint**, not after. So `updateSW(true)` was sent, the new SW claimed the page, and workbox-window called `location.reload()` before Leaflet had painted → a **blank page on iOS Safari** that only a manual reload recovered. (The original comment claimed to prevent exactly this, but one rAF doesn't.)
2. **`requestAnimationFrame` is paused while `document.hidden`.** If the update landed while the tab/PWA was backgrounded, the callback never fired, so `updateSW(true)` was never called — the page stayed on the stale SW and never reloaded on its own until a manual reload.

Both paths produce the reported symptom.

## Changes

- **New `src/sw-update.ts`** — `scheduleSwUpdate(deps)`, a dependency-injected scheduler that:
  - defers to the next visibility change when the document is hidden (rAF is paused while hidden);
  - then waits **two** animation frames so a real paint has completed before applying the update (a single rAF runs pre-paint);
  - applies at most once.
  Timing primitives (`isHidden`, `onVisible`, `raf`, `apply`) are injected so the logic is testable without a real browser paint loop.
- **`src/main.ts`** — `onNeedRefresh` now delegates to `scheduleSwUpdate`, passing `document.hidden`, a one-shot `visibilitychange` listener, `requestAnimationFrame`, and `updateSW(true)`. Removed the now-dead `applyUpdateWhenSafe` wrapper.
- **New `src/sw-update.test.ts`** — covers: applies only after two frames when visible; waits for visibility before scheduling frames when hidden; applies at most once even if frame callbacks fire repeatedly.

## Test plan

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm test` ✅ (103 tests; 3 new for `sw-update`)
- `npm run build` ✅
- `npm run size` ✅ (103.88 kB gzipped, under the 105 kB cap)

### Manual verification (PWA/SW behavior requires a real browser — per CLAUDE.md)
1. Build + `npm run preview`, load the app, let the SW install.
2. Deploy/serve a new build so an update is detected. Confirm the app **auto-reloads to the new version with no blank flash** and no manual reload needed.
3. Repeat with the tab backgrounded when the update lands, then re-focus: confirm the reload happens on return to foreground (not before).
4. iOS Safari: confirm no blank page on the post-update reload.

## Assumptions

- Issue #192 has an empty body (bug template only); the title is the sole signal. I scoped the fix to the SW update-reload path — the area the existing code comments were already wrestling with — which is the mechanism that produces "doesn't load until manual reload." The fix is robust regardless of the exact trigger: it makes the reload visibility-aware and genuinely post-paint.
- Kept `registerType: 'prompt'` and the app's deliberate "defer past first paint" intent; only the gating mechanism changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)