### PR TITLE
feat(maps): split Routes overlay into Hiking and Cycling toggles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -353,13 +353,18 @@ const overlayDefs: OverlayDef[] = [
     tileLayer: tileLayers.hillshadeLayer,
   },
   {
-    id: 'routes',
-    name: 'Routes (hiking & cycling)',
-    tileLayer: tileLayers.routesLayer,
+    id: 'hiking-routes',
+    name: 'Hiking routes',
+    tileLayer: tileLayers.hikingLayer,
+  },
+  {
+    id: 'cycling-routes',
+    name: 'Cycling routes',
+    tileLayer: tileLayers.cyclingLayer,
   },
 ];
 
-addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'routes']);
+addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'hiking-routes', 'cycling-routes']);
 
 addOfflineDownloadControl(map, showToast);
 addSearchControl(map, state, showToast);

--- a/src/map.ts
+++ b/src/map.ts
@@ -13,7 +13,8 @@ let cycleLayer: L.TileLayer | null = null;
 let outdoorsLayer: L.TileLayer | null = null;
 let humanitarianLayer: L.TileLayer | null = null;
 let hillshadeLayer: L.TileLayer | null = null;
-let routesLayer: L.LayerGroup | null = null;
+let hikingLayer: L.TileLayer | null = null;
+let cyclingLayer: L.TileLayer | null = null;
 // Tile error event shape (Leaflet fires this on tileerror but @types/leaflet may not expose it fully)
 interface TileErrorEvent extends L.LeafletEvent {
   tile: HTMLImageElement;
@@ -236,19 +237,20 @@ export function createMap(): L.Map {
     },
   );
 
-  // Waymarked hiking + cycling route highlights — transparent overlays exposed
-  // as ONE toggleable "Routes" overlay (like Hillshade) that composes over any
-  // base. Kept out of the base layer so a route-tile failure can never blank the
-  // map. Share stdConfig geometry so routes scale 1:1 with the base.
-  const hikingRoutes = L.tileLayer(
+  // Waymarked route highlights — transparent overlays that compose over any base.
+  // Exposed as TWO independent toggles (Hiking routes / Cycling routes) rather
+  // than one combined layer: Waymarked colors routes by network hierarchy, not by
+  // activity, so the only way to see hiking-only segments is to switch cycling off.
+  // Kept out of the base layer so a route-tile failure can never blank the map;
+  // share stdConfig geometry so routes scale 1:1 with the base.
+  hikingLayer = L.tileLayer(
     'https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png',
     { attribution: '© waymarkedtrails.org', ...stdConfig },
   );
-  const cyclingRoutes = L.tileLayer(
+  cyclingLayer = L.tileLayer(
     'https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png',
     { attribution: '© waymarkedtrails.org', ...stdConfig },
   );
-  routesLayer = L.layerGroup([hikingRoutes, cyclingRoutes]);
 
   humanitarianLayer = L.tileLayer(
     'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
@@ -284,9 +286,10 @@ export function getTileLayers(): {
   outdoorsLayer: L.TileLayer;
   humanitarianLayer: L.TileLayer;
   hillshadeLayer: L.TileLayer;
-  routesLayer: L.LayerGroup;
+  hikingLayer: L.TileLayer;
+  cyclingLayer: L.TileLayer;
 } {
-  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !hillshadeLayer || !routesLayer) {
+  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !hillshadeLayer || !hikingLayer || !cyclingLayer) {
     throw new Error('Tile layers not initialized — call createMap() first');
   }
   return {
@@ -295,6 +298,7 @@ export function getTileLayers(): {
     outdoorsLayer,
     humanitarianLayer,
     hillshadeLayer,
-    routesLayer,
+    hikingLayer,
+    cyclingLayer,
   };
 }


### PR DESCRIPTION
Closes #201

## Summary
The combined Routes overlay can't show which segments are hiking-only, because Waymarked colors routes by network hierarchy (intl=red, national=blue, …), not by activity. Split into two independent, default-on overlays — **Hiking routes** and **Cycling routes** — so disabling cycling reveals hiking-only segments (the OsmAnd/Gaia GPS pattern).

## Changes
- `src/map.ts`: replace `routesLayer` (`L.layerGroup`) with separate `hikingLayer` + `cyclingLayer` tile layers; update `getTileLayers()`.
- `src/main.ts`: replace the `routes` overlayDef with `hiking-routes` + `cycling-routes`; default all of `['hillshade','hiking-routes','cycling-routes']` on.
- No `layers-control.ts` change (already supports multiple `L.Layer` overlays).

## Migration
The old `'routes'` overlay id in localStorage no longer matches; `loadPersistedSelection` falls back to the defaults, so existing users get both route overlays on (≈ prior behavior).

## Test plan
- type-check / lint / test (96/96), build, size (104.38 kB < 108) all green.
- Manual: layers popover shows independent Hiking/Cycling toggles; disabling Cycling leaves only hiking routes.