### PR TITLE
feat(consent): require scrolling the terms before enabling "I agree"

### DIFF
--- a/src/consent.ts
+++ b/src/consent.ts
@@ -37,7 +37,7 @@ export function showConsentModal(): Promise<boolean> {
     panel.innerHTML = `
       <h2>webmap.dev — privacy-first GPS mapping, no account required</h2>
 
-      <div id="consent-body">
+      <div id="consent-body" tabindex="0" aria-label="Terms — scroll to read">
         <h3>Privacy Policy</h3>
         <ul class="consent-legal">
           <li><strong>Local only.</strong> All GPS data and app settings stay in your browser. Nothing is sent to our servers.</li>
@@ -59,7 +59,8 @@ export function showConsentModal(): Promise<boolean> {
       </div>
 
       <div id="consent-actions">
-        <button id="consent-accept" class="rec-btn rec-btn-start">I agree — continue</button>
+        <p id="consent-scroll-hint">Please scroll to the bottom to continue.</p>
+        <button id="consent-accept" class="rec-btn rec-btn-start" disabled>I agree — continue</button>
         <button id="consent-decline">Decline</button>
       </div>
     `;
@@ -67,14 +68,43 @@ export function showConsentModal(): Promise<boolean> {
     overlay.appendChild(panel);
     document.body.appendChild(overlay);
 
+    const acceptBtn = panel.querySelector<HTMLButtonElement>('#consent-accept')!;
+    const body = panel.querySelector<HTMLElement>('#consent-body')!;
+    const hint = panel.querySelector<HTMLElement>('#consent-scroll-hint')!;
+
+    // Gate the accept button on the user having scrolled to the bottom of the terms.
+    // Enable as soon as the bottom is reached (4px tolerance for sub-pixel rounding),
+    // or immediately if the terms are short enough not to scroll. Re-checked on resize
+    // so a rotate that makes the content fit also unlocks it.
+    const atBottom = (): boolean =>
+      body.scrollTop + body.clientHeight >= body.scrollHeight - 4;
+    const unlock = (): void => {
+      acceptBtn.disabled = false;
+      hint.style.display = 'none';
+      body.removeEventListener('scroll', onScrollOrResize);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+    const onScrollOrResize = (): void => {
+      if (atBottom()) unlock();
+    };
+
+    if (atBottom()) {
+      unlock();
+    } else {
+      hint.style.display = 'block';
+      body.addEventListener('scroll', onScrollOrResize, { passive: true });
+      window.addEventListener('resize', onScrollOrResize);
+    }
+
     function cleanup(accepted: boolean): void {
+      window.removeEventListener('resize', onScrollOrResize);
       overlay.remove();
       if (accepted) recordConsent();
       resolve(accepted);
     }
 
-    document.getElementById('consent-accept')!.addEventListener('click', () => cleanup(true));
-    document.getElementById('consent-decline')!.addEventListener('click', () => cleanup(false));
+    acceptBtn.addEventListener('click', () => cleanup(true));
+    panel.querySelector('#consent-decline')!.addEventListener('click', () => cleanup(false));
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) cleanup(false);
     });
@@ -87,7 +117,8 @@ export function showConsentModal(): Promise<boolean> {
     };
     document.addEventListener('keydown', onKey);
 
-    // Focus the accept button for keyboard accessibility
-    document.getElementById('consent-accept')!.focus();
+    // Focus the scrollable terms so keyboard users can scroll to read (and thereby
+    // unlock the accept button, which starts disabled and can't take focus yet).
+    body.focus();
   });
 }

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -83,6 +83,9 @@ export function showConsentModal(): Promise<boolean> {
       hint.style.display = 'none';
       body.removeEventListener('scroll', onScrollOrResize);
       window.removeEventListener('resize', onScrollOrResize);
+      // Move focus to the now-interactive button so a keyboard user who just scrolled
+      // to the bottom doesn't have to Tab forward to reach it.
+      acceptBtn.focus();
     };
     const onScrollOrResize = (): void => {
       if (atBottom()) unlock();
@@ -97,6 +100,9 @@ export function showConsentModal(): Promise<boolean> {
     }
 
     function cleanup(accepted: boolean): void {
+      // Symmetric teardown — tear down both listeners regardless of which path closes
+      // the modal (e.g. decline-before-scroll leaves the scroll listener attached).
+      body.removeEventListener('scroll', onScrollOrResize);
       window.removeEventListener('resize', onScrollOrResize);
       overlay.remove();
       if (accepted) recordConsent();

--- a/src/style.css
+++ b/src/style.css
@@ -1538,6 +1538,21 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   cursor: pointer;
 }
 
+#consent-accept:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Shown (display:block via JS) only while the accept button is locked, i.e. when the
+   terms actually overflow and haven't been scrolled to the bottom yet. */
+#consent-scroll-hint {
+  display: none;
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: #888;
+  text-align: center;
+}
+
 #consent-decline {
   padding: 8px 16px;
   font-size: 13px;


### PR DESCRIPTION
## Summary

The first-run consent dialog now disables **"I agree — continue"** until the user scrolls to the bottom of the terms — so acceptance follows actually viewing the full Privacy Policy + Terms of Use.

## Changes

`src/consent.ts`:
- Accept button renders `disabled`; a hint (*"Please scroll to the bottom to continue."*) shows beneath the actions while it's locked.
- Unlocks when `#consent-body` is scrolled to the bottom (`scrollTop + clientHeight >= scrollHeight - 4`), hiding the hint and removing the listeners.
- **Fits-without-scrolling fallback:** if the terms don't overflow (tall viewport), it enables immediately — checked right after mount.
- **Resize re-check:** rotating to a layout where the content fits also unlocks it.
- Terms region is `tabindex=0` and gets initial focus (keyboard users can scroll to read/unlock instead of landing on a disabled button). Decline stays enabled.
- `resize` listener cleaned up on close, including decline-before-scroll.

`src/style.css`:
- `#consent-accept:disabled` — dimmed + `not-allowed` cursor.
- `#consent-scroll-hint` — hidden by default; shown via JS only while locked.

## Test plan

- [x] `type-check` (app + worker), `lint`, `test` (96), `build` — all green; markup/logic verified in the bundle
- [ ] **Manual browser check** (vitest is pure-function-only here, so the DOM behavior needs a real browser): on a short viewport the button is disabled + hint visible → scroll to bottom → button enables + hint hides; on a tall viewport where the terms fit, the button is enabled immediately; declining before scrolling still works.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)