### PR TITLE
fix(pwa): strip first-paint compositing layers to prevent iOS WebKit freeze

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,9 +145,10 @@
 </head>
 <body>
   <div id="map"></div>
-  <div id="offline-banner" class="offline-banner">
-    <span>You are offline — cached tiles and GPS recording still work</span>
-  </div>
+  <!-- #offline-banner is created lazily by main.ts only when the app goes offline.
+       Keeping it out of the static HTML avoids a position:fixed+transform compositing
+       layer at first paint, which (with #map) contributed to the iOS-26 WKWebView
+       whole-page render freeze. -->
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -511,11 +511,24 @@ document.getElementById('map')?.focus();
 document.body.style.zoom = '100%';
 
 // ── Offline detection ─────────────────────────────────────────────────────────
+// The banner is created lazily (not in static HTML) so it isn't a position:fixed +
+// transform compositing layer at first paint — that, with #map, contributed to the
+// iOS-26 WKWebView whole-page render freeze. It only ever exists once the app has
+// been offline.
 function updateOfflineBanner(): void {
-  const banner = document.getElementById('offline-banner');
-  if (!banner) return;
+  let banner = document.getElementById('offline-banner');
   if (navigator.onLine) {
-    banner.classList.remove('visible');
+    banner?.classList.remove('visible');
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'offline-banner';
+    banner.className = 'offline-banner';
+    banner.innerHTML = '<span>You are offline — cached tiles and GPS recording still work</span>';
+    document.body.appendChild(banner);
+    // Mount hidden, then reveal next frame so the slide-in transition plays.
+    requestAnimationFrame(() => banner!.classList.add('visible'));
   } else {
     banner.classList.add('visible');
   }

--- a/src/style.css
+++ b/src/style.css
@@ -6,8 +6,13 @@
 
 html { height: 100%; width: 100%; padding: 0; margin: 0; }
 body { height: 100%; width: 100%; padding: 0; margin: 0; }
-/* isolation: isolate keeps mix-blend-mode contained to the map's own stacking context. */
-#map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; isolation: isolate; }
+/* No `isolation: isolate` here on purpose: an empty, full-screen *composited* #map
+   layer at first paint was a prime trigger for the iOS-26 WKWebView render freeze
+   (whole page never composites to screen until a reload). Containment isn't needed —
+   the hillshade overlay's mix-blend-mode:multiply blends against the opaque base
+   tiles directly beneath it regardless, and multiply against the white body behind a
+   full-screen map is a no-op. */
+#map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
 
 /* Blend at the layer container so multiply composites against the base-layer sibling below. */
 .hillshade-blend { mix-blend-mode: multiply; }


### PR DESCRIPTION
## Summary

Pivot from *recover* to *prevent* on the iOS-26 WKWebView whole-page render freeze. A compositing freeze can't be detected from JS (FCP is recorded but never composited to screen), so the Paint-Timing auto-reload (#221) never fired — and **Safari works while only Edge/WKWebView freezes**, which points at WKWebView's greater sensitivity to first-paint compositing-layer pressure. So: reduce what's composited at first paint.

Before any JS runs (the freeze is at the consent gate), two elements force compositing layers:

## Changes

- **`src/style.css`** — remove `isolation: isolate` from `#map` (a full-screen composited layer present from first paint). Visually safe: `isolation` only contained the hillshade overlay's `mix-blend-mode: multiply`, which blends against the opaque base tiles directly beneath it regardless (and multiply against the white `body` behind a full-screen map is a no-op).
- **`index.html` + `src/main.ts`** — remove the static `#offline-banner` (`position: fixed` + `transform`) from the HTML; lazy-create it in `updateOfflineBanner()` only when the app actually goes offline, so it's absent from first paint.

## Test plan

- [x] `type-check` (app + worker), `lint`, `test` (96), `build` — all green
- [x] Verified built output: no `isolation` in CSS, no static `#offline-banner` in HTML, lazy-create present in bundle
- [ ] **Real-device soak (Edge/iPhone)** — clear data, cold-start ×N. If the white-screen rate drops to zero, first-paint compositing pressure was the trigger. If unchanged, the trigger is elsewhere / a deeper WKWebView issue and we reassess (the offline-banner lazy-load and isolation removal are both harmless to keep regardless).

## Notes

The Paint-Timing auto-reload from #221 stays as a harmless fallback. Once this is confirmed, the temporary diagnostics can be stripped and the (exonerated) service worker simplified.

Closes #222
Refs #218, #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)