### PR TITLE
fix(nginx): serve /sw.js no-cache so service-worker updates are discovered

### DIFF
--- a/infrastructure/nginx/www.webmap.dev.conf
+++ b/infrastructure/nginx/www.webmap.dev.conf
@@ -67,6 +67,18 @@ server {
     gzip_proxied any;
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml+rss application/atom+xml image/svg+xml;
 
+    # Service worker: NEVER cache. /sw.js has a stable (unhashed) name, so it must
+    # be revalidated on every visit for a new deploy's service worker to be
+    # discovered. Without this exact-match override, the generic immutable .js rule
+    # below pins /sw.js for a year and clients get stuck on a stale service worker
+    # — which keeps serving a stale app shell (blank page / no updates). An exact
+    # `location =` match takes priority over the regex location, so this wins.
+    location = /sw.js {
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header X-Content-Type-Options nosniff always;
+    }
+
     # Hashed assets: long TTL (Vite appends content hash to filenames)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
Closes #209

## Root cause (of the entire blank-page saga)
The nginx rule `location ~* \.(js|...)$ { expires 1y; Cache-Control: public, immutable; }` matched **/sw.js** (unhashed, stable name), pinning the **service worker** for a year. Browsers/proxies never re-fetched it → the new SW was never discovered → clients stuck on the old SW serving a stale app shell. Verified: `curl -sI .../sw.js` → `cache-control: max-age=31536000, public, immutable`.

This is why mobile Edge kept blanking with **no diagnostic** (it never loaded the new index), while Chrome/Safari/desktop — whose cached sw.js evicted — recovered. The app-side fixes (#204/#206/#207/#208) can't reach a browser that never loads the new SW.

## Change
Add an exact-match `location = /sw.js` (higher priority than the regex) → `no-cache, no-store, must-revalidate`. Hashed assets (incl. `workbox-*.js`) remain immutable.

## ⚠️ Deployment
The deploy ships only `dist/` content and does **not** apply nginx config. This must be applied on the host: copy the updated conf into `sites-available`, `nginx -t`, `systemctl reload nginx`. Already-stuck clients recover on their next SW update check once the server stops sending immutable for sw.js.

## Note
Config-only (no `src` change) — build/lint/test unaffected.