### PR TITLE
fix(pwa): auto-reload on iOS WebKit render freeze (Paint Timing self-heal)

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,31 @@
         }, 3000);
       }
 
+      // Render-freeze self-heal. iOS WebKit (iOS 26 / WKWebView — e.g. Edge & Chrome
+      // on iOS) intermittently loads the page into a frozen render process: the DOM is
+      // complete and the bundle runs, but the whole content area stays white and ONLY
+      // a reload (not scroll/touch/rotate) clears it. The Paint Timing API records a
+      // 'first-contentful-paint' entry only when WebKit actually paints content; if
+      // it's still absent ~3s in, the page froze — reload once (guarded) to recover.
+      // This complements the boot-watchdog above (which covers a bundle that never
+      // runs); here the bundle runs fine but the render is dead until a fresh load.
+      var RKEY = 'webmap-render-reload';
+      setTimeout(function () {
+        var painted;
+        try {
+          painted = performance.getEntriesByType('paint').some(function (p) {
+            return p.name === 'first-contentful-paint';
+          });
+        } catch (e) { painted = true; } // no Paint Timing API → never risk a reload loop
+        if (painted) { try { sessionStorage.removeItem(RKEY); } catch (e) {} return; }
+        var rAlready;
+        try { rAlready = sessionStorage.getItem(RKEY) === '1'; } catch (e) { rAlready = false; }
+        if (!rAlready) {
+          try { sessionStorage.setItem(RKEY, '1'); } catch (e) {}
+          location.reload();
+        }
+      }, 3000);
+
       // Blank-state probe: if the map still hasn't rendered after 5s and no error
       // was captured, dump enough state to see WHY it's blank.
       setTimeout(function () {

--- a/index.html
+++ b/index.html
@@ -96,8 +96,12 @@
         var rAlready;
         try { rAlready = sessionStorage.getItem(RKEY) === '1'; } catch (e) { rAlready = false; }
         if (!rAlready) {
-          try { sessionStorage.setItem(RKEY, '1'); } catch (e) {}
-          location.reload();
+          // Only reload if the guard actually persisted — if sessionStorage is
+          // unavailable (private mode, storage disabled), reloading would loop
+          // forever. Mirrors the boot-watchdog above. (Key: 'webmap-render-reload'.)
+          var rPersisted = false;
+          try { sessionStorage.setItem(RKEY, '1'); rPersisted = true; } catch (e) { rPersisted = false; }
+          if (rPersisted) { location.reload(); }
         }
       }, 3000);
 

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -65,6 +65,7 @@ export function showConsentModal(): Promise<boolean> {
     `;
 
     overlay.appendChild(panel);
+    document.body.appendChild(overlay);
 
     function cleanup(accepted: boolean): void {
       overlay.remove();
@@ -72,10 +73,8 @@ export function showConsentModal(): Promise<boolean> {
       resolve(accepted);
     }
 
-    // Wire listeners on the still-detached panel so they're ready before mount
-    // (querySelector works on a detached element; getElementById would not).
-    panel.querySelector('#consent-accept')!.addEventListener('click', () => cleanup(true));
-    panel.querySelector('#consent-decline')!.addEventListener('click', () => cleanup(false));
+    document.getElementById('consent-accept')!.addEventListener('click', () => cleanup(true));
+    document.getElementById('consent-decline')!.addEventListener('click', () => cleanup(false));
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) cleanup(false);
     });
@@ -88,18 +87,7 @@ export function showConsentModal(): Promise<boolean> {
     };
     document.addEventListener('keydown', onKey);
 
-    // Mount on the next frame, NOT synchronously during the page's first paint.
-    // iOS WebKit (including Edge/Chrome on iOS, which run on WKWebView) intermittently
-    // fails to composite a fixed-position layer injected during that first paint,
-    // leaving a white screen with the modal present in the DOM but unpainted — the
-    // blank-on-cold-start that "prevents usage" until a manual refresh (confirmed via
-    // on-screen diagnostic: bundleRan=true, hasConsent=false, nothing visible).
-    // Mounting after first paint and flushing layout makes the overlay paint reliably.
-    requestAnimationFrame(() => {
-      document.body.appendChild(overlay);
-      void overlay.getBoundingClientRect(); // flush layout → ensure a paint
-      // Focus the accept button for keyboard accessibility (post-mount).
-      (panel.querySelector('#consent-accept') as HTMLElement | null)?.focus();
-    });
+    // Focus the accept button for keyboard accessibility
+    document.getElementById('consent-accept')!.focus();
   });
 }


### PR DESCRIPTION
## Summary

The blank-on-cold-start is a **whole-page render freeze in iOS WebKit** (iOS 26 / WKWebView), not any content-level bug. On a blank load, neither the consent overlay nor the *separate* inline diagnostic overlay paints — two unrelated DOM elements both invisible — so the entire page fails to paint white. DOM is complete, bundle runs (`bundleRan=true`), service worker uninvolved (`swController=no`). User confirmed: **only a full refresh clears it** (scroll/tap/rotate do not), browser chrome normal. Content is never painted and won't be until a fresh navigation — which is why none of the prior content-level fixes could have worked.

## Fix: Paint-Timing self-heal

Since a reload reliably clears it, detect and reload:
- **`index.html`** inline script: ~3s after load, check the Paint Timing API for a `first-contentful-paint` entry. Absent ⇒ the page never painted ⇒ `location.reload()` once (sessionStorage-guarded). Runs independent of the bundle, so it works through the freeze. If Paint Timing is unavailable, treated as painted (never risk a loop). Complements the boot-watchdog (bundle-never-runs case).
- **`consent.ts`** — revert the `requestAnimationFrame` mount from #219 (wrong layer; 5/9-vs-3/7 suggested it slightly regressed).

This doesn't *prevent* the WKWebView freeze (un-patchable from JS), but the app now **auto-recovers** (brief white flash → reload → working) instead of a stuck dead page.

## Test plan

- [x] `type-check` (app + worker), `lint`, `test` (96), `build` — all green; self-heal verified in built `index.html`
- [ ] **Real-device soak (Edge/iPhone)** — clear data, cold-start ×N. Expect: any freeze now auto-reloads within ~3s and lands on a working page (brief white flash, no stuck blank). If a stuck blank still survives, Paint Timing isn't catching the freeze and we escalate (animation-start probe / CSS trigger bisect).

## Notes

Once confirmed in the field, the temporary diagnostics (#207/#208 + SW-diag) can be removed and the SW simplified (it was never the cause).

Closes #220
Refs #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)