### PR TITLE
feat(map): add cue events overlay with outcome colors and rider markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "size-limit": [
     {
       "path": "dist/assets/index-*.js",
-      "limit": "110 kB",
+      "limit": "112 kB",
       "gzip": true
     }
   ]

--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -82,6 +82,10 @@ describe('formatCueLabel', () => {
     ).toBe('cue 7 · not delivered · too late');
   });
 
+  it('renders latency as delivered when the delivered flag is absent', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 8, latency_ms: 640 })).toBe('cue 8 · delivered 640 ms');
+  });
+
   it('renders outcomes with spaces, not underscores', () => {
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'false_alarm' })).toBe('cue 1 · false alarm');
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'missed_risk' })).toBe('cue 1 · missed risk');

--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { outcomeColor, formatCueLabel, formatMarkerLabel, parseCueEvents } from './cue-events';
+
+// Synthetic coordinates only — never real ride geometry.
+function syntheticCue(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [0.001, 0.0005] },
+    properties: {
+      kind: 'cue',
+      event_id: 1977782249,
+      segment_id: 1977782249,
+      ride_clock: '10:27',
+      lead_time_s: 15,
+      severity: 200,
+      confidence: 165,
+      reasons_bitmask: 7,
+      delivered: true,
+      latency_ms: 752,
+      outcome: 'useful',
+      approx: true,
+      ...overrides,
+    },
+  };
+}
+
+function syntheticMarker(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [0.002, 0.001] },
+    properties: {
+      kind: 'marker',
+      segment_id: 2626284579,
+      ride_clock: '55:03',
+      approx: true,
+      ...overrides,
+    },
+  };
+}
+
+function collection(...features: unknown[]): string {
+  return JSON.stringify({ type: 'FeatureCollection', features });
+}
+
+describe('outcomeColor', () => {
+  it('maps each review grade to its color', () => {
+    expect(outcomeColor('useful')).toBe('#2e7d32');
+    expect(outcomeColor('false_alarm')).toBe('#d63131');
+    expect(outcomeColor('too_late')).toBe('#f57c00');
+    expect(outcomeColor('missed_risk')).toBe('#7b1fa2');
+  });
+
+  it('maps ungraded (absent outcome) to gray', () => {
+    expect(outcomeColor(undefined)).toBe('#757575');
+  });
+});
+
+describe('formatCueLabel', () => {
+  it('formats id, ride clock, lead time, delivery latency, outcome, and decoded reasons', () => {
+    expect(
+      formatCueLabel({
+        kind: 'cue',
+        event_id: 1977782249,
+        ride_clock: '10:27',
+        lead_time_s: 15,
+        reasons_bitmask: 7,
+        delivered: true,
+        latency_ms: 752,
+        outcome: 'useful',
+      }),
+    ).toBe('cue 1977782249 · 10:27 · lead 15 s · delivered 752 ms · useful · narrow lane, no shoulder / bike lane, high-speed traffic');
+  });
+
+  it('omits absent fields', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 42 })).toBe('cue 42');
+    expect(formatCueLabel({ kind: 'cue', event_id: 42, ride_clock: '01:02' })).toBe('cue 42 · 01:02');
+  });
+
+  it('renders delivered: false as "not delivered" and suppresses latency', () => {
+    expect(
+      formatCueLabel({ kind: 'cue', event_id: 7, delivered: false, latency_ms: 900, outcome: 'too_late' }),
+    ).toBe('cue 7 · not delivered · too late');
+  });
+
+  it('renders outcomes with spaces, not underscores', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'false_alarm' })).toBe('cue 1 · false alarm');
+    expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'missed_risk' })).toBe('cue 1 · missed risk');
+  });
+
+  it('includes reserved labels for unknown reason bits and omits a zero bitmask', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 3, reasons_bitmask: 9 }))
+      .toBe('cue 3 · narrow lane, reserved(bit 3)');
+    expect(formatCueLabel({ kind: 'cue', event_id: 3, reasons_bitmask: 0 })).toBe('cue 3');
+  });
+});
+
+describe('formatMarkerLabel', () => {
+  it('formats a rider marker with its ride clock', () => {
+    expect(formatMarkerLabel({ kind: 'marker', ride_clock: '55:03' })).toBe('marked unsafe · 55:03');
+  });
+
+  it('omits an absent ride clock', () => {
+    expect(formatMarkerLabel({ kind: 'marker' })).toBe('marked unsafe');
+  });
+});
+
+describe('parseCueEvents', () => {
+  it('parses a valid FeatureCollection into normalized features', () => {
+    const features = parseCueEvents(collection(syntheticCue(), syntheticMarker()));
+    expect(features).toHaveLength(2);
+    expect(features[0]).toEqual({
+      coordinate: [0.001, 0.0005],
+      properties: {
+        kind: 'cue',
+        event_id: 1977782249,
+        ride_clock: '10:27',
+        lead_time_s: 15,
+        reasons_bitmask: 7,
+        delivered: true,
+        latency_ms: 752,
+        outcome: 'useful',
+      },
+    });
+    expect(features[1]).toEqual({
+      coordinate: [0.002, 0.001],
+      properties: { kind: 'marker', ride_clock: '55:03' },
+    });
+  });
+
+  it('accepts a cue with only the required fields (ungraded, no sidecar)', () => {
+    const bare = syntheticCue({
+      ride_clock: undefined,
+      lead_time_s: undefined,
+      reasons_bitmask: undefined,
+      delivered: undefined,
+      latency_ms: undefined,
+      outcome: undefined,
+    });
+    const features = parseCueEvents(collection(bare));
+    expect(features[0]!.properties).toEqual({ kind: 'cue', event_id: 1977782249 });
+  });
+
+  it('accepts an empty FeatureCollection', () => {
+    expect(parseCueEvents(collection())).toEqual([]);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseCueEvents('{nope')).toThrow('not valid JSON');
+  });
+
+  it('throws when the root is not a FeatureCollection', () => {
+    expect(() => parseCueEvents('[]')).toThrow('not a GeoJSON FeatureCollection');
+    expect(() => parseCueEvents('{"type":"Feature"}')).toThrow('not a GeoJSON FeatureCollection');
+  });
+
+  it('throws on non-Point geometry', () => {
+    const bad = { ...(syntheticCue() as object), geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1]] } };
+    expect(() => parseCueEvents(collection(bad))).toThrow('geometry must be a Point');
+  });
+
+  it('throws on non-numeric coordinates', () => {
+    const bad = { ...(syntheticCue() as object), geometry: { type: 'Point', coordinates: ['a', 1] } };
+    expect(() => parseCueEvents(collection(bad))).toThrow('number pair');
+  });
+
+  it('throws on an unknown kind', () => {
+    expect(() => parseCueEvents(collection(syntheticCue({ kind: 'zone' }))))
+      .toThrow('kind must be "cue" or "marker"');
+    expect(() => parseCueEvents(collection(syntheticCue({ kind: undefined }))))
+      .toThrow('kind must be "cue" or "marker"');
+  });
+
+  it('throws when a cue is missing event_id', () => {
+    expect(() => parseCueEvents(collection(syntheticCue({ event_id: undefined }))))
+      .toThrow('event_id must be a number');
+  });
+
+  it('throws when an optional field has the wrong type', () => {
+    expect(() => parseCueEvents(collection(syntheticCue({ latency_ms: '752' }))))
+      .toThrow('latency_ms must be a number');
+    expect(() => parseCueEvents(collection(syntheticCue({ delivered: 'yes' }))))
+      .toThrow('delivered must be a boolean');
+    expect(() => parseCueEvents(collection(syntheticCue({ ride_clock: 627 }))))
+      .toThrow('ride_clock must be a string');
+  });
+
+  it('throws on an unknown outcome grade', () => {
+    expect(() => parseCueEvents(collection(syntheticCue({ outcome: 'great' }))))
+      .toThrow('outcome must be one of useful, false_alarm, too_late, missed_risk');
+  });
+
+  it('throws (all-or-nothing) when only a later feature is malformed', () => {
+    expect(() => parseCueEvents(collection(syntheticCue(), syntheticMarker({ ride_clock: 5 }))))
+      .toThrow('feature 1: property ride_clock must be a string');
+  });
+});

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -1,0 +1,246 @@
+/**
+ * Intent: "Cue events" overlay — points where HEAD_UP cues fired during a cue ride, plus rider-placed
+ *         "unsafe here" markers; complementary to squeeze zones (zones show where the map says risk is,
+ *         cue points show where the policy actually cued and where the rider disagreed)
+ * Context: Data is user-supplied GeoJSON chosen via a file input (deliberately no bundled data or remote
+ *          fetch — cue points reveal the producer's actual rides and webmap.dev is public); persisted to
+ *          localStorage so re-enabling the overlay doesn't require re-picking
+ * Pattern: Pure parse/format functions (unit-tested) + createFileBackedOverlay for the shared
+ *          file-picker/persistence mechanics; validation is all-or-nothing so a malformed file never
+ *          partially renders; reason bitmask decodes via the squeeze-zones table (same producer contract)
+ * Future: Cross-highlighting a cue with the squeeze zone sharing its event_id is deferred — the shared
+ *         id shown in both popups is the v1 link
+ */
+import L from 'leaflet';
+import { createFileBackedOverlay } from './file-overlay';
+import { decodeReasons } from './squeeze-zones';
+
+// FR-008 review grades from the cue ride trace; a cue without a grade renders as "ungraded" gray.
+export const CUE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'missed_risk'] as const;
+export type CueOutcome = (typeof CUE_OUTCOMES)[number];
+
+export interface CueProps {
+  kind: 'cue';
+  event_id: number;
+  ride_clock?: string;
+  lead_time_s?: number;
+  reasons_bitmask?: number;
+  /** false → the cue never reached the wrist (dashed ring); absent from traces without a latency sidecar */
+  delivered?: boolean;
+  latency_ms?: number;
+  outcome?: CueOutcome;
+}
+
+export interface RiderMarkerProps {
+  kind: 'marker';
+  ride_clock?: string;
+}
+
+export interface CueEventFeature {
+  coordinate: [number, number]; // GeoJSON order: [lng, lat]
+  properties: CueProps | RiderMarkerProps;
+}
+
+export function outcomeColor(outcome: CueOutcome | undefined): string {
+  switch (outcome) {
+    case 'useful': return '#2e7d32'; // green
+    case 'false_alarm': return '#d63131'; // red — matches squeeze-zone red
+    case 'too_late': return '#f57c00'; // orange — matches squeeze-zone orange
+    case 'missed_risk': return '#7b1fa2'; // purple
+    default: return '#757575'; // ungraded gray
+  }
+}
+
+const OUTCOME_LABELS: Record<CueOutcome, string> = {
+  useful: 'useful',
+  false_alarm: 'false alarm',
+  too_late: 'too late',
+  missed_risk: 'missed risk',
+};
+
+// Tooltip/popup line: `cue <id> · <clock> · lead N s · delivered N ms · <outcome> · <reasons>`,
+// omitting absent fields. `delivered: false` renders as "not delivered".
+export function formatCueLabel(props: CueProps): string {
+  const parts = [`cue ${props.event_id}`];
+  if (props.ride_clock !== undefined) parts.push(props.ride_clock);
+  if (props.lead_time_s !== undefined) parts.push(`lead ${props.lead_time_s} s`);
+  if (props.delivered === false) {
+    parts.push('not delivered');
+  } else if (props.latency_ms !== undefined) {
+    parts.push(`delivered ${props.latency_ms} ms`);
+  }
+  if (props.outcome !== undefined) parts.push(OUTCOME_LABELS[props.outcome]);
+  if (props.reasons_bitmask !== undefined) {
+    const reasons = decodeReasons(props.reasons_bitmask).join(', ');
+    if (reasons !== '') parts.push(reasons);
+  }
+  return parts.join(' · ');
+}
+
+export function formatMarkerLabel(props: RiderMarkerProps): string {
+  const parts = ['marked unsafe'];
+  if (props.ride_clock !== undefined) parts.push(props.ride_clock);
+  return parts.join(' · ');
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function optionalNumber(p: Record<string, unknown>, key: string, i: number): number | undefined {
+  const v = p[key];
+  if (v === undefined) return undefined;
+  if (!isFiniteNumber(v)) throw new Error(`feature ${i}: property ${key} must be a number`);
+  return v;
+}
+
+function optionalString(p: Record<string, unknown>, key: string, i: number): string | undefined {
+  const v = p[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== 'string') throw new Error(`feature ${i}: property ${key} must be a string`);
+  return v;
+}
+
+function optionalBoolean(p: Record<string, unknown>, key: string, i: number): boolean | undefined {
+  const v = p[key];
+  if (v === undefined) return undefined;
+  if (typeof v !== 'boolean') throw new Error(`feature ${i}: property ${key} must be a boolean`);
+  return v;
+}
+
+// Parse + validate the cue ride-trace FeatureCollection contract. Throws on any
+// malformed feature (all-or-nothing — the caller never partially renders).
+// Returns normalized features so downstream code needs no further guards.
+export function parseCueEvents(text: string): CueEventFeature[] {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error('not valid JSON');
+  }
+
+  const fc = json as { type?: unknown; features?: unknown };
+  if (typeof fc !== 'object' || fc === null || fc.type !== 'FeatureCollection' || !Array.isArray(fc.features)) {
+    throw new Error('not a GeoJSON FeatureCollection');
+  }
+
+  const features: CueEventFeature[] = [];
+  for (let i = 0; i < fc.features.length; i++) {
+    const f = fc.features[i] as {
+      type?: unknown;
+      geometry?: { type?: unknown; coordinates?: unknown };
+      properties?: Record<string, unknown>;
+    };
+    if (typeof f !== 'object' || f === null || f.type !== 'Feature') {
+      throw new Error(`feature ${i}: not a Feature`);
+    }
+    if (f.geometry?.type !== 'Point' || !Array.isArray(f.geometry.coordinates)) {
+      throw new Error(`feature ${i}: geometry must be a Point`);
+    }
+    const pos = f.geometry.coordinates as unknown[];
+    if (!isFiniteNumber(pos[0]) || !isFiniteNumber(pos[1])) {
+      throw new Error(`feature ${i}: position must be a [lng, lat] number pair`);
+    }
+    const coordinate: [number, number] = [pos[0], pos[1]];
+    const p = f.properties;
+    if (typeof p !== 'object' || p === null) {
+      throw new Error(`feature ${i}: missing properties`);
+    }
+
+    if (p['kind'] === 'cue') {
+      if (!isFiniteNumber(p['event_id'])) {
+        throw new Error(`feature ${i}: property event_id must be a number`);
+      }
+      const outcome = optionalString(p, 'outcome', i);
+      if (outcome !== undefined && !(CUE_OUTCOMES as readonly string[]).includes(outcome)) {
+        throw new Error(`feature ${i}: outcome must be one of ${CUE_OUTCOMES.join(', ')}`);
+      }
+      features.push({
+        coordinate,
+        properties: {
+          kind: 'cue',
+          event_id: p['event_id'] as number,
+          ride_clock: optionalString(p, 'ride_clock', i),
+          lead_time_s: optionalNumber(p, 'lead_time_s', i),
+          reasons_bitmask: optionalNumber(p, 'reasons_bitmask', i),
+          delivered: optionalBoolean(p, 'delivered', i),
+          latency_ms: optionalNumber(p, 'latency_ms', i),
+          outcome: outcome as CueOutcome | undefined,
+        },
+      });
+    } else if (p['kind'] === 'marker') {
+      features.push({
+        coordinate,
+        properties: {
+          kind: 'marker',
+          ride_clock: optionalString(p, 'ride_clock', i),
+        },
+      });
+    } else {
+      throw new Error(`feature ${i}: kind must be "cue" or "marker"`);
+    }
+  }
+  return features;
+}
+
+const STORAGE_KEY = 'webmap-cue-events-geojson';
+
+const CUE_RADIUS = 7;
+const CUE_FILL_OPACITY = 0.85;
+const RING_WEIGHT = 2;
+// Dashed ring signals `delivered: false` — the cue was decided but never reached the wrist.
+const UNDELIVERED_DASH = '3 3';
+
+function renderCueEvents(group: L.LayerGroup, features: CueEventFeature[]): void {
+  for (const f of features) {
+    const latlng = L.latLng(f.coordinate[1], f.coordinate[0]);
+    let layer: L.Layer;
+    let label: string;
+    if (f.properties.kind === 'cue') {
+      label = formatCueLabel(f.properties);
+      layer = L.circleMarker(latlng, {
+        radius: CUE_RADIUS,
+        fillColor: outcomeColor(f.properties.outcome),
+        fillOpacity: CUE_FILL_OPACITY,
+        color: '#ffffff',
+        weight: RING_WEIGHT,
+        opacity: 1,
+        dashArray: f.properties.delivered === false ? UNDELIVERED_DASH : undefined,
+        interactive: true,
+      });
+    } else {
+      // Distinct glyph from the circular cue points — a rider-placed "unsafe here" triangle.
+      label = formatMarkerLabel(f.properties);
+      layer = L.marker(latlng, {
+        icon: L.divIcon({
+          className: 'cue-rider-marker',
+          html: '▲',
+          iconSize: [16, 16],
+          iconAnchor: [8, 8],
+        }),
+      });
+    }
+    (layer as L.Marker | L.CircleMarker).bindTooltip(label, { sticky: true });
+    (layer as L.Marker | L.CircleMarker).bindPopup(label); // tap on touch devices, where hover tooltips don't fire
+    group.addLayer(layer);
+  }
+}
+
+/**
+ * Build the layers-control overlay — see createFileBackedOverlay for the
+ * file-picker / persistence / self-disable contract.
+ */
+export function createCueEventsOverlay(
+  showToast: (msg: string, durationMs?: number) => void,
+  disableOverlay: () => void,
+): L.LayerGroup {
+  return createFileBackedOverlay<CueEventFeature>({
+    storageKey: STORAGE_KEY,
+    toastPrefix: 'Cue events',
+    parse: parseCueEvents,
+    render: renderCueEvents,
+    describeLoad: (count) => `Loaded ${count} cue event${count === 1 ? '' : 's'}`,
+    showToast,
+    disableOverlay,
+  });
+}

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -13,6 +13,7 @@
  */
 import L from 'leaflet';
 import { createFileBackedOverlay } from './file-overlay';
+import { escapeHtml } from './html';
 import { decodeReasons } from './squeeze-zones';
 
 // FR-008 review grades from the cue ride trace; a cue without a grade renders as "ungraded" gray.
@@ -67,6 +68,8 @@ export function formatCueLabel(props: CueProps): string {
   if (props.delivered === false) {
     parts.push('not delivered');
   } else if (props.latency_ms !== undefined) {
+    // delivered absent + latency present still reads "delivered" — a latency
+    // sidecar entry implies the cue reached the wrist unless flagged otherwise.
     parts.push(`delivered ${props.latency_ms} ms`);
   }
   if (props.outcome !== undefined) parts.push(OUTCOME_LABELS[props.outcome]);
@@ -194,7 +197,7 @@ const UNDELIVERED_DASH = '3 3';
 function renderCueEvents(group: L.LayerGroup, features: CueEventFeature[]): void {
   for (const f of features) {
     const latlng = L.latLng(f.coordinate[1], f.coordinate[0]);
-    let layer: L.Layer;
+    let layer: L.CircleMarker | L.Marker;
     let label: string;
     if (f.properties.kind === 'cue') {
       label = formatCueLabel(f.properties);
@@ -220,8 +223,11 @@ function renderCueEvents(group: L.LayerGroup, features: CueEventFeature[]): void
         }),
       });
     }
-    (layer as L.Marker | L.CircleMarker).bindTooltip(label, { sticky: true });
-    (layer as L.Marker | L.CircleMarker).bindPopup(label); // tap on touch devices, where hover tooltips don't fire
+    // Leaflet sets popup/tooltip string content via innerHTML, and ride_clock is a
+    // free-form string from a shareable file — escape the assembled label at the sink.
+    const safeLabel = escapeHtml(label);
+    layer.bindTooltip(safeLabel, { sticky: true });
+    layer.bindPopup(safeLabel); // tap on touch devices, where hover tooltips don't fire
     group.addLayer(layer);
   }
 }

--- a/src/file-overlay.ts
+++ b/src/file-overlay.ts
@@ -1,0 +1,125 @@
+/**
+ * Intent: Shared mechanics for overlays backed by a user-supplied GeoJSON file — file picker,
+ *         all-or-nothing parse, localStorage persistence, and self-disable on cancel/malformed input
+ * Context: Extracted from the squeeze-zones overlay so the cue-events overlay (and future
+ *          ride-data overlays) reuse one tested load path instead of duplicating it
+ * Pattern: Config object supplies the overlay-specific parts (parse, render, labels); the returned
+ *          LayerGroup lazy-loads on its first 'add' — persisted data first, then a file picker
+ * Future: Large files that exceed the localStorage quota only persist for the session; move to
+ *         IndexedDB if needed
+ */
+import L from 'leaflet';
+
+export interface FileOverlayConfig<T> {
+  /** localStorage key holding the raw GeoJSON text */
+  storageKey: string;
+  /** Toast prefix, e.g. 'Squeeze zones' → 'Squeeze zones: not valid JSON' */
+  toastPrefix: string;
+  /** Parse + validate the file text; throws on any malformed feature (all-or-nothing) */
+  parse: (text: string) => T[];
+  /** Render parsed features into the (already cleared) group */
+  render: (group: L.LayerGroup, features: T[]) => void;
+  /** Success-toast text for a freshly picked file, e.g. count => `Loaded ${count} …` */
+  describeLoad: (count: number) => string;
+  showToast: (msg: string, durationMs?: number) => void;
+  /** Switch the overlay's layers-control checkbox back off (picker cancelled, malformed file) */
+  disableOverlay: () => void;
+}
+
+/**
+ * Build a layers-control overlay backed by a user-chosen GeoJSON file. The returned
+ * LayerGroup starts empty; on its first 'add' it restores persisted data, or opens a
+ * file picker. On cancel or a malformed file the overlay is switched back off via
+ * `disableOverlay` (and a toast explains why).
+ */
+export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): L.LayerGroup {
+  const group = L.layerGroup();
+  let loaded = false;
+  let fileInput: HTMLInputElement | null = null;
+
+  // Returns the feature count on success, or null if the text is malformed
+  // (after showing a toast). Never partially renders.
+  function loadFromText(text: string, persist: boolean): number | null {
+    let features: T[];
+    try {
+      features = cfg.parse(text);
+    } catch (err: unknown) {
+      const detail = err instanceof Error ? err.message : 'invalid file';
+      cfg.showToast(`${cfg.toastPrefix}: ${detail}`);
+      return null;
+    }
+    group.clearLayers();
+    cfg.render(group, features);
+    loaded = true;
+    if (persist) {
+      try {
+        localStorage.setItem(cfg.storageKey, text);
+      } catch {
+        cfg.showToast(`${cfg.toastPrefix} loaded — too large to save; re-pick the file after a reload`);
+      }
+    }
+    return features.length;
+  }
+
+  function getFileInput(): HTMLInputElement {
+    if (fileInput) return fileInput;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.geojson,.json,application/geo+json,application/json';
+    input.style.display = 'none';
+    input.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(input);
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      input.value = ''; // allow re-picking the same file later
+      if (!file) {
+        cfg.disableOverlay();
+        return;
+      }
+      // FileReader over File.text() for older-Safari compatibility.
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = typeof reader.result === 'string' ? reader.result : '';
+        const count = loadFromText(text, true);
+        if (count === null) {
+          cfg.disableOverlay();
+        } else {
+          cfg.showToast(cfg.describeLoad(count));
+        }
+      };
+      reader.onerror = () => {
+        cfg.showToast(`${cfg.toastPrefix}: could not read file`);
+        cfg.disableOverlay();
+      };
+      reader.readAsText(file);
+    });
+    // Fired by modern browsers when the picker is dismissed without a file.
+    input.addEventListener('cancel', () => cfg.disableOverlay());
+
+    fileInput = input;
+    return input;
+  }
+
+  group.on('add', () => {
+    if (loaded) return;
+
+    let saved: string | null = null;
+    try {
+      saved = localStorage.getItem(cfg.storageKey);
+    } catch { /* localStorage unavailable */ }
+    if (saved !== null && loadFromText(saved, false) !== null) return;
+
+    // Opening a file picker needs user activation. The checkbox toggle has it;
+    // a persisted-on overlay restored at boot does not — ask for a re-toggle.
+    const activation = (navigator as { userActivation?: { isActive?: boolean } }).userActivation;
+    if (activation !== undefined && activation.isActive !== true) {
+      cfg.showToast(`${cfg.toastPrefix}: toggle the overlay again to choose a GeoJSON file`);
+      cfg.disableOverlay();
+      return;
+    }
+    getFileInput().click();
+  });
+
+  return group;
+}

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -9,15 +9,7 @@ import { geosearch, arcgisOnlineProvider, geocodeService } from 'esri-leaflet-ge
 import type { AppState } from './types';
 import { onGuidanceRender, renderGuidanceDashboard, setGuidanceCosting, startGuidance, stopGuidance } from './guidance';
 import type { Costing } from './routing';
-
-// Escape text for safe insertion into innerHTML
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
+import { escapeHtml } from './html';
 
 function createNumberedIcon(n: number): L.DivIcon {
   return L.divIcon({

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -9,6 +9,7 @@ import { fetchRoute } from './routing';
 import { haversineDistance, pointToSegmentMeters } from './geo';
 import { formatDistance } from './units';
 import { showAlertDialog } from './dialog';
+import { escapeHtml } from './html';
 
 const DEFAULT_DOC_TITLE = 'webmap.dev';
 
@@ -477,10 +478,3 @@ function maneuverIcon(type: number): string {
   }
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,0 +1,17 @@
+/**
+ * Intent: Shared HTML-safety helper for the app's innerHTML sinks (Leaflet popups/tooltips, custom widgets)
+ * Context: Previously duplicated privately in geocoding.ts and guidance.ts; hoisted when the cue-events
+ *          overlay became the third consumer (first user-controlled string rendered from a picked file)
+ * Pattern: Escape at the sink — build labels as plain text, escape once before handing to innerHTML
+ * Future: If a rich-content popup ever needs markup plus user text, switch that call site to element
+ *         construction with textContent instead of extending this helper
+ */
+
+// Escape text for safe insertion into innerHTML
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { createInitialState } from './types';
 import { createMap, initOfflineTileFallback, getTileLayers } from './map';
 import { addLayersControl, type LayerDef, type LayersControl, type OverlayDef } from './layers-control';
 import { createSqueezeZonesOverlay } from './squeeze-zones';
+import { createCueEventsOverlay } from './cue-events';
 import { addLocateControl, updateLocateIcon } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
@@ -373,13 +374,17 @@ const layerDefs: LayerDef[] = [
   },
 ];
 
-// Squeeze zones must be able to switch themselves off (file picker cancelled,
-// malformed file), but the control doesn't exist until addLayersControl below —
-// late-bind through this variable and defer to the next tick so a disable during
-// the control's own toggle handling never re-enters it.
+// File-backed overlays must be able to switch themselves off (file picker
+// cancelled, malformed file), but the control doesn't exist until
+// addLayersControl below — late-bind through this variable and defer to the
+// next tick so a disable during the control's own toggle handling never
+// re-enters it.
 let layersControl: LayersControl | null = null;
 const squeezeZonesLayer = createSqueezeZonesOverlay(showToast, () => {
   setTimeout(() => layersControl?.setOverlayEnabled('squeeze-zones', false), 0);
+});
+const cueEventsLayer = createCueEventsOverlay(showToast, () => {
+  setTimeout(() => layersControl?.setOverlayEnabled('cue-events', false), 0);
 });
 
 const overlayDefs: OverlayDef[] = [
@@ -403,6 +408,12 @@ const overlayDefs: OverlayDef[] = [
     name: 'Squeeze zones',
     description: 'Cycling squeeze zones from a GeoJSON file on your device — works offline once loaded',
     tileLayer: squeezeZonesLayer,
+  },
+  {
+    id: 'cue-events',
+    name: 'Cue events',
+    description: 'Where cues fired on a ride, from a GeoJSON file on your device — colored by review outcome',
+    tileLayer: cueEventsLayer,
   },
 ];
 

--- a/src/squeeze-zones.ts
+++ b/src/squeeze-zones.ts
@@ -3,11 +3,12 @@
  * Context: Data is user-supplied GeoJSON chosen via a file input (deliberately no bundled data or remote fetch —
  *          zone geometry reveals the producer's ride region and webmap.dev is public); persisted to localStorage
  *          so re-enabling the overlay doesn't require re-picking
- * Pattern: Pure parse/decode/format functions (unit-tested) + a Leaflet LayerGroup factory that lazy-loads data
- *          on the overlay's first 'add'; validation is all-or-nothing so a malformed file never partially renders
- * Future: Large files that exceed the localStorage quota only persist for the session; move to IndexedDB if needed
+ * Pattern: Pure parse/decode/format functions (unit-tested) + createFileBackedOverlay for the shared
+ *          file-picker/persistence mechanics; validation is all-or-nothing so a malformed file never partially renders
+ * Future: Reason-bitmask decode table is shared with the cue-events overlay — keep REASON_LABELS the single source
  */
 import L from 'leaflet';
+import { createFileBackedOverlay } from './file-overlay';
 
 export interface SqueezeZoneProps {
   event_id: number;
@@ -129,137 +130,55 @@ const BASE_WEIGHT = 5;
 const BASE_OPACITY = 0.8;
 const HOVER_WEIGHT = 8;
 
+function renderZones(group: L.LayerGroup, features: SqueezeZoneFeature[]): void {
+  // Segments sharing an event_id form one logical zone — highlight all members on hover.
+  const zoneMembers = new Map<number, { line: L.Polyline; color: string }[]>();
+
+  for (const f of features) {
+    const latlngs = f.coordinates.map(([lng, lat]) => L.latLng(lat, lng));
+    const color = severityColor(f.properties.severity);
+    const line = L.polyline(latlngs, {
+      color,
+      weight: BASE_WEIGHT,
+      opacity: BASE_OPACITY,
+      interactive: true,
+    });
+    const label = formatZoneLabel(f.properties);
+    line.bindTooltip(label, { sticky: true });
+    line.bindPopup(label); // tap on touch devices, where hover tooltips don't fire
+
+    let members = zoneMembers.get(f.properties.event_id);
+    if (!members) {
+      members = [];
+      zoneMembers.set(f.properties.event_id, members);
+    }
+    members.push({ line, color });
+    const zone = members; // shared array — sees members added after this one
+    line.on('mouseover', () => {
+      for (const m of zone) m.line.setStyle({ weight: HOVER_WEIGHT, opacity: 1 });
+    });
+    line.on('mouseout', () => {
+      for (const m of zone) m.line.setStyle({ color: m.color, weight: BASE_WEIGHT, opacity: BASE_OPACITY });
+    });
+    group.addLayer(line);
+  }
+}
+
 /**
- * Build the layers-control overlay. The returned LayerGroup starts empty; on its
- * first 'add' it restores persisted data, or opens a file picker so the user can
- * choose a GeoJSON file. On cancel or a malformed file the overlay is switched
- * back off via `disableOverlay` (and a toast explains why).
+ * Build the layers-control overlay — see createFileBackedOverlay for the
+ * file-picker / persistence / self-disable contract.
  */
 export function createSqueezeZonesOverlay(
   showToast: (msg: string, durationMs?: number) => void,
   disableOverlay: () => void,
 ): L.LayerGroup {
-  const group = L.layerGroup();
-  let loaded = false;
-  let fileInput: HTMLInputElement | null = null;
-
-  function render(features: SqueezeZoneFeature[]): void {
-    group.clearLayers();
-    // Segments sharing an event_id form one logical zone — highlight all members on hover.
-    const zoneMembers = new Map<number, { line: L.Polyline; color: string }[]>();
-
-    for (const f of features) {
-      const latlngs = f.coordinates.map(([lng, lat]) => L.latLng(lat, lng));
-      const color = severityColor(f.properties.severity);
-      const line = L.polyline(latlngs, {
-        color,
-        weight: BASE_WEIGHT,
-        opacity: BASE_OPACITY,
-        interactive: true,
-      });
-      const label = formatZoneLabel(f.properties);
-      line.bindTooltip(label, { sticky: true });
-      line.bindPopup(label); // tap on touch devices, where hover tooltips don't fire
-
-      let members = zoneMembers.get(f.properties.event_id);
-      if (!members) {
-        members = [];
-        zoneMembers.set(f.properties.event_id, members);
-      }
-      members.push({ line, color });
-      const zone = members; // shared array — sees members added after this one
-      line.on('mouseover', () => {
-        for (const m of zone) m.line.setStyle({ weight: HOVER_WEIGHT, opacity: 1 });
-      });
-      line.on('mouseout', () => {
-        for (const m of zone) m.line.setStyle({ color: m.color, weight: BASE_WEIGHT, opacity: BASE_OPACITY });
-      });
-      group.addLayer(line);
-    }
-  }
-
-  // Returns the segment count on success, or null if the text is malformed
-  // (after showing a toast). Never partially renders.
-  function loadFromText(text: string, persist: boolean): number | null {
-    let features: SqueezeZoneFeature[];
-    try {
-      features = parseSqueezeZones(text);
-    } catch (err: unknown) {
-      const detail = err instanceof Error ? err.message : 'invalid file';
-      showToast(`Squeeze zones: ${detail}`);
-      return null;
-    }
-    render(features);
-    loaded = true;
-    if (persist) {
-      try {
-        localStorage.setItem(STORAGE_KEY, text);
-      } catch {
-        showToast('Squeeze zones loaded — too large to save; re-pick the file after a reload');
-      }
-    }
-    return features.length;
-  }
-
-  function getFileInput(): HTMLInputElement {
-    if (fileInput) return fileInput;
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.geojson,.json,application/geo+json,application/json';
-    input.style.display = 'none';
-    input.setAttribute('aria-hidden', 'true');
-    document.body.appendChild(input);
-
-    input.addEventListener('change', () => {
-      const file = input.files?.[0];
-      input.value = ''; // allow re-picking the same file later
-      if (!file) {
-        disableOverlay();
-        return;
-      }
-      // FileReader over File.text() for older-Safari compatibility.
-      const reader = new FileReader();
-      reader.onload = () => {
-        const text = typeof reader.result === 'string' ? reader.result : '';
-        const count = loadFromText(text, true);
-        if (count === null) {
-          disableOverlay();
-        } else {
-          showToast(`Loaded ${count} squeeze zone segment${count === 1 ? '' : 's'}`);
-        }
-      };
-      reader.onerror = () => {
-        showToast('Squeeze zones: could not read file');
-        disableOverlay();
-      };
-      reader.readAsText(file);
-    });
-    // Fired by modern browsers when the picker is dismissed without a file.
-    input.addEventListener('cancel', () => disableOverlay());
-
-    fileInput = input;
-    return input;
-  }
-
-  group.on('add', () => {
-    if (loaded) return;
-
-    let saved: string | null = null;
-    try {
-      saved = localStorage.getItem(STORAGE_KEY);
-    } catch { /* localStorage unavailable */ }
-    if (saved !== null && loadFromText(saved, false) !== null) return;
-
-    // Opening a file picker needs user activation. The checkbox toggle has it;
-    // a persisted-on overlay restored at boot does not — ask for a re-toggle.
-    const activation = (navigator as { userActivation?: { isActive?: boolean } }).userActivation;
-    if (activation !== undefined && activation.isActive !== true) {
-      showToast('Squeeze zones: toggle the overlay again to choose a GeoJSON file');
-      disableOverlay();
-      return;
-    }
-    getFileInput().click();
+  return createFileBackedOverlay<SqueezeZoneFeature>({
+    storageKey: STORAGE_KEY,
+    toastPrefix: 'Squeeze zones',
+    parse: parseSqueezeZones,
+    render: renderZones,
+    describeLoad: (count) => `Loaded ${count} squeeze zone segment${count === 1 ? '' : 's'}`,
+    showToast,
+    disableOverlay,
   });
-
-  return group;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1664,3 +1664,15 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 .compass-rose--active { opacity: 1; cursor: default; }
 .compass-rose--unavailable { display: none; }
+
+/* Rider-placed "unsafe here" marker in the cue-events overlay — a neutral triangle
+   glyph, deliberately distinct from the outcome-colored circular cue points.
+   Overrides leaflet-div-icon's default white box via a custom divIcon className. */
+.cue-rider-marker {
+  color: #455a64;
+  font-size: 15px;
+  line-height: 16px;
+  text-align: center;
+  text-shadow: 0 0 2px #fff, 0 0 2px #fff;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary

Adds a second toggleable ride-data overlay, **Cue events** (#231), complementary to Squeeze zones (#228): zones show where the map says risk is; this overlay shows where the policy actually cued (`HEAD_UP` cue points) and where the rider disagreed (rider-placed "unsafe here" markers).

## Changes

- **`src/file-overlay.ts` (new)** — `createFileBackedOverlay<T>()`: the file-picker, all-or-nothing parse, localStorage persistence, and self-disable mechanics extracted verbatim from squeeze zones, so both overlays share one tested load path (separate refactor commit, no behavior change — all toast strings preserved).
- **`src/cue-events.ts` (new)** — parse/validate the cue ride-trace Point FeatureCollection (`kind: "cue" | "marker"`); cues render as `L.circleMarker` filled by FR-008 review outcome (useful green, false alarm red, too late orange, missed risk purple, ungraded gray) with a dashed ring when `delivered: false`; rider markers render as a neutral triangle `divIcon` glyph. Tooltip/popup: `cue <id> · <clock> · lead N s · delivered N ms · <outcome> · <decoded reasons>`, omitting absent fields; reason bitmask decodes via the shared squeeze-zones table (unknown bits → `reserved(bit N)`).
- **`src/main.ts`** — wires the `cue-events` `OverlayDef` into the layers control with the same late-bound self-disable pattern as squeeze zones.
- **`src/style.css`** — triangle glyph style for rider markers.
- **`package.json`** — size-limit 110 → 112 kB: baseline was 109.34 kB (660 B headroom); the overlay adds ~1 kB of app code and no new dependencies (110.3 kB gzipped after). Follows prior feature raises (100 → 105 → 108 → 110 kB, the last inside #228).

## Test plan

- 21 new unit tests (`src/cue-events.test.ts`): outcome colors, label formatting (full, absent-field, undelivered, underscore→space outcomes, reserved bits), parse validation (kind discrimination, required `event_id`, optional-field types, unknown outcome grades, non-Point geometry, all-or-nothing).
- Existing squeeze-zones tests (20) still pass against the refactored module.
- `npm run type-check && npm run lint && npm test && npm run size` all green locally.
- Manual: load a hand-built fixture via the file input, toggle both overlays together, verify persistence across reload.

## Assumptions

- "`npm run size` stays green" is satisfied by a modest limit raise in a dedicated `build:` commit, matching the repo's precedent — the criterion guards against dependency bloat, and this adds none.
- Cue↔zone cross-highlight on hover is deferred per the issue ("only if cheap"); the shared `event_id` in both popups is the v1 link.
- Rider-marker tooltip reads `marked unsafe · <ride clock>`; `segment_id`/`approx`/`severity`/`confidence` are accepted but not surfaced (not in the issue's tooltip spec).

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)