### PR TITLE
feat(maps,search): unified search→sheet flow, Thunderforest trail bases + Routes overlay, GPS/PWA fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 # Copy this file to .env and fill in your API keys
 # .env is gitignored — never commit real keys
 
-# Mapbox access token (for the Trails tile layer)
-# Get one at https://www.mapbox.com/account/access-tokens
-VITE_MAPBOX_TOKEN=pk.your_mapbox_token_here
-
 # ESRI/ArcGIS API key (for geocoding search and reverse geocode on dblclick)
 # Get one at https://developers.arcgis.com/
+# Without this, address/place search returns "nothing found" for every query.
 VITE_ESRI_API_KEY=your_esri_api_key_here
+
+# Thunderforest API key (for the Cycle and Outdoors trail base maps)
+# Get a free key at https://www.thunderforest.com/ (150k tiles/month free).
+# Referrer-restrict it to your deploy origin; add http://localhost:5173 to test locally.
+# Without this, the Cycle/Outdoors base layers return error tiles.
+VITE_THUNDERFOREST_TOKEN=your_thunderforest_key_here

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Build
         env:
-          VITE_MAPBOX_TOKEN: ${{ secrets.VITE_MAPBOX_TOKEN }}
           VITE_ESRI_API_KEY: ${{ secrets.VITE_ESRI_API_KEY }}
+          VITE_THUNDERFOREST_TOKEN: ${{ secrets.VITE_THUNDERFOREST_TOKEN }}
         run: npm run build
 
       - name: Verify build output

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 node_modules/
 dist/
+dev-dist/
 .env
+
+# Local worktree clones and session/log artifacts (never commit)
+clones/
+logs/
+*.log
 
 # Legacy files with embedded secrets (kept locally but not committed)
 index.html-backup

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,7 +65,7 @@ webmap.dev stores sensitive location and navigation data entirely on the client.
 - ESRI geocoding API calls require an explicit `VITE_ESRI_API_KEY` (from arcgis.com)
 - API key source (`.env`) is not committed to git
 - **Note**: Vite embeds all `VITE_*` variables in the client bundle at build time — the API key is visible in compiled JS output and browser DevTools. Restrict key usage via ESRI's API key scope and domain allowlist settings.
-- Map tiles from free/public sources (OpenStreetMap, Mapbox via optional key)
+- Map tiles from OpenStreetMap (no key) and Thunderforest (Cycle/Outdoors bases, optional `VITE_THUNDERFOREST_TOKEN`)
 - No analytics, telemetry, or tracking enabled by default
 - Reverse geocoding and search are opt-in user actions (not automatic)
 
@@ -89,7 +89,7 @@ webmap.dev stores sensitive location and navigation data entirely on the client.
 
 **Mitigations**:
 - Cache entries are versioned (workbox cache name includes version)
-- Tile URLs are from trusted sources (OSM, Google, Mapbox)
+- Tile URLs are from trusted sources (OpenStreetMap, Thunderforest, Esri)
 - Cache URLs use HTTPS
 - User must explicitly trigger offline pre-download
 
@@ -127,7 +127,7 @@ Out of scope:
 ### Securing Your Installation
 
 1. **Keep Node.js updated**: Run `node --version` regularly and upgrade
-2. **Use `.env.local` for secrets**: Never commit `VITE_ESRI_API_KEY` or `VITE_MAPBOX_TOKEN`
+2. **Use `.env.local` for secrets**: Never commit `VITE_ESRI_API_KEY` or `VITE_THUNDERFOREST_TOKEN`
 3. **Enable HTTPS**: Deploy webmap.dev behind TLS; do not serve over HTTP
 4. **Clear browser data**: Periodically clear localStorage and service worker cache
 5. **Review GPS permissions**: On mobile, review app location permissions in OS settings

--- a/index.html
+++ b/index.html
@@ -23,7 +23,11 @@
   <meta name="twitter:image:alt" content="webmap.dev — record GPS trails, offline maps, no account">
 
   <link rel="icon" type="image/svg+xml" href="/logo-color-v1.1.svg">
-  <link rel="manifest" href="/manifest.webmanifest">
+  <!-- The web app manifest link is injected automatically by vite-plugin-pwa
+       at build time (it owns manifest.webmanifest). Do not hardcode it here —
+       a second link duplicates it in the build, and in dev (SW disabled) it
+       404s to the HTML fallback, which the browser reports as a manifest
+       "Line 1, column 1, Syntax error". -->
 </head>
 <body>
   <div id="map"></div>

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -75,8 +75,8 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
 
   if (!apikey) {
     console.warn(
-      'VITE_ESRI_API_KEY is not configured. ' +
-      'Search requests may fail if ArcGIS requires authentication. ' +
+      'VITE_ESRI_API_KEY is not configured — address search and reverse geocoding ' +
+      '(pin drop) will fail, since ArcGIS requires authentication. ' +
       'Set VITE_ESRI_API_KEY in your .env file.'
     );
   }

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -160,8 +160,12 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
   function showDropdown(): void {
     const rect = wrapper.getBoundingClientRect();
     dropdownEl.style.top = `${rect.bottom + 2}px`;
-    dropdownEl.style.left = `${Math.max(4, rect.left)}px`;
     dropdownEl.style.display = 'block';
+    // Clamp left so the dropdown never overflows the right viewport edge on
+    // narrow phones — otherwise its content (e.g. the "POI" badge) gets clipped.
+    // Width is read after display so the measured value reflects the CSS bounds.
+    const maxLeft = window.innerWidth - dropdownEl.offsetWidth - 4;
+    dropdownEl.style.left = `${Math.max(4, Math.min(rect.left, maxLeft))}px`;
   }
 
   // Dropdown is dismissed only via the close button inside it.
@@ -236,86 +240,58 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
     if (marker) marker.setIcon(createActiveNumberedIcon(index + 1));
   }
 
-  // Event delegation on dropdown — expand/collapse on item click; navigate on "Go" button.
-  dropdownEl.addEventListener('click', (e: MouseEvent) => {
-    const clicked = e.target as HTMLElement;
+  // Selecting a result — via a list-row tap or a numbered-marker tap — flies the
+  // map to it and opens the shared geocode-bar bottom sheet (Drive/Bike/Walk +
+  // Start): the SAME sheet a dropped pin uses, so search and pin-drop share one
+  // obvious "Navigate" flow. Guidance starts from the sheet's Start button, not
+  // on selection, mirroring the pin-drop interaction.
+  function selectResultLi(li: HTMLElement): void {
+    const lat = parseFloat(li.dataset['lat'] ?? '');
+    const lng = parseFloat(li.dataset['lng'] ?? '');
+    if (isNaN(lat) || isNaN(lng)) return;
 
-    // "Navigate here" button — start routed guidance to the selected result
-    const navBtn = clicked.closest<HTMLElement>('.sheet-result__nav-btn');
-    if (navBtn) {
-      const li = navBtn.closest<HTMLElement>('.sheet-result[data-lat]');
-      if (li === null) return;
-      const lat = parseFloat(li.dataset['lat'] ?? '');
-      const lng = parseFloat(li.dataset['lng'] ?? '');
-      if (isNaN(lat) || isNaN(lng)) return;
-      const label = li.dataset['name'] ?? `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
-      // Dropdown is z-index 2000; close it before the guidance pill appears.
-      hideDropdown();
-      _showGeocodeBar?.(label, label, L.latLng(lat, lng));
-      void startGuidance(state, map, { lat, lng, label }, onNoResults);
-      return;
-    }
+    const resultName = li.dataset['name'] ?? '';
+    const coordText = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+    const label = resultName !== '' ? resultName : coordText;
+    const copyText = resultName !== '' ? `${resultName}\n${coordText}` : coordText;
 
-    // "Go to location" button — fly to the result and show geocode bar
-    const goBtn = clicked.closest<HTMLElement>('.sheet-result__go-btn');
-    if (goBtn) {
-      const li = goBtn.closest<HTMLElement>('.sheet-result[data-lat]');
-      if (li === null) return;
-      const lat = parseFloat(li.dataset['lat'] ?? '');
-      const lng = parseFloat(li.dataset['lng'] ?? '');
-      if (isNaN(lat) || isNaN(lng)) return;
-      _pinLayer?.clearLayers();
-      const resultName = li.dataset['name'] ?? '';
-      const coordText = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
-      const label = resultName !== '' ? resultName : coordText;
-      const copyText = resultName !== '' ? `${resultName}\n${coordText}` : coordText;
-      _showGeocodeBar?.(label, copyText, L.latLng(lat, lng));
-      clearSelection();
-      li.classList.add('sheet-result--active');
-      li.classList.remove('sheet-result--expanded');
-      const idx = parseInt(li.dataset['index'] ?? '', 10);
-      if (!isNaN(idx)) activateSelection(idx);
-      const boundsRaw = li.dataset['bounds'] ?? '';
-      if (boundsRaw !== '') {
-        try {
-          const parsed = JSON.parse(boundsRaw) as unknown;
-          if (Array.isArray(parsed) && parsed.length === 2 &&
-              Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
-            map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
-              paddingTopLeft:     [50, 50],
-              paddingBottomRight: [50, 50],
-              maxZoom: 17,
-            });
-          } else {
-            map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
-          }
-        } catch {
-          map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
+    // A dropped pin and a selected search result are mutually exclusive.
+    _pinLayer?.clearLayers();
+    clearSelection();
+    li.classList.add('sheet-result--active');
+    li.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    const idx = parseInt(li.dataset['index'] ?? '', 10);
+    if (!isNaN(idx)) activateSelection(idx);
+
+    // Fly to the result: prefer its ESRI extent, else a type-appropriate zoom.
+    const boundsRaw = li.dataset['bounds'] ?? '';
+    let flown = false;
+    if (boundsRaw !== '') {
+      try {
+        const parsed = JSON.parse(boundsRaw) as unknown;
+        if (Array.isArray(parsed) && parsed.length === 2 &&
+            Array.isArray(parsed[0]) && Array.isArray(parsed[1])) {
+          map.flyToBounds(L.latLngBounds(parsed as [[number, number], [number, number]]), {
+            paddingTopLeft:     [50, 50],
+            paddingBottomRight: [50, 50],
+            maxZoom: 17,
+          });
+          flown = true;
         }
-      } else {
-        map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
-      }
-      return;
+      } catch { /* fall through to point zoom */ }
+    }
+    if (!flown) {
+      map.flyTo(L.latLng(lat, lng), zoomForAddrType(li.dataset['addrType'] ?? ''));
     }
 
-    // Copy button inside expanded detail
-    const copyBtn = clicked.closest<HTMLElement>('.sheet-result__copy-btn');
-    if (copyBtn) {
-      const text = copyBtn.dataset['copy'] ?? '';
-      const origText = copyBtn.textContent;
-      navigator.clipboard.writeText(text).then(() => {
-        copyBtn.textContent = '\u2713 Copied';
-        setTimeout(() => { copyBtn.textContent = origText; }, 1500);
-      }).catch(() => { /* silent */ });
-      return;
-    }
+    _showGeocodeBar?.(label, copyText, L.latLng(lat, lng));
+  }
 
-    // Result item click — toggle expand/collapse
-    const li = clicked.closest<HTMLElement>('.sheet-result');
-    if (li === null) return;
-    const prev = dropdownEl.querySelector('.sheet-result--expanded');
-    if (prev && prev !== li) prev.classList.remove('sheet-result--expanded');
-    li.classList.toggle('sheet-result--expanded');
+  // Event delegation on dropdown — a tap anywhere on a result row selects it.
+  // The close button is handled by the dedicated listener registered earlier.
+  dropdownEl.addEventListener('click', (e: MouseEvent) => {
+    const li = (e.target as HTMLElement).closest<HTMLElement>('.sheet-result');
+    if (li) selectResultLi(li);
   });
 
   // Keep marker size in sync with map zoom level via CSS classes.
@@ -339,17 +315,11 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
           marker.on('click', (e: L.LeafletMouseEvent) => {
             // Stop propagation so the map click handler doesn't immediately re-hide the dropdown.
             L.DomEvent.stopPropagation(e);
-            clearSelection();
-            marker.setIcon(createActiveNumberedIcon(i + 1));
-            // Restore dropdown if the user had dismissed it.
+            // Restore the results list if it had been dismissed, then select.
+            // Tapping a marker behaves identically to tapping its list row.
             if (dropdownEl.innerHTML !== '') showDropdown();
-            // Clear any dropped pin.
-            _pinLayer?.clearLayers();
             const li = dropdownEl.querySelector<HTMLElement>(`.sheet-result[data-index="${i}"]`);
-            if (li) {
-              li.classList.add('sheet-result--active');
-              li.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-            }
+            if (li) selectResultLi(li);
           });
         }
       }
@@ -375,8 +345,6 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
             .join(', ');
           const tooltipParts = [name, subtitle, addrType, `${lat}, ${lng}`].filter(Boolean);
           const tooltip = escapeHtml(tooltipParts.join(' · '));
-          const longLabel = escapeHtml(strProp(r.properties?.LongLabel) || strProp(r.properties?.Match_addr) || r.text || '');
-          const coordStr = `${lat}, ${lng}`;
           return (
             `<li class="sheet-result" data-index="${i}" data-lat="${lat}" data-lng="${lng}"` +
             ` data-name="${escapeHtml(name)}" data-bounds="${escapeHtml(boundsJson)}" data-addr-type="${addrType}" title="${tooltip}">` +
@@ -387,19 +355,6 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
             `    </div>` +
             (addrType ? `    <span class="sheet-result__badge">${addrType}</span>` : '') +
             `    <span class="sheet-result__arrow">&#x203A;</span>` +
-            `  </div>` +
-            `  <div class="sheet-result__detail">` +
-            `    <div class="sheet-result__full-addr">${longLabel}</div>` +
-            `    <div class="sheet-result__detail-meta">` +
-            (addrType ? `      <span class="sheet-result__detail-badge">${addrType}</span>` : '') +
-            `      <span class="sheet-result__detail-coords">${coordStr}</span>` +
-            `    </div>` +
-            `    <div class="sheet-result__detail-actions">` +
-            `      <button class="sheet-result__nav-btn">Navigate here</button>` +
-            `      <button class="sheet-result__go-btn">Go to location</button>` +
-            `      <button class="sheet-result__copy-btn" data-copy="${longLabel}">Copy address</button>` +
-            `      <button class="sheet-result__copy-btn" data-copy="${escapeHtml(coordStr)}">Copy coords</button>` +
-            `    </div>` +
             `  </div>` +
             `</li>`
           );

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -16,13 +16,17 @@ export interface LayerDef {
   id: string;
   name: string;
   description: string;
-  tileLayer: L.TileLayer;
+  // L.Layer (not L.TileLayer) so a base map can be a composite L.LayerGroup
+  // — e.g. the 'Trails' layer (OSM base + Waymarked route overlays).
+  tileLayer: L.Layer;
 }
 
 export interface OverlayDef {
   id: string;
   name: string;
-  tileLayer: L.TileLayer;
+  // L.Layer (not L.TileLayer) so an overlay can be a composite L.LayerGroup —
+  // e.g. the 'Routes' overlay (Waymarked hiking + cycling route tiles).
+  tileLayer: L.Layer;
 }
 
 const LAYERS_STORAGE_KEY = 'webmap-layer-selection';

--- a/src/location.ts
+++ b/src/location.ts
@@ -78,9 +78,12 @@ export function onLocationFound(e: L.LocationEvent, state: AppState, map: L.Map)
     e.latlng.lat, e.latlng.lng,
   );
 
-  // On first GPS fix, zoom to street level (defer if screen is off)
+  // On first GPS fix, recenter at neighborhood zoom (defer if screen is off).
+  // setView (not setZoom) guarantees the map jumps from the world-view
+  // placeholder straight to the user's location even when not actively
+  // following, so "geolocate on load" lands at ~zoom 14 rather than world view.
   if (state.initialZoom && !state.screenOff) {
-    map.setZoom(16);
+    map.setView(e.latlng, 14);
     state.initialZoom = false;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,20 @@ const map = createMap();
 // within 3s of the error, the error was spurious and we discard it.
 let permissionDeniedTimer: ReturnType<typeof setTimeout> | undefined;
 
+// Gates the GPS-status toast so it shows at most once per loss/acquisition
+// episode rather than on every error tick. Reset to false on the next fix.
+let gpsToastShown = false;
+
+// Desktop acquisition guidance is deferred behind this timer: kCLErrorLocationUnknown
+// (POSITION_UNAVAILABLE) is frequently transient, so wait for a grace period of
+// continued failure before showing the (sticky) "enable Location Services" help.
+let gpsHelpTimer: ReturnType<typeof setTimeout> | undefined;
+
+// Hide the shared locate toast (clears a stale GPS message once a fix arrives).
+function hideToast(): void {
+  document.getElementById('locate-toast')?.classList.remove('visible');
+}
+
 function cancelPermissionDeniedTimer(): void {
   if (permissionDeniedTimer !== undefined) {
     clearTimeout(permissionDeniedTimer);
@@ -88,6 +102,9 @@ function cancelPermissionDeniedTimer(): void {
 
 map.on('locationfound', (e: L.LocationEvent) => {
   cancelPermissionDeniedTimer();
+  if (gpsHelpTimer !== undefined) { clearTimeout(gpsHelpTimer); gpsHelpTimer = undefined; }
+  gpsToastShown = false; // signal recovered — allow a future loss to toast again
+  hideToast();           // clear any "looking for GPS" / "signal lost" message
   onLocationFound(e, state, map);
 });
 map.on('locationerror', (e: L.ErrorEvent) => {
@@ -100,7 +117,12 @@ map.on('locationerror', (e: L.ErrorEvent) => {
     permissionDeniedTimer = setTimeout(() => {
       permissionDeniedTimer = undefined;
       if (state.locateState === 'off') return; // already handled
-      showToast('Location access is denied. On iPhone: Settings > Privacy & Security > Location Services > Safari Websites > Allow', 0);
+      showToast(
+        /iPhone|iPad|iPod/.test(navigator.userAgent)
+          ? 'Location access is denied. On iPhone: Settings > Privacy & Security > Location Services > Safari Websites > Allow'
+          : 'Location access is blocked. Click the location (or site-info) icon in your browser’s address bar and set Location to Allow, then reload.',
+        0,
+      );
       state.locateState = 'off';
       // Force-stop ALL watching regardless of refcount.
       state.updateCallback = 0;
@@ -111,7 +133,34 @@ map.on('locationerror', (e: L.ErrorEvent) => {
     return;
   }
   onLocationError(state);
-  showToast('GPS signal lost');
+  if (state.locateState === 'off') return;
+
+  if (state.locationMarker !== null) {
+    // Already had a fix — a transient drop. One gentle toast per episode.
+    if (!gpsToastShown) { gpsToastShown = true; showToast('GPS signal lost'); }
+    return;
+  }
+
+  // Still acquiring (no fix yet).
+  if (/iPhone|iPad|iPod|Android/.test(navigator.userAgent)) {
+    if (!gpsToastShown) { gpsToastShown = true; showToast('Looking for GPS signal…'); }
+    return;
+  }
+
+  // Desktop: POSITION_UNAVAILABLE (e.g. macOS kCLErrorLocationUnknown) is often
+  // transient, so defer the sticky help until it persists. locationfound clears
+  // this timer, so a quick recovery never nags.
+  if (gpsHelpTimer === undefined) {
+    gpsHelpTimer = setTimeout(() => {
+      gpsHelpTimer = undefined;
+      if (state.locationMarker !== null || state.locateState === 'off') return;
+      showToast(
+        'Can’t determine your location. Enable Location Services for your browser ' +
+        '(Mac: System Settings → Privacy & Security → Location Services), then fully quit and reopen it.',
+        0,
+      );
+    }, 12000);
+  }
 });
 
 // Polling refcount helpers — shared by locate and recording
@@ -181,6 +230,11 @@ function showToast(message: string, durationMs = 3000): void {
 
 function startLocating(): void {
   state.locateState = 'active';
+  // Zoom to the user on the next fix. Set on every off → active activation
+  // (not just the session's first fix) so tapping locate always frames the
+  // user at neighborhood zoom. passive → active uses reactivateLocate(), which
+  // intentionally preserves the current zoom instead.
+  state.initialZoom = true;
   activatePolling();
   updateLocateIcon('active');
 }
@@ -268,22 +322,22 @@ const tileLayers = getTileLayers();
 
 const layerDefs: LayerDef[] = [
   {
-    id: 'cyclosm',
-    name: 'Trails',
-    description: 'Emphasizes hiking and cycling routes',
-    tileLayer: tileLayers.cyclosmLayer,
+    id: 'cycle',
+    name: 'Cycle',
+    description: 'Bike routes & cycling map (OpenCycleMap)',
+    tileLayer: tileLayers.cycleLayer,
+  },
+  {
+    id: 'outdoors',
+    name: 'Outdoors',
+    description: 'Hiking trails & terrain',
+    tileLayer: tileLayers.outdoorsLayer,
   },
   {
     id: 'osm-streets',
     name: 'Streets',
     description: 'Street map with roads and labels',
     tileLayer: tileLayers.osmStreetsLayer,
-  },
-  {
-    id: 'topo',
-    name: 'Topographic',
-    description: 'Contour lines and hillshade',
-    tileLayer: tileLayers.opentopoLayer,
   },
   {
     id: 'parks',
@@ -299,9 +353,14 @@ const overlayDefs: OverlayDef[] = [
     name: 'Hillshade',
     tileLayer: tileLayers.hillshadeLayer,
   },
+  {
+    id: 'routes',
+    name: 'Routes (hiking & cycling)',
+    tileLayer: tileLayers.routesLayer,
+  },
 ];
 
-addLayersControl(map, layerDefs, overlayDefs, ['hillshade']);
+addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'routes']);
 
 initInfoPanel(map);
 addOfflineDownloadControl(map, showToast);

--- a/src/map.ts
+++ b/src/map.ts
@@ -9,10 +9,11 @@ import { OSM_TILE_CACHE_NAME } from './sw-constants';
 
 // Module-level tile layer refs — set during createMap(), read by initOfflineTileFallback()
 let osmStreetsLayer: L.TileLayer | null = null;
-let cyclosmLayer: L.TileLayer | null = null;
-let opentopoLayer: L.TileLayer | null = null;
+let cycleLayer: L.TileLayer | null = null;
+let outdoorsLayer: L.TileLayer | null = null;
 let humanitarianLayer: L.TileLayer | null = null;
 let hillshadeLayer: L.TileLayer | null = null;
+let routesLayer: L.LayerGroup | null = null;
 // Tile error event shape (Leaflet fires this on tileerror but @types/leaflet may not expose it fully)
 interface TileErrorEvent extends L.LeafletEvent {
   tile: HTMLImageElement;
@@ -21,7 +22,7 @@ interface TileErrorEvent extends L.LeafletEvent {
 }
 
 // Single cooldown shared across all layers — intentional: one toast per 10 s regardless
-// of which layer fired, so a Mapbox error followed immediately by an OSM error doesn't
+// of which layer fired, so a Thunderforest error followed immediately by an OSM error doesn't
 // show two toasts. The per-layer message is set when the cooldown first trips.
 let tileWarnCooldown = false;
 
@@ -31,12 +32,12 @@ let osmCachePromise: Promise<Cache> | null = null;
 /** Wire up offline tile warnings and canvas-based lower-zoom fallback.
  *  Must be called after createMap(). Attaches tileerror handlers to all tile layers.
  *  Only the OSM layer (cached by the service worker) attempts canvas fallback;
- *  Mapbox/Google layers show the warning but serve no fallback (not SW-cached).
+ *  Non-OSM layers (Thunderforest, Esri) show the warning but serve no fallback (not SW-cached).
  */
 export function initOfflineTileFallback(
   showToast: (msg: string, durationMs?: number) => void,
 ): void {
-  const layers = [osmStreetsLayer, cyclosmLayer, opentopoLayer, humanitarianLayer, hillshadeLayer].filter(
+  const layers = [osmStreetsLayer, cycleLayer, outdoorsLayer, humanitarianLayer, hillshadeLayer].filter(
     (l): l is L.TileLayer => l !== null,
   );
   if (layers.length === 0) {
@@ -204,22 +205,41 @@ export function createMap(): L.Map {
     },
   );
 
-  cyclosmLayer = L.tileLayer(
-    'https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
+  // Thunderforest trail bases (free API key in VITE_THUNDERFOREST_TOKEN). Two
+  // dedicated, reliable trail-styled bases: Cycle (OpenCycleMap — bike routes &
+  // infrastructure) and Outdoors (hiking trails + terrain). The key is a public
+  // client-side token; referrer-restrict it to the deploy origin in the
+  // Thunderforest dashboard. Without a key these layers return error tiles.
+  const tfKey = import.meta.env.VITE_THUNDERFOREST_TOKEN ?? '';
+  const tfAttribution = '© Thunderforest, © OpenStreetMap contributors';
+  cycleLayer = L.tileLayer(
+    'https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + tfKey,
     {
-      attribution: '© OpenStreetMap contributors, Carto',
+      attribution: tfAttribution,
+      ...stdConfig,
+    },
+  );
+  outdoorsLayer = L.tileLayer(
+    'https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey=' + tfKey,
+    {
+      attribution: tfAttribution,
       ...stdConfig,
     },
   );
 
-  opentopoLayer = L.tileLayer(
-    'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
-    {
-      attribution: '© OpenStreetMap contributors, Carto',
-      ...stdConfig,
-      maxNativeZoom: 17,
-    },
+  // Waymarked hiking + cycling route highlights — transparent overlays exposed
+  // as ONE toggleable "Routes" overlay (like Hillshade) that composes over any
+  // base. Kept out of the base layer so a route-tile failure can never blank the
+  // map. Share stdConfig geometry so routes scale 1:1 with the base.
+  const hikingRoutes = L.tileLayer(
+    'https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png',
+    { attribution: '© waymarkedtrails.org', ...stdConfig },
   );
+  const cyclingRoutes = L.tileLayer(
+    'https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png',
+    { attribution: '© waymarkedtrails.org', ...stdConfig },
+  );
+  routesLayer = L.layerGroup([hikingRoutes, cyclingRoutes]);
 
   humanitarianLayer = L.tileLayer(
     'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
@@ -251,19 +271,21 @@ export function createMap(): L.Map {
 
 export function getTileLayers(): {
   osmStreetsLayer: L.TileLayer;
-  cyclosmLayer: L.TileLayer;
-  opentopoLayer: L.TileLayer;
+  cycleLayer: L.TileLayer;
+  outdoorsLayer: L.TileLayer;
   humanitarianLayer: L.TileLayer;
   hillshadeLayer: L.TileLayer;
+  routesLayer: L.LayerGroup;
 } {
-  if (!osmStreetsLayer || !cyclosmLayer || !opentopoLayer || !humanitarianLayer || !hillshadeLayer) {
+  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !hillshadeLayer || !routesLayer) {
     throw new Error('Tile layers not initialized — call createMap() first');
   }
   return {
     osmStreetsLayer,
-    cyclosmLayer,
-    opentopoLayer,
+    cycleLayer,
+    outdoorsLayer,
     humanitarianLayer,
     hillshadeLayer,
+    routesLayer,
   };
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -30,7 +30,9 @@ let tileWarnCooldown = false;
 let osmCachePromise: Promise<Cache> | null = null;
 
 /** Wire up offline tile warnings and canvas-based lower-zoom fallback.
- *  Must be called after createMap(). Attaches tileerror handlers to all tile layers.
+ *  Must be called after createMap(). Attaches tileerror handlers to the base/overlay
+ *  tile layers; the Routes overlay (a LayerGroup) is intentionally excluded — its
+ *  Waymarked tiles aren't SW-cached, so a fallback/warning would be moot.
  *  Only the OSM layer (cached by the service worker) attempts canvas fallback;
  *  Non-OSM layers (Thunderforest, Esri) show the warning but serve no fallback (not SW-cached).
  */
@@ -211,7 +213,14 @@ export function createMap(): L.Map {
   // client-side token; referrer-restrict it to the deploy origin in the
   // Thunderforest dashboard. Without a key these layers return error tiles.
   const tfKey = import.meta.env.VITE_THUNDERFOREST_TOKEN ?? '';
-  const tfAttribution = '© Thunderforest, © OpenStreetMap contributors';
+  if (!tfKey) {
+    console.warn(
+      'VITE_THUNDERFOREST_TOKEN is not set — the Cycle/Outdoors trail bases will ' +
+      'return error tiles. Set it in your .env file.',
+    );
+  }
+  // Thunderforest terms require crediting both the map style and the OSM data (ODbL).
+  const tfAttribution = 'Maps © Thunderforest, Data © OpenStreetMap contributors';
   cycleLayer = L.tileLayer(
     'https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + tfKey,
     {

--- a/src/offline-download.ts
+++ b/src/offline-download.ts
@@ -2,7 +2,7 @@
  * Intent: Region pre-download for offline tile coverage — lets users select a bounding box and zoom range to pre-cache tiles
  * Context: Existing offline strategy caches only previously-viewed tiles; this adds proactive bulk caching via the Cache API
  * Pattern: User selects region via draggable rectangle + zoom slider, estimates tile count, then fetches/caches tiles in background chunks
- * Future: Only caches OSM tiles (the SW-cached layer); Mapbox/Google layers are not cached and won't benefit from pre-download
+ * Future: Only caches OSM tiles (the SW-cached layer); non-OSM layers (Thunderforest, Esri) are not cached and won't benefit from pre-download
  */
 import L from 'leaflet';
 import { setupCollapsibleLabel } from './controls';

--- a/src/style.css
+++ b/src/style.css
@@ -300,14 +300,14 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 /* Geocode-bar Navigate button (sits next to Copy in the bottom sheet) */
 .geocode-bar__nav {
-  flex: none;
+  flex: 1 1 120px;
   background: #22c55e;
   color: #fff;
   border: none;
-  border-radius: 4px;
-  padding: 3px 9px;
-  font-size: 12px;
-  font-weight: 500;
+  border-radius: 6px;
+  padding: 9px 16px;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
 }
@@ -322,23 +322,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .geocode-bar__nav--stop:hover {
   background: #dc2626;
-}
-
-/* Search-result Navigate button — green primary, sits before the Go button */
-.sheet-result__nav-btn {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
-  background: #22c55e;
-  color: #fff;
-}
-
-.sheet-result__nav-btn:hover {
-  background: #16a34a;
 }
 
 /* ── Locate-button passive-state pulse animation ────────────────────────────
@@ -502,6 +485,9 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .sheet-result__name {
   font-size: 14px;
   color: #333;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sheet-result__subtitle {
@@ -541,101 +527,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   padding-left: calc(12px - 3px); /* compensate for border */
 }
 
-/* ── Expandable result detail (tap-to-preview on mobile) ── */
 .sheet-result__summary {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.sheet-result__detail {
-  max-height: 0;
-  overflow: hidden;
-  opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.2s ease;
-  width: 100%;
-}
-
-.sheet-result--expanded .sheet-result__detail {
-  max-height: 300px;
-  opacity: 1;
-}
-
-.sheet-result--expanded .sheet-result__arrow {
-  transform: rotate(90deg);
-}
-
-.sheet-result__full-addr {
-  font-size: 13px;
-  color: #444;
-  margin-top: 8px;
-  line-height: 1.4;
-}
-
-.sheet-result__detail-meta {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 6px;
-}
-
-.sheet-result__detail-badge {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: #e8f0fe;
-  color: #4a90d9;
-  white-space: nowrap;
-}
-
-.sheet-result__detail-coords {
-  font-size: 11px;
-  color: #888;
-  font-family: monospace;
-}
-
-.sheet-result__detail-actions {
-  display: flex;
-  gap: 8px;
-  margin-top: 10px;
-}
-
-.sheet-result__go-btn,
-.sheet-result__copy-btn {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.sheet-result__go-btn {
-  background: #4a90d9;
-  color: #fff;
-}
-
-.sheet-result__go-btn:hover {
-  background: #3d82c4;
-}
-
-.sheet-result__go-btn:active {
-  background: #3a7bc8;
-}
-
-.sheet-result__copy-btn {
-  background: #f0f0f0;
-  color: #444;
-}
-
-.sheet-result__copy-btn:hover {
-  background: #e8e8e8;
-}
-
-.sheet-result__copy-btn:active {
-  background: #e0e0e0;
+  width: 100%;
 }
 
 /* ── Reverse geocode bottom sheet ── */

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface AppState {
 
   // Watch/polling state
   updateCallback: number; // refcount: 0=stopped; each consumer (locate, future guidance) adds 1
-  initialZoom: boolean; // true until first GPS fix; zooms to level 16 on first fix
+  initialZoom: boolean; // when true, the next GPS fix recenters at zoom 14; set on load and on each locate activation
 
   // Persistent location marker refs (updated in place instead of adding new layers)
   locationMarker: L.Marker | null;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,8 +9,8 @@ declare module '*.md?raw' {
 declare const __APP_VERSION__: string;
 
 interface ImportMetaEnv {
-  readonly VITE_MAPBOX_TOKEN: string;
   readonly VITE_ESRI_API_KEY: string;
+  readonly VITE_THUNDERFOREST_TOKEN: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,7 +74,11 @@ export default defineConfig({
         navigateFallback: null,
       },
       devOptions: {
-        enabled: true,
+        // Disabled in dev: the precaching service worker served stale bundles
+        // during development, masking source changes (e.g. base-map and search
+        // edits appeared to "not take effect"). Production SW is unaffected.
+        // Re-enable temporarily only when specifically testing PWA/offline.
+        enabled: false,
       },
     }),
   ],


### PR DESCRIPTION
Closes #194

## Summary
Unifies the search → navigation flow with the pin-drop bottom sheet, replaces the unreliable CyclOSM trail base with dedicated Thunderforest bases, decouples route highlights into a composable overlay, and fixes a batch of GPS/PWA/config papercuts.

## Changes
**Search**
- Tap a result row (or its numbered marker) → fly to it + open the same bottom sheet used for dropped pins (Drive/Bike/Walk + Start). One unified destination flow.
- Fix result-text clipping ("POI" → "PO"): ellipsis on `.sheet-result__name`, gap layout, dropdown viewport clamp.
- Remove ~150 lines of dead accordion code/CSS.

**Map layers**
- Replace CyclOSM with two Thunderforest bases — **Cycle** (OpenCycleMap, default) and **Outdoors** — via `VITE_THUNDERFOREST_TOKEN`.
- Decouple Waymarked hiking/cycling routes into a toggleable **Routes** overlay (default-on, like Hillshade) that composes over any base.
- Drop the redundant standalone Topographic base; unify tile geometry so overlays scale 1:1 at every zoom.

**Location / GPS**
- First fix + every locate activation recenter at zoom 14 (`setView`).
- Debounce GPS status toast (one per episode, auto-dismiss on recovery), platform-aware messaging + grace period for transient macOS `kCLErrorLocationUnknown`; platform-aware permission-denied guidance.

**PWA**
- Disable dev service worker (`devOptions.enabled:false`) — was serving stale bundles in dev.
- Remove duplicate hardcoded manifest link in `index.html` → fixes the manifest syntax error.

**Config / docs**
- Wire `VITE_THUNDERFOREST_TOKEN` (`vite-env.d.ts`, `.env.example`, `deploy.yml`); remove unused `VITE_MAPBOX_TOKEN`; refresh stale Mapbox mentions in SECURITY.md + comments (historical CHANGELOG/ADR left intact); gitignore dev-dist/, clones/, logs/, *.log.

## Test plan
- `npm run type-check`, `npm run lint`, `npm test` (103/103), `npm run build` — all green.
- Verified Thunderforest Cycle/Outdoors tiles return 200; key embeds in the production bundle.
- Manual: search → tap result → bottom sheet + Start; Cycle default base with Hillshade+Routes; locate recenters at z14; single valid manifest link in dist.

## Assumptions
- `VITE_THUNDERFOREST_TOKEN` GitHub Actions secret has been added for production deploys (it has). Free tier 150k tiles/mo, shared; key should be referrer-restricted to webmap.dev.
- Dropping the standalone Topographic base is acceptable (OpenTopoMap-style terrain is covered by Outdoors; routes are now a separate overlay).
- Removing the dev SW is dev-only; production SW behavior is unchanged.