### PR TITLE
fix(pwa): inline boot-watchdog to auto-recover from a blank page on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,31 @@
        a second link duplicates it in the build, and in dev (SW disabled) it
        404s to the HTML fallback, which the browser reports as a manifest
        "Line 1, column 1, Syntax error". -->
+
+  <!-- Boot watchdog: runs independently of the JS bundle. If the bundle never
+       executes (e.g. a stale service worker serves an index whose hashed JS
+       404s → blank page), main.ts can't call __webmapBootOk(), so this reloads
+       the page once to fetch a consistent asset set — automating the manual
+       reload that would otherwise be required. One-shot, sessionStorage-guarded
+       against reload loops on a persistent failure. -->
+  <script>
+    (function () {
+      var KEY = 'webmap-boot-watchdog';
+      var timer;
+      // main.ts calls this as its first statement (the bundle is executing).
+      window.__webmapBootOk = function () {
+        if (timer) { clearTimeout(timer); }
+        try { sessionStorage.removeItem(KEY); } catch (e) { /* unavailable */ }
+      };
+      var reloadedOnce;
+      try { reloadedOnce = sessionStorage.getItem(KEY) === '1'; } catch (e) { reloadedOnce = false; }
+      if (reloadedOnce) { return; } // already reloaded once this session — don't loop
+      timer = setTimeout(function () {
+        try { sessionStorage.setItem(KEY, '1'); } catch (e) { /* unavailable */ }
+        location.reload();
+      }, 10000);
+    })();
+  </script>
 </head>
 <body>
   <div id="map"></div>

--- a/index.html
+++ b/index.html
@@ -29,13 +29,12 @@
        404s to the HTML fallback, which the browser reports as a manifest
        "Line 1, column 1, Syntax error". -->
 
-  <!-- Boot watchdog: runs independently of the JS bundle. If the bundle never
-       executes (e.g. a stale service worker serves an index whose hashed JS
-       404s → blank page), main.ts can't call __webmapBootOk(), so this reloads
-       the page once to fetch a consistent asset set — automating the manual
-       reload that would otherwise be required. One-shot, sessionStorage-guarded
-       against reload loops on a persistent failure. -->
+  <!-- Boot watchdog: if the JS bundle never executes (stale SW serving an index
+       whose hashed JS 404s → blank page), main.ts can't call __webmapBootOk(),
+       so this reloads once. One-shot, sessionStorage-guarded against loops. -->
   <script>
+    /* var (not let/const) is intentional — broadest browser support so recovery
+       never breaks on an old engine. */
     (function () {
       var KEY = 'webmap-boot-watchdog';
       var timer;
@@ -48,9 +47,12 @@
       try { reloadedOnce = sessionStorage.getItem(KEY) === '1'; } catch (e) { reloadedOnce = false; }
       if (reloadedOnce) { return; } // already reloaded once this session — don't loop
       timer = setTimeout(function () {
-        try { sessionStorage.setItem(KEY, '1'); } catch (e) { /* unavailable */ }
-        location.reload();
-      }, 10000);
+        // Only reload if we can persist the one-shot guard; otherwise (e.g. Safari
+        // private mode with storage full) skip it so we can't loop unbounded.
+        var persisted = false;
+        try { sessionStorage.setItem(KEY, '1'); persisted = true; } catch (e) { persisted = false; }
+        if (persisted) { location.reload(); }
+      }, 3000);
     })();
   </script>
 </head>

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,12 @@ import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
 import { scheduleSwUpdate } from './sw-update';
 
+// Tell the index.html boot-watchdog the bundle loaded and is executing, so it
+// cancels its reload timer. If the bundle ever fails to load (a stale service
+// worker serving a 404'd chunk → blank page), this line never runs and the
+// watchdog reloads once to recover.
+(window as unknown as { __webmapBootOk?: () => void }).__webmapBootOk?.();
+
 // ── Consent gate — block all interaction until terms are accepted ─────────────
 if (!hasConsent()) {
   // Show modal immediately; re-show on decline (user cannot bypass)

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import { scheduleSwUpdate } from './sw-update';
 // cancels its reload timer. If the bundle ever fails to load (a stale service
 // worker serving a 404'd chunk → blank page), this line never runs and the
 // watchdog reloads once to recover.
-(window as unknown as { __webmapBootOk?: () => void }).__webmapBootOk?.();
+window.__webmapBootOk?.();
 
 // ── Consent gate — block all interaction until terms are accepted ─────────────
 if (!hasConsent()) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,12 @@ declare module '*.md?raw' {
 
 declare const __APP_VERSION__: string;
 
+interface Window {
+  /** Defined by the index.html boot-watchdog; main.ts calls it once the bundle
+   *  executes, cancelling the watchdog's reload timer. */
+  __webmapBootOk?: () => void;
+}
+
 interface ImportMetaEnv {
   readonly VITE_ESRI_API_KEY: string;
   readonly VITE_THUNDERFOREST_TOKEN: string;


### PR DESCRIPTION
Closes #205

## Summary
Escalation after #204: the blank page on iOS persisted. `navigateFallback` can't help when a stale SW serves an index whose hashed JS chunk **404s** — the bundle never executes, so `bootApp()` and all in-bundle recovery never run.

## Change
- `index.html`: a tiny inline `<script>` (independent of the bundle). It arms a 10s timer; `main.ts` calls `window.__webmapBootOk()` as its first executable statement to cancel it. If the bundle never runs, the timer fires and reloads **once** (sessionStorage-guarded against loops).
- `src/main.ts`: the `__webmapBootOk()` call at module top.

## Why signal at module-top (not after init)
The failure is 'the bundle never executed' (chunk 404). Signaling the moment main.ts runs means a slow consent screen or slow init never false-triggers a reload — the watchdog only fires when JS truly didn't load. `bootApp()` (from #204) still separately handles a *throw inside* init.

## Test plan
- type-check / lint / test (96/96), build, size (104.65 kB < 108) green.
- Verified the inline watchdog is present in `dist/index.html` and `__webmapBootOk()` is called in the bundle.

## Caveat
Can't repro iOS locally; needs on-device confirmation post-deploy. This is the belt-and-suspenders that recovers regardless of root cause.