### PR TITLE
fix(pwa): drop NetworkFirst nav timeout to stop residual Edge-iPhone blank

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,16 +61,22 @@ export default defineConfig({
           {
             // Cold-start navigations: fetch a fresh index.html from the network when
             // online so the served shell always pairs with current chunk hashes; fall
-            // back to the last cached navigation only when the network is slow/offline.
-            // Replaces the cache-first `navigateFallback` precache route, which
-            // intermittently returned a blank document in third-party iOS browsers
+            // back to the last cached navigation only on a genuine network failure
+            // (offline). Replaces the cache-first `navigateFallback` precache route,
+            // which intermittently returned a blank document in third-party iOS browsers
             // (WKWebView), whose Cache Storage / service-worker support is flakier than
             // Safari's. Safari rendered fine; only Edge-on-iPhone blanked on cold start.
+            //
+            // No networkTimeoutSeconds: a timeout makes NetworkFirst fall back to the
+            // (WKWebView-flaky) runtime cache while the network is merely slow — which
+            // intermittently served an empty navigation → blank document with no
+            // index.html rendered (so even the in-page watchdog couldn't recover). Wait
+            // for the network instead; a slow shell beats a blank one. Only a real fetch
+            // rejection (offline) falls back to cache.
             urlPattern: ({ request }) => request.mode === 'navigate',
             handler: 'NetworkFirst',
             options: {
               cacheName: 'html-navigations',
-              networkTimeoutSeconds: 3,
               expiration: { maxEntries: 1 },
             },
           },


### PR DESCRIPTION
## Summary

Follow-up to #213 / v0.34.3-beta. The NetworkFirst navigation fix dropped the Edge-on-iPhone blank-on-cold-start from frequent to **~2 in 7**, but didn't eliminate it.

**New signal:** on the residual blanks, **no on-screen diagnostic overlay ever appears** (plain white). The watchdog + overlay live inside `index.html`'s inline script, so this confirms a **document-level** failure — the SW returns an empty/blank navigation and `index.html` never renders (which is also why it can't auto-recover and needs a manual refresh).

## Change

`vite.config.ts` — remove `networkTimeoutSeconds: 3` from the NetworkFirst navigation rule.

The timeout made NetworkFirst fall back to the WKWebView-flaky `html-navigations` runtime cache while the network was merely *slow* (cold-radio wake on a phone), and that cache intermittently returned an empty navigation → blank. Without the timeout, navigation **waits for the network** when online; only a genuine fetch rejection (offline) falls back to cache. A slow shell beats a blank one.

## Test plan

- [x] `type-check`, `lint`, `test` (96), `build`, `size` (105.5/108 kB) — all green
- [x] Verified `dist/sw.js` no longer contains `networkTimeoutSeconds`; NetworkFirst navigation route intact
- [ ] **Real-device soak** — intermittent and not remote-inspectable; confirmation is observational

## If this doesn't fully fix it

The cause is then deeper WKWebView SW flakiness, not the timeout. Escalation (tracked): migrate `generateSW` → `injectManifest` custom `sw.ts` with a navigation handler that provably cannot return blank (network-first → falls back to the **install-verified precache** copy of index.html, not the runtime cache) plus SW-side error capture for observability.

Closes #214
Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)