### PR TITLE
feat(overlays): allow loading a different GeoJSON file after one is loaded

### DIFF
--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -12,7 +12,7 @@
  *         id shown in both popups is the v1 link
  */
 import L from 'leaflet';
-import { createFileBackedOverlay } from './file-overlay';
+import { createFileBackedOverlay, type FileBackedOverlay } from './file-overlay';
 import { escapeHtml } from './html';
 import { decodeReasons } from './squeeze-zones';
 
@@ -239,7 +239,7 @@ function renderCueEvents(group: L.LayerGroup, features: CueEventFeature[]): void
 export function createCueEventsOverlay(
   showToast: (msg: string, durationMs?: number) => void,
   disableOverlay: () => void,
-): L.LayerGroup {
+): FileBackedOverlay {
   return createFileBackedOverlay<CueEventFeature>({
     storageKey: STORAGE_KEY,
     toastPrefix: 'Cue events',

--- a/src/file-overlay.test.ts
+++ b/src/file-overlay.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import L from 'leaflet';
+import { createFileBackedOverlay } from './file-overlay';
+
+const STORAGE_KEY = 'test-overlay-geojson';
+
+// Parse contract mirrors the real overlays: JSON array of strings, all-or-nothing.
+function parseItems(text: string): string[] {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error('not valid JSON');
+  }
+  if (!Array.isArray(json) || !json.every((v) => typeof v === 'string')) {
+    throw new Error('not a string array');
+  }
+  return json;
+}
+
+function makeOverlay() {
+  const showToast = vi.fn();
+  const disableOverlay = vi.fn();
+  // Real markers in the group so tests can observe old layers being replaced.
+  const render = vi.fn((group: L.LayerGroup, features: string[]) => {
+    features.forEach(() => group.addLayer(L.marker([0, 0])));
+  });
+  const overlay = createFileBackedOverlay<string>({
+    storageKey: STORAGE_KEY,
+    toastPrefix: 'Test overlay',
+    parse: parseItems,
+    render,
+    describeLoad: (count) => `Loaded ${count}`,
+    showToast,
+    disableOverlay,
+  });
+  return { overlay, showToast, disableOverlay, render };
+}
+
+function getPickerInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) throw new Error('file input not created');
+  return input;
+}
+
+function pickFile(contents: string): void {
+  const input = getPickerInput();
+  const file = new File([contents], 'data.geojson', { type: 'application/geo+json' });
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  input.dispatchEvent(new Event('change'));
+}
+
+function cancelPick(): void {
+  getPickerInput().dispatchEvent(new Event('cancel'));
+}
+
+describe('createFileBackedOverlay', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('opens the picker on first add, then renders and persists the picked file', async () => {
+    const { overlay, render, showToast, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('["a","b"]');
+
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+    expect(render).toHaveBeenCalledWith(overlay.group, ['a', 'b']);
+    expect(overlay.group.getLayers()).toHaveLength(2);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('["a","b"]');
+    expect(showToast).toHaveBeenCalledWith('Loaded 2');
+    expect(disableOverlay).not.toHaveBeenCalled();
+  });
+
+  it('cancel on the initial pick still disables the overlay', () => {
+    const { overlay, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    cancelPick();
+    expect(disableOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('malformed file on the initial pick disables the overlay and toasts', async () => {
+    const { overlay, showToast, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('not json');
+
+    await vi.waitFor(() => expect(disableOverlay).toHaveBeenCalledTimes(1));
+    expect(showToast).toHaveBeenCalledWith('Test overlay: not valid JSON');
+    expect(overlay.group.getLayers()).toHaveLength(0);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('requestFilePick replaces rendered layers and the persisted copy', async () => {
+    const { overlay, render, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('["a","b"]');
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+
+    overlay.requestFilePick();
+    pickFile('["c"]');
+
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2));
+    expect(render).toHaveBeenLastCalledWith(overlay.group, ['c']);
+    expect(overlay.group.getLayers()).toHaveLength(1); // old layers cleared, not stacked
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('["c"]');
+    expect(disableOverlay).not.toHaveBeenCalled();
+  });
+
+  it('replaces persisted-restored data after a reload', async () => {
+    localStorage.setItem(STORAGE_KEY, '["a","b"]');
+    const { overlay, render, disableOverlay } = makeOverlay();
+    overlay.group.fire('add'); // restores from localStorage, no picker
+    expect(render).toHaveBeenCalledTimes(1);
+
+    overlay.requestFilePick();
+    pickFile('["c"]');
+
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(2));
+    expect(render).toHaveBeenLastCalledWith(overlay.group, ['c']);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('["c"]');
+    expect(disableOverlay).not.toHaveBeenCalled();
+  });
+
+  it('cancelling a replacement pick keeps the current data and the overlay on', async () => {
+    const { overlay, render, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('["a","b"]');
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+
+    overlay.requestFilePick();
+    cancelPick();
+
+    expect(disableOverlay).not.toHaveBeenCalled();
+    expect(overlay.group.getLayers()).toHaveLength(2);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('["a","b"]');
+  });
+
+  it('a malformed replacement file keeps the current data and the overlay on', async () => {
+    const { overlay, render, showToast, disableOverlay } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('["a","b"]');
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+
+    overlay.requestFilePick();
+    pickFile('{"not":"an array"}');
+
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalledWith('Test overlay: not a string array'));
+    expect(disableOverlay).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1); // never re-rendered
+    expect(overlay.group.getLayers()).toHaveLength(2);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('["a","b"]');
+  });
+
+  it('re-add after data is loaded does not reopen the picker', async () => {
+    const { overlay, render } = makeOverlay();
+    overlay.group.fire('add');
+    pickFile('["a"]');
+    await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+
+    const clickSpy = vi.spyOn(getPickerInput(), 'click');
+    overlay.group.fire('add');
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/file-overlay.ts
+++ b/src/file-overlay.ts
@@ -4,7 +4,8 @@
  * Context: Extracted from the squeeze-zones overlay so the cue-events overlay (and future
  *          ride-data overlays) reuse one tested load path instead of duplicating it
  * Pattern: Config object supplies the overlay-specific parts (parse, render, labels); the returned
- *          LayerGroup lazy-loads on its first 'add' — persisted data first, then a file picker
+ *          group lazy-loads on its first 'add' — persisted data first, then a file picker — and
+ *          requestFilePick lets the layers control swap in a different file at any time
  * Future: Large files that exceed the localStorage quota only persist for the session; move to
  *         IndexedDB if needed
  */
@@ -22,17 +23,34 @@ export interface FileOverlayConfig<T> {
   /** Success-toast text for a freshly picked file, e.g. count => `Loaded ${count} …` */
   describeLoad: (count: number) => string;
   showToast: (msg: string, durationMs?: number) => void;
-  /** Switch the overlay's layers-control checkbox back off (picker cancelled, malformed file) */
+  /**
+   * Switch the overlay's layers-control checkbox back off (picker cancelled, malformed
+   * file). Only called while nothing is loaded yet — a failed replacement pick keeps
+   * the current data and leaves the overlay on.
+   */
   disableOverlay: () => void;
+}
+
+export interface FileBackedOverlay {
+  /** The layer group to register with the layers control */
+  group: L.LayerGroup;
+  /**
+   * Open the file picker to load a (different) file. Must be called from a user
+   * gesture — a click carries the user activation the picker needs. On success the
+   * new data replaces both the rendered layers and the persisted copy; on cancel or
+   * a malformed file the current data stays fully intact.
+   */
+  requestFilePick: () => void;
 }
 
 /**
  * Build a layers-control overlay backed by a user-chosen GeoJSON file. The returned
- * LayerGroup starts empty; on its first 'add' it restores persisted data, or opens a
- * file picker. On cancel or a malformed file the overlay is switched back off via
- * `disableOverlay` (and a toast explains why).
+ * group starts empty; on its first 'add' it restores persisted data, or opens a
+ * file picker. While nothing is loaded, cancel or a malformed file switches the
+ * overlay back off via `disableOverlay` (and a toast explains why); once data is
+ * loaded, a failed pick keeps it untouched.
  */
-export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): L.LayerGroup {
+export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): FileBackedOverlay {
   const group = L.layerGroup();
   let loaded = false;
   let fileInput: HTMLInputElement | null = null;
@@ -70,11 +88,17 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): L.LayerGr
     input.setAttribute('aria-hidden', 'true');
     document.body.appendChild(input);
 
+    // A pick that fails before anything is loaded switches the overlay off;
+    // a failed replacement pick keeps the current data and leaves it on.
+    const disableIfNothingLoaded = (): void => {
+      if (!loaded) cfg.disableOverlay();
+    };
+
     input.addEventListener('change', () => {
       const file = input.files?.[0];
       input.value = ''; // allow re-picking the same file later
       if (!file) {
-        cfg.disableOverlay();
+        disableIfNothingLoaded();
         return;
       }
       // FileReader over File.text() for older-Safari compatibility.
@@ -83,19 +107,19 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): L.LayerGr
         const text = typeof reader.result === 'string' ? reader.result : '';
         const count = loadFromText(text, true);
         if (count === null) {
-          cfg.disableOverlay();
+          disableIfNothingLoaded();
         } else {
           cfg.showToast(cfg.describeLoad(count));
         }
       };
       reader.onerror = () => {
         cfg.showToast(`${cfg.toastPrefix}: could not read file`);
-        cfg.disableOverlay();
+        disableIfNothingLoaded();
       };
       reader.readAsText(file);
     });
     // Fired by modern browsers when the picker is dismissed without a file.
-    input.addEventListener('cancel', () => cfg.disableOverlay());
+    input.addEventListener('cancel', disableIfNothingLoaded);
 
     fileInput = input;
     return input;
@@ -121,5 +145,8 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): L.LayerGr
     getFileInput().click();
   });
 
-  return group;
+  return {
+    group,
+    requestFilePick: () => getFileInput().click(),
+  };
 }

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -28,6 +28,11 @@ export interface OverlayDef {
   // L.Layer (not L.TileLayer) so an overlay can be a composite L.LayerGroup —
   // e.g. the 'Routes' overlay (Waymarked hiking + cycling route tiles).
   tileLayer: L.Layer;
+  // File-backed overlays supply this to get a "Change…" button on their row —
+  // it reopens the file picker so a different file can replace the loaded one.
+  // Enabled only while the overlay is checked (the picker needs the overlay's
+  // load path active, and a click here carries the required user activation).
+  requestFilePick?: () => void;
 }
 
 const LAYERS_STORAGE_KEY = 'webmap-layer-selection';
@@ -297,6 +302,7 @@ export class LayersControl extends L.Control {
 
         L.DomEvent.on(checkbox, 'change', () => {
           this.toggleOverlay(overlay, checkbox.checked);
+          this.syncChangeFileButton(overlay.id, checkbox.checked);
         });
 
         label.appendChild(checkbox);
@@ -311,6 +317,23 @@ export class LayersControl extends L.Control {
           overlayDesc.className = 'layers-option__desc';
           overlayDesc.textContent = overlay.description;
           label.appendChild(overlayDesc);
+        }
+
+        const requestFilePick = overlay.requestFilePick;
+        if (requestFilePick) {
+          const changeBtn = document.createElement('button');
+          changeBtn.type = 'button';
+          changeBtn.className = 'layers-option__change-file';
+          changeBtn.dataset['overlayId'] = overlay.id;
+          changeBtn.textContent = 'Change…';
+          changeBtn.title = 'Load a different GeoJSON file';
+          changeBtn.disabled = !checkbox.checked;
+          L.DomEvent.on(changeBtn, 'click', (e: Event) => {
+            // Keep the click from toggling the wrapping label's checkbox.
+            L.DomEvent.stop(e);
+            requestFilePick();
+          });
+          label.appendChild(changeBtn);
         }
 
         overlaysFieldset.appendChild(label);
@@ -365,6 +388,14 @@ export class LayersControl extends L.Control {
     this.toggleOverlay(overlay, enabled);
     const checkbox = this.popoverEl?.querySelector<HTMLInputElement>(`input[name="overlay-${id}"]`);
     if (checkbox) checkbox.checked = enabled;
+    this.syncChangeFileButton(id, enabled);
+  }
+
+  private syncChangeFileButton(id: string, enabled: boolean): void {
+    const btn = this.popoverEl?.querySelector<HTMLButtonElement>(
+      `button.layers-option__change-file[data-overlay-id="${id}"]`,
+    );
+    if (btn) btn.disabled = !enabled;
   }
 
   private toggleOverlay(overlay: OverlayDef, enabled: boolean): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -380,10 +380,10 @@ const layerDefs: LayerDef[] = [
 // next tick so a disable during the control's own toggle handling never
 // re-enters it.
 let layersControl: LayersControl | null = null;
-const squeezeZonesLayer = createSqueezeZonesOverlay(showToast, () => {
+const squeezeZonesOverlay = createSqueezeZonesOverlay(showToast, () => {
   setTimeout(() => layersControl?.setOverlayEnabled('squeeze-zones', false), 0);
 });
-const cueEventsLayer = createCueEventsOverlay(showToast, () => {
+const cueEventsOverlay = createCueEventsOverlay(showToast, () => {
   setTimeout(() => layersControl?.setOverlayEnabled('cue-events', false), 0);
 });
 
@@ -407,13 +407,15 @@ const overlayDefs: OverlayDef[] = [
     id: 'squeeze-zones',
     name: 'Squeeze zones',
     description: 'Cycling squeeze zones from a GeoJSON file on your device — works offline once loaded',
-    tileLayer: squeezeZonesLayer,
+    tileLayer: squeezeZonesOverlay.group,
+    requestFilePick: squeezeZonesOverlay.requestFilePick,
   },
   {
     id: 'cue-events',
     name: 'Cue events',
     description: 'Where cues fired on a ride, from a GeoJSON file on your device — colored by review outcome',
-    tileLayer: cueEventsLayer,
+    tileLayer: cueEventsOverlay.group,
+    requestFilePick: cueEventsOverlay.requestFilePick,
   },
 ];
 

--- a/src/squeeze-zones.ts
+++ b/src/squeeze-zones.ts
@@ -8,7 +8,7 @@
  * Future: Reason-bitmask decode table is shared with the cue-events overlay — keep REASON_LABELS the single source
  */
 import L from 'leaflet';
-import { createFileBackedOverlay } from './file-overlay';
+import { createFileBackedOverlay, type FileBackedOverlay } from './file-overlay';
 
 export interface SqueezeZoneProps {
   event_id: number;
@@ -171,7 +171,7 @@ function renderZones(group: L.LayerGroup, features: SqueezeZoneFeature[]): void 
 export function createSqueezeZonesOverlay(
   showToast: (msg: string, durationMs?: number) => void,
   disableOverlay: () => void,
-): L.LayerGroup {
+): FileBackedOverlay {
   return createFileBackedOverlay<SqueezeZoneFeature>({
     storageKey: STORAGE_KEY,
     toastPrefix: 'Squeeze zones',

--- a/src/style.css
+++ b/src/style.css
@@ -1439,6 +1439,29 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   margin-top: 2px;
 }
 
+.layers-option__change-file {
+  align-self: center;
+  margin-left: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: #4287f5;
+  background: none;
+  border: 1px solid rgba(66, 135, 245, 0.4);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.layers-option__change-file:hover:not(:disabled) {
+  background-color: rgba(66, 135, 245, 0.12);
+}
+
+.layers-option__change-file:disabled {
+  color: #bbb;
+  border-color: #ddd;
+  cursor: default;
+}
+
 
 
 /* Mobile layers popover ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Fixes the dead end where a file-backed overlay (Squeeze zones, Cue events) could never load a different GeoJSON file once one was loaded — previously the only workaround was `localStorage.removeItem(...)` in DevTools plus a reload.

Closes #235

## Changes

- **`src/file-overlay.ts`**: `createFileBackedOverlay` now returns `{ group, requestFilePick }` (new `FileBackedOverlay` interface). `requestFilePick()` reopens the file picker at any time. Cancel / malformed file / read error now only call `disableOverlay()` while nothing is loaded yet — a failed replacement pick keeps the current data, rendering, persistence, and checkbox state fully intact (the all-or-nothing load path never mutates state before a successful parse).
- **`src/layers-control.ts`**: `OverlayDef` gains optional `requestFilePick`; overlay rows that supply it get a **Change…** button. The button is disabled while the overlay is unchecked and stays in sync through both the checkbox handler and `setOverlayEnabled`. `L.DomEvent.stop` keeps the click from toggling the wrapping label's checkbox. The click carries user activation, satisfying the `navigator.userActivation` guard.
- **`src/squeeze-zones.ts` / `src/cue-events.ts`**: return type updated to `FileBackedOverlay` — both overlays get the affordance identically.
- **`src/main.ts`**: wires `group` + `requestFilePick` into the two overlay defs.
- **`src/style.css`**: styling for the new button (enabled/hover/disabled).
- **`src/file-overlay.test.ts`** (new): 8 tests covering initial pick, initial cancel/malformed still disabling, replace via `requestFilePick` (same-session and persisted-restore paths), cancel-keeps-old, malformed-keeps-old, and no picker reopen on re-add.

## Test plan

- `npm run type-check` && `npm run lint` — clean
- `npm test` — 146 passed (8 new in `file-overlay.test.ts`)
- `npm run build` && `npm run size` — 110.81 kB gzipped, under the 112 kB cap
- Manual: toggle overlay on → pick file → Change… → pick different file (replaces on screen + in localStorage); Change… → cancel or malformed file leaves existing data untouched; button disabled while overlay is off

## Assumptions

- Issue #235 left off-state behavior to the implementer ("hidden/disabled or enable the overlay as part of picking"); chose **disabled while unchecked** — it avoids double-picker races with the group's lazy `'add'` load path and keeps checkbox/persistence/rendering state trivially consistent.
- No new runtime dependencies; ES2020-only syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)