### PR TITLE
fix(pwa): injectManifest SW — bulletproof navigation + SW-side diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webmap-dev",
-  "version": "0.29.0-beta",
+  "version": "0.34.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webmap-dev",
-      "version": "0.29.0-beta",
+      "version": "0.34.4-beta",
       "dependencies": {
         "esri-leaflet": "^3.0.12",
         "esri-leaflet-geocoder": "^3.1.4",
@@ -27,6 +27,8 @@
         "vitest": "^2.1.9",
         "workbox-core": "^7.4.0",
         "workbox-expiration": "^7.4.0",
+        "workbox-precaching": "^7.4.0",
+        "workbox-routing": "^7.4.0",
         "workbox-strategies": "^7.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.worker.json --noEmit",
     "lint": "eslint src",
     "size": "size-limit",
     "og": "node scripts/generate-og-image.mjs",
@@ -33,6 +33,8 @@
     "vitest": "^2.1.9",
     "workbox-core": "^7.4.0",
     "workbox-expiration": "^7.4.0",
+    "workbox-precaching": "^7.4.0",
+    "workbox-routing": "^7.4.0",
     "workbox-strategies": "^7.4.0"
   },
   "size-limit": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,50 @@ import { scheduleSwUpdate } from './sw-update';
 // watchdog reloads once to recover.
 window.__webmapBootOk?.();
 
+// ── Temporary: surface service-worker-captured diagnostics ─────────────────────
+// src/sw.ts stashes navigation failures in the 'webmap-sw-diag' cache because a
+// blank navigation can't report anything itself — the page never renders. On a good
+// load we read, show (screenshot-friendly), and clear them, so the failure mode is
+// finally visible on devices we can't remote-inspect (Edge on iOS = WKWebView). These
+// constants MUST match src/sw.ts. Defined here (before bootApp() runs below) so the
+// const isn't in its temporal dead zone when initApp calls surfaceSwDiagnostics().
+// Remove with the #207/#208 diagnostics once the WKWebView blank is confirmed fixed.
+const SW_DIAG_CACHE = 'webmap-sw-diag';
+const SW_DIAG_URL = '/__webmap_sw_diag__';
+
+interface SwDiagRecord { t?: string; context?: string; message?: string; }
+
+async function surfaceSwDiagnostics(): Promise<void> {
+  if (!('caches' in window)) return;
+  try {
+    const cache = await caches.open(SW_DIAG_CACHE);
+    const res = await cache.match(SW_DIAG_URL);
+    if (!res) return;
+    const records = (await res.json()) as SwDiagRecord[];
+    await cache.delete(SW_DIAG_URL);
+    if (!Array.isArray(records) || records.length === 0) return;
+
+    console.warn('[webmap] service worker recovered blank navigation(s):', records);
+
+    const el = document.createElement('div');
+    el.setAttribute(
+      'style',
+      'position:fixed;left:0;right:0;bottom:0;z-index:2147483646;max-height:45%;overflow:auto;' +
+        'background:#101418;color:#7CFC00;font:11px/1.45 ui-monospace,Menlo,monospace;' +
+        'padding:12px;white-space:pre-wrap;word-break:break-word;',
+    );
+    const lines = records
+      .map((r) => `${r.t ?? '?'}  [${r.context ?? '?'}]  ${r.message ?? ''}`)
+      .join('\n');
+    el.textContent =
+      `webmap.dev — service worker recovered ${records.length} blank navigation(s); please screenshot\n\n${lines}\n\n(tap to dismiss)`;
+    el.addEventListener('click', () => el.remove());
+    document.body.appendChild(el);
+  } catch {
+    // Best-effort: diagnostics must never break the app.
+  }
+}
+
 // ── Consent gate — block all interaction until terms are accepted ─────────────
 if (!hasConsent()) {
   // Show modal immediately; re-show on decline (user cannot bypass)
@@ -528,5 +572,9 @@ const updateSW = registerSW({
     });
   },
 });
+
+// Surface any blank navigations the service worker recovered from this/last load
+// (see surfaceSwDiagnostics + src/sw.ts). Temporary on-device observability.
+void surfaceSwDiagnostics();
 
 } // end initApp

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import { addCompassControl } from './compass';
 import { initBattery } from './battery';
 import { registerSW } from 'virtual:pwa-register';
 import { scheduleSwUpdate } from './sw-update';
+import { SW_DIAG_CACHE, SW_DIAG_URL } from './sw-constants';
 
 // Tell the index.html boot-watchdog the bundle loaded and is executing, so it
 // cancels its reload timer. If the bundle ever fails to load (a stale service
@@ -43,12 +44,10 @@ window.__webmapBootOk?.();
 // blank navigation can't report anything itself — the page never renders. On a good
 // load we read, show (screenshot-friendly), and clear them, so the failure mode is
 // finally visible on devices we can't remote-inspect (Edge on iOS = WKWebView). These
-// constants MUST match src/sw.ts. Defined here (before bootApp() runs below) so the
-// const isn't in its temporal dead zone when initApp calls surfaceSwDiagnostics().
-// Remove with the #207/#208 diagnostics once the WKWebView blank is confirmed fixed.
-const SW_DIAG_CACHE = 'webmap-sw-diag';
-const SW_DIAG_URL = '/__webmap_sw_diag__';
-
+// cache name/URL are shared via sw-constants.ts so the two sides can't drift. This
+// lives above bootApp() (which runs during module eval) so surfaceSwDiagnostics and
+// its imports are ready when initApp calls it. Remove with the #207/#208 diagnostics
+// once the WKWebView blank is confirmed fixed.
 interface SwDiagRecord { t?: string; context?: string; message?: string; }
 
 async function surfaceSwDiagnostics(): Promise<void> {

--- a/src/sw-constants.ts
+++ b/src/sw-constants.ts
@@ -3,3 +3,10 @@
  *  at the import site rather than silently breaking the canvas tile fallback.
  */
 export const OSM_TILE_CACHE_NAME = 'osm-tiles' as const;
+
+/** TEMPORARY (remove with the #207/#208 diagnostics once the WKWebView blank is
+ *  confirmed fixed). The service worker stashes recovered blank-navigation records
+ *  in this cache because a blank navigation can't report anything itself; the page
+ *  reads them on its next good load. Shared so sw.ts and main.ts can't drift. */
+export const SW_DIAG_CACHE = 'webmap-sw-diag' as const;
+export const SW_DIAG_URL = '/__webmap_sw_diag__' as const;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -22,7 +22,7 @@ import { registerRoute } from 'workbox-routing';
 import { StaleWhileRevalidate, NetworkOnly } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { clientsClaim } from 'workbox-core';
-import { OSM_TILE_CACHE_NAME } from './sw-constants';
+import { OSM_TILE_CACHE_NAME, SW_DIAG_CACHE, SW_DIAG_URL } from './sw-constants';
 
 declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
@@ -34,15 +34,13 @@ cleanupOutdatedCaches();
 
 // ── SW-side diagnostics ───────────────────────────────────────────────────────
 // A blank navigation can't report anything itself, but the worker survives it — so
-// it records failures here and the page reads them on its next good load. These
-// constants are duplicated in main.ts (surfaceSwDiagnostics); keep them in sync.
-const DIAG_CACHE = 'webmap-sw-diag';
-const DIAG_URL = '/__webmap_sw_diag__';
-
+// it records failures in SW_DIAG_CACHE and the page reads them on its next good load
+// (surfaceSwDiagnostics in main.ts). The cache name/URL live in sw-constants.ts so
+// the two sides can't drift.
 async function recordSwError(context: string, err: unknown): Promise<void> {
   try {
-    const cache = await caches.open(DIAG_CACHE);
-    const prev = await cache.match(DIAG_URL);
+    const cache = await caches.open(SW_DIAG_CACHE);
+    const prev = await cache.match(SW_DIAG_URL);
     const list: unknown[] = prev ? await prev.json() : [];
     list.push({
       t: new Date().toISOString(),
@@ -52,7 +50,7 @@ async function recordSwError(context: string, err: unknown): Promise<void> {
     // Keep only the most recent few so the entry can't grow unbounded.
     while (list.length > 20) list.shift();
     await cache.put(
-      DIAG_URL,
+      SW_DIAG_URL,
       new Response(JSON.stringify(list), { headers: { 'Content-Type': 'application/json' } }),
     );
   } catch {
@@ -72,6 +70,8 @@ registerRoute(
       if (!res.ok) throw new Error(`navigation HTTP ${res.status}`);
       // Guard against an empty/blank 200 (the WKWebView failure mode): validate the
       // body before trusting it. index.html is tiny, so reading a clone is cheap.
+      // A valid HTML document is always well over 50 chars; under that is an
+      // empty/stub response we must not serve.
       const body = await res.clone().text();
       if (body.trim().length < 50) throw new Error('navigation body empty');
       return res;

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,120 @@
+/**
+ * Intent: Custom service worker (injectManifest) — a navigation handler that can
+ *   never blank the page, plus SW-side error capture for on-device observability.
+ * Context: Replaces vite-plugin-pwa's generateSW. The Edge-on-iPhone (WKWebView)
+ *   blank-on-cold-start survived the navigation-strategy fixes (NetworkFirst in
+ *   v0.34.3, timeout removal in v0.34.4). It only appears after several loads from a
+ *   clean state — pointing at accumulated storage/SW-runtime pressure tipping the
+ *   worker over and returning an empty navigation. A blank navigation is invisible to
+ *   page-side diagnostics, so both the recovery and the diagnostics have to live here.
+ * Pattern: Navigations go network-first but any failure OR an empty body falls back to
+ *   the install-verified precache copy of index.html — never the flaky runtime cache,
+ *   so the page can never go blank (worst case: a slightly-stale shell). Failures are
+ *   stashed in a cache that the next good load reads (see surfaceSwDiagnostics in
+ *   main.ts). The registerType:'prompt' update flow is wired manually here
+ *   (SKIP_WAITING message + clientsClaim), since generateSW no longer does it.
+ * Future: The diagnostics (DIAG_*) are temporary — remove with the #207/#208 overlay
+ *   once the WKWebView blank is confirmed fixed in the field.
+ */
+/// <reference lib="webworker" />
+import { precacheAndRoute, cleanupOutdatedCaches, matchPrecache } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { StaleWhileRevalidate, NetworkOnly } from 'workbox-strategies';
+import { ExpirationPlugin } from 'workbox-expiration';
+import { clientsClaim } from 'workbox-core';
+import { OSM_TILE_CACHE_NAME } from './sw-constants';
+
+declare const self: ServiceWorkerGlobalScope & {
+  __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
+};
+
+// ── Precache the build assets (manifest injected by vite-plugin-pwa at build) ──
+precacheAndRoute(self.__WB_MANIFEST);
+cleanupOutdatedCaches();
+
+// ── SW-side diagnostics ───────────────────────────────────────────────────────
+// A blank navigation can't report anything itself, but the worker survives it — so
+// it records failures here and the page reads them on its next good load. These
+// constants are duplicated in main.ts (surfaceSwDiagnostics); keep them in sync.
+const DIAG_CACHE = 'webmap-sw-diag';
+const DIAG_URL = '/__webmap_sw_diag__';
+
+async function recordSwError(context: string, err: unknown): Promise<void> {
+  try {
+    const cache = await caches.open(DIAG_CACHE);
+    const prev = await cache.match(DIAG_URL);
+    const list: unknown[] = prev ? await prev.json() : [];
+    list.push({
+      t: new Date().toISOString(),
+      context,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    // Keep only the most recent few so the entry can't grow unbounded.
+    while (list.length > 20) list.shift();
+    await cache.put(
+      DIAG_URL,
+      new Response(JSON.stringify(list), { headers: { 'Content-Type': 'application/json' } }),
+    );
+  } catch {
+    // Diagnostics are best-effort; never let them throw back into a handler.
+  }
+}
+
+// ── Bulletproof navigation ─────────────────────────────────────────────────────
+// Network-first, but the ONLY fallback is the install-verified precache copy of
+// index.html — never a runtime cache (whose flaky reads in WKWebView were returning
+// empty navigations). So the page always renders a real document.
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  async ({ request }) => {
+    try {
+      const res = await fetch(request);
+      if (!res.ok) throw new Error(`navigation HTTP ${res.status}`);
+      // Guard against an empty/blank 200 (the WKWebView failure mode): validate the
+      // body before trusting it. index.html is tiny, so reading a clone is cheap.
+      const body = await res.clone().text();
+      if (body.trim().length < 50) throw new Error('navigation body empty');
+      return res;
+    } catch (err) {
+      await recordSwError('navigate', err);
+      const fallback = await matchPrecache('index.html');
+      if (fallback) return fallback;
+      // index.html is always precached, so this is unreachable — but never blank:
+      // a zero-delay refresh document beats a white screen.
+      return new Response('<!doctype html><meta http-equiv="refresh" content="0">', {
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+  },
+);
+
+// ── Map tiles ──────────────────────────────────────────────────────────────────
+// Cache-while-revalidate. purgeOnQuotaError purges the cache on a storage-quota hit
+// instead of throwing (the documented iOS/WKWebView mitigation for "fails after N
+// loads"); the lower maxEntries trims the footprint that accumulates across a soak.
+registerRoute(
+  /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
+  new StaleWhileRevalidate({
+    cacheName: OSM_TILE_CACHE_NAME,
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 300,
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
+);
+
+// ── Geocoding: never cache (parity with the previous generateSW config) ─────────
+registerRoute(/^https:\/\/geocode\.arcgis\.com\/.*/, new NetworkOnly());
+
+// ── Update flow (registerType: 'prompt') ────────────────────────────────────────
+// virtual:pwa-register's updateSW(true) posts SKIP_WAITING to the waiting worker;
+// activate + claim so workbox-window's 'controlling' event fires and reloads the
+// page. The visibility/post-paint gating of that reload lives in main.ts.
+self.addEventListener('message', (event: ExtendableMessageEvent) => {
+  const data = event.data as { type?: string } | undefined;
+  if (data?.type === 'SKIP_WAITING') void self.skipWaiting();
+});
+clientsClaim();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "comment-exclude": "src/sw.ts runs in a ServiceWorkerGlobalScope and is type-checked separately via tsconfig.worker.json (WebWorker lib, which conflicts with DOM here).",
+  "exclude": ["src/sw.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "noUncheckedIndexedAccess": true
   },
   "include": ["src"],
-  "comment-exclude": "src/sw.ts runs in a ServiceWorkerGlobalScope and is type-checked separately via tsconfig.worker.json (WebWorker lib, which conflicts with DOM here).",
+  "//": "src/sw.ts runs in a ServiceWorkerGlobalScope and is type-checked separately via tsconfig.worker.json (WebWorker lib, which conflicts with DOM here).",
   "exclude": ["src/sw.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,9 @@
+{
+  "//": "Type-checks the service worker (src/sw.ts) in isolation. It runs in a ServiceWorkerGlobalScope, so it needs the WebWorker lib instead of DOM — which is why it can't share the main tsconfig (the two libs declare `self` incompatibly). Run via `npm run type-check`.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "WebWorker"]
+  },
+  "include": ["src/sw.ts"],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { readFileSync } from 'fs';
-import { OSM_TILE_CACHE_NAME } from './src/sw-constants';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
@@ -11,7 +10,18 @@ export default defineConfig({
   },
   plugins: [
     VitePWA({
+      // injectManifest: we ship a hand-written service worker (src/sw.ts) so the
+      // navigation handler can guarantee a non-blank document and capture its own
+      // failures. generateSW gave no control over either — see src/sw.ts and the
+      // Edge-on-iPhone (WKWebView) blank-on-cold-start saga (#216).
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       registerType: 'prompt',
+      injectManifest: {
+        // The app bundle is ~350 KB gzipped-source; keep a generous precache cap.
+        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+      },
       manifest: {
         name: 'webmap.dev',
         short_name: 'webmap',
@@ -47,64 +57,6 @@ export default defineConfig({
             purpose: 'maskable',
           },
         ],
-      },
-      workbox: {
-        // After skipWaiting activates the new SW, claim all open clients so
-        // workbox-window's 'controlling' event fires and triggers location.reload().
-        // Without this, onNeedRefresh sends SKIP_WAITING but the page never reloads
-        // automatically — users see a blank/stale page until they manually refresh.
-        clientsClaim: true,
-        // Drop precache entries from older SW generations on activate, so a stale
-        // index referencing chunks that no longer exist can't be served.
-        cleanupOutdatedCaches: true,
-        runtimeCaching: [
-          {
-            // Cold-start navigations: fetch a fresh index.html from the network when
-            // online so the served shell always pairs with current chunk hashes; fall
-            // back to the last cached navigation only on a genuine network failure
-            // (offline). Replaces the cache-first `navigateFallback` precache route,
-            // which intermittently returned a blank document in third-party iOS browsers
-            // (WKWebView), whose Cache Storage / service-worker support is flakier than
-            // Safari's. Safari rendered fine; only Edge-on-iPhone blanked on cold start.
-            //
-            // No networkTimeoutSeconds: a timeout makes NetworkFirst fall back to the
-            // (WKWebView-flaky) runtime cache while the network is merely slow — which
-            // intermittently served an empty navigation → blank document with no
-            // index.html rendered (so even the in-page watchdog couldn't recover). Wait
-            // for the network instead; a slow shell beats a blank one. Only a real fetch
-            // rejection (offline) falls back to cache.
-            urlPattern: ({ request }) => request.mode === 'navigate',
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'html-navigations',
-              expiration: { maxEntries: 1 },
-            },
-          },
-          {
-            urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*/,
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: OSM_TILE_CACHE_NAME,
-              expiration: {
-                maxEntries: 500,
-                maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
-              },
-            },
-          },
-          {
-            urlPattern: /^https:\/\/geocode\.arcgis\.com\/.*/,
-            handler: 'NetworkOnly',
-          },
-        ],
-        // Disable vite-plugin-pwa's default `navigateFallback: 'index.html'`. That
-        // default registers a cache-first NavigationRoute *before* our runtimeCaching
-        // rules, so without this `null` it would win for every navigation and the
-        // NetworkFirst rule above would never fire. Navigation is handled NetworkFirst
-        // instead: an online cold start always fetches a fresh index.html that pairs
-        // with current chunk hashes (also retiring the shell/chunk hash-mismatch that
-        // navigateFallback was patching), while fixing the WKWebView blank-page bug the
-        // cache-first precache route caused.
-        navigateFallback: null,
       },
       devOptions: {
         // Disabled in dev: the precaching service worker served stale bundles


### PR DESCRIPTION
## Summary

Follow-up to #214 / v0.34.4-beta. The Edge-on-iPhone (WKWebView) blank-on-cold-start survived both navigation-strategy fixes (NetworkFirst in v0.34.3, timeout removal in v0.34.4) — still ~2 in 7 cold starts.

**Two facts pinned it down:**
- The app shows **0.34.4-beta** on successful loads → our fixes ARE live on the device (not a stale SW).
- Site data is **cleared before each soak**, yet it fails on the **5th–6th** cold start — not the 1st. A static navigation bug fails from the first controlled load; a failure that only appears after several loads from a clean state points at **accumulation** (storage/quota or SW-runtime pressure) tipping the worker over and returning an empty navigation.
- Residual blanks show **no overlay** (document-level): the SW returns an empty navigation, `index.html` never renders, so page-side diagnostics are blind by construction.

So both the recovery and the observability have to live **in the service worker**. Migrate `generateSW` → `injectManifest`.

## Changes

**`src/sw.ts`** (new, hand-written SW):
- **Bulletproof navigation** — network-first, but any failure *or an empty body* falls back to the install-verified **precache** copy of `index.html` (never a flaky runtime cache). The page can no longer go blank — worst case a slightly-stale shell.
- **SW-side error capture** — failures are stashed in a `webmap-sw-diag` cache; the next good load reads and shows them on-screen (`surfaceSwDiagnostics` in `main.ts`). This survives a blank navigation: the SW writes, a later good load reports.
- **Quota mitigation** — `purgeOnQuotaError` on the tile cache (documented iOS/WKWebView fix for "fails after N loads") + tile `maxEntries` 500→300.
- **Mechanical** — port tile (`StaleWhileRevalidate`) and geocode (`NetworkOnly`) caching; wire the prompt-update flow (`SKIP_WAITING` message + `clientsClaim`) manually.

**`main.ts`** — `surfaceSwDiagnostics()` reads/clears the `webmap-sw-diag` cache and shows a dismissible on-screen readout. Defined before `bootApp()` runs so its consts aren't in TDZ when `initApp` calls it.

**Build/TS** — `vite.config.ts` switches to `strategies: 'injectManifest'`; `src/sw.ts` needs the `WebWorker` lib (conflicts with the app's `DOM` lib), so it's type-checked via a separate **`tsconfig.worker.json`** wired into `npm run type-check` and excluded from the app tsconfig. Added `workbox-precaching` / `workbox-routing` to deps.

## Test plan

- [x] `type-check` (app **and** worker tsconfig), `lint`, `test` (96), `build` (injectManifest), `size` (106.0/108 kB) — all green
- [x] Verified `dist/sw.js`: navigate route (`mode==="navigate"` → fetch → `matchPrecache("index.html")` fallback + empty-body guard), `purgeOnQuotaError`, `SKIP_WAITING`/`clients.claim()`, precache manifest injected
- [ ] **Real-device soak** — the decisive test. Either the blank is gone (bulletproof nav), or the SW-diag readout appears on the next good load and finally tells us the failure mode.

## Notes

`surfaceSwDiagnostics` + the SW `webmap-sw-diag` stash are **temporary** observability (like #207/#208) — remove together once the WKWebView blank is confirmed fixed in the field.

Closes #216
Refs #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)