### PR TITLE
fix(pwa): serve navigations NetworkFirst to fix Edge-on-iPhone blank page

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,22 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         runtimeCaching: [
           {
+            // Cold-start navigations: fetch a fresh index.html from the network when
+            // online so the served shell always pairs with current chunk hashes; fall
+            // back to the last cached navigation only when the network is slow/offline.
+            // Replaces the cache-first `navigateFallback` precache route, which
+            // intermittently returned a blank document in third-party iOS browsers
+            // (WKWebView), whose Cache Storage / service-worker support is flakier than
+            // Safari's. Safari rendered fine; only Edge-on-iPhone blanked on cold start.
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'html-navigations',
+              networkTimeoutSeconds: 3,
+              expiration: { maxEntries: 1 },
+            },
+          },
+          {
             urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
             handler: 'StaleWhileRevalidate',
             options: {
@@ -74,12 +90,15 @@ export default defineConfig({
             handler: 'NetworkOnly',
           },
         ],
-        // Serve the precached app shell for navigation requests. With null, a
-        // returning user after a deploy could get a shell/chunk hash mismatch
-        // (old SW serving an index whose hashed JS is no longer in its precache),
-        // blanking the page until a manual reload. 'index.html' guarantees the
-        // navigation is answered from one consistent precache generation.
-        navigateFallback: 'index.html',
+        // Disable vite-plugin-pwa's default `navigateFallback: 'index.html'`. That
+        // default registers a cache-first NavigationRoute *before* our runtimeCaching
+        // rules, so without this `null` it would win for every navigation and the
+        // NetworkFirst rule above would never fire. Navigation is handled NetworkFirst
+        // instead: an online cold start always fetches a fresh index.html that pairs
+        // with current chunk hashes (also retiring the shell/chunk hash-mismatch that
+        // navigateFallback was patching), while fixing the WKWebView blank-page bug the
+        // cache-first precache route caused.
+        navigateFallback: null,
       },
       devOptions: {
         // Disabled in dev: the precaching service worker served stale bundles


### PR DESCRIPTION
## Summary

Fixes the intermittent **blank page on cold start in Edge on iPhone** (and other third-party iOS browsers). Safari on iPhone worked; only WKWebView-backed browsers blanked, requiring a manual refresh.

Both are WebKit, so the differentiator is the **service-worker / Cache Storage implementation** — WKWebView's is flakier than Safari's. vite-plugin-pwa's default `navigateFallback: 'index.html'` answered cold-start navigations **cache-first** from the SW precache; in WKWebView that precache match intermittently returned empty → blank document → no document JS ran (which is why the #207/#208 on-screen diagnostics never fired). This also explains why #210 (sw.js no-cache, an *update-discovery* fix) didn't help — the failing path is navigation *serving*.

## Changes

`vite.config.ts` (Workbox `generateSW` config):
- **`navigateFallback: null`** — disable vite-plugin-pwa's default cache-first `NavigationRoute`. (It registers *before* `runtimeCaching`, so without this it wins for every navigation and the rule below never fires — verified in the generated `dist/sw.js`.)
- **NetworkFirst navigation rule** — `urlPattern: ({ request }) => request.mode === 'navigate'`, `cacheName: 'html-navigations'`, `networkTimeoutSeconds: 3`. Online cold starts fetch a fresh `index.html` from the network; the last cached navigation is the offline fallback.
- `clientsClaim` is kept (drives the post-update auto-reload).

Network-first navigation also inherently retires the shell/chunk hash-mismatch that `navigateFallback` was patching — an online cold start always pairs a fresh index with current chunk hashes.

## Test plan

- [x] `npm run type-check` — clean (`navigateFallback: null` is type-accepted)
- [x] `npm run lint` — clean
- [x] `npm test` — 96 passed
- [x] `npm run build` — SW generates; verified `dist/sw.js` now registers **only** the NetworkFirst navigation route (no `createHandlerBoundToURL("index.html")`)
- [x] `npm run size` — 105.19 kB / 108 kB limit
- [ ] **Real-device soak** — behavioral confirmation of the intermittent Edge-on-iPhone blank requires field testing; WKWebView can't be remote-inspected and the failure is intermittent.

## Assumptions

- The app has a single navigation target (`/`); there is no client-side routing, so NetworkFirst on navigations is sufficient (no deep-link fallback needed).
- First-ever *offline* navigation (offline before any successful online load) is not a real scenario.

## Follow-up

Once confirmed in the field, the temporary on-screen diagnostics (#207/#208) can be removed.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)