### PR TITLE
fix(pwa): eliminate blank page on first load after a deploy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ if (!hasConsent()) {
   // IIFE that delays the rest of init until consent is granted.  The import
   // side-effects above (CSS, Leaflet icon config) are harmless before consent.
   void waitForConsent()
-    .then(() => initApp())
+    .then(() => bootApp())
     .catch((err: unknown) => {
       console.error('[webmap] consent flow failed', err);
       // Only reload if consent wasn't recorded yet — avoids a reload loop if
@@ -56,7 +56,27 @@ if (!hasConsent()) {
       }
     });
 } else {
-  initApp();
+  bootApp();
+}
+
+// Run initApp with a one-shot self-heal: if initialization throws (e.g. a stale
+// service worker serving a shell/chunk hash mismatch right after a deploy),
+// reload once to pick up a consistent asset set rather than leaving a blank
+// page that the user has to reload manually. The sessionStorage guard prevents
+// a reload loop if the failure is persistent (then the error surfaces instead).
+function bootApp(): void {
+  try {
+    initApp();
+    try { sessionStorage.removeItem('webmap-boot-retry'); } catch { /* sessionStorage unavailable */ }
+  } catch (err: unknown) {
+    console.error('[webmap] app initialization failed', err);
+    let retried = false;
+    try { retried = sessionStorage.getItem('webmap-boot-retry') === '1'; } catch { /* ignore */ }
+    if (!retried) {
+      try { sessionStorage.setItem('webmap-boot-retry', '1'); } catch { /* ignore */ }
+      location.reload();
+    }
+  }
 }
 
 function initApp(): void {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,9 @@ export default defineConfig({
         // Without this, onNeedRefresh sends SKIP_WAITING but the page never reloads
         // automatically — users see a blank/stale page until they manually refresh.
         clientsClaim: true,
+        // Drop precache entries from older SW generations on activate, so a stale
+        // index referencing chunks that no longer exist can't be served.
+        cleanupOutdatedCaches: true,
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
@@ -71,7 +74,12 @@ export default defineConfig({
             handler: 'NetworkOnly',
           },
         ],
-        navigateFallback: null,
+        // Serve the precached app shell for navigation requests. With null, a
+        // returning user after a deploy could get a shell/chunk hash mismatch
+        // (old SW serving an index whose hashed JS is no longer in its precache),
+        // blanking the page until a manual reload. 'index.html' guarantees the
+        // navigation is answered from one consistent precache generation.
+        navigateFallback: 'index.html',
       },
       devOptions: {
         // Disabled in dev: the precaching service worker served stale bundles


### PR DESCRIPTION
Closes #203

## Summary
Returning users (previous SW cached) got a **blank white page** on first load after a deploy until a manual reload. Root cause: `workbox.navigateFallback: null` — a navigation could be answered with a shell/chunk hash mismatch (old SW serving an index referencing JS chunks no longer in its precache). The earlier fix (#192) only gated update-reload *timing*, never app-shell serving, so this class of blank persisted.

## Changes
- `vite.config.ts`: `workbox.navigateFallback: 'index.html'` — answer navigations from one consistent precache generation; `workbox.cleanupOutdatedCaches: true` — drop stale precache entries on activate.
- `src/main.ts`: wrap `initApp()` in `bootApp()` — a one-shot, sessionStorage-guarded self-heal that reloads once if init throws, instead of leaving a blank page.

## Test plan
- type-check / lint / test (96/96), build, size (104.42 kB < 108) green.
- Verified `dist/sw.js` now includes `cleanupOutdatedCaches` and `createHandlerBoundToURL` (the navigateFallback route).

## Caveat
iOS Safari can't be reproduced locally; this is a high-confidence config fix (the canonical Workbox SPA pattern, which the prior timing-only fix missed) plus a self-heal safety net. Needs on-device confirmation after deploy.

## Assumptions
- index.html is in the precache manifest (vite-plugin-pwa precaches it by default), so `navigateFallback: 'index.html'` resolves.
- The self-heal guard (sessionStorage `webmap-boot-retry`) prevents reload loops on persistent failures.