### PR TITLE
feat(map): render GPS track and exact event positions in cue events overlay

### DIFF
--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -38,6 +38,14 @@ function syntheticMarker(overrides: Record<string, unknown> = {}): unknown {
   };
 }
 
+function syntheticTrack(coordinates: unknown = [[0.001, 0.0005], [0.0011, 0.00055], [0.0012, 0.0006]]): unknown {
+  return {
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates },
+    properties: { kind: 'track' },
+  };
+}
+
 function collection(...features: unknown[]): string {
   return JSON.stringify({ type: 'FeatureCollection', features });
 }
@@ -96,6 +104,12 @@ describe('formatCueLabel', () => {
       .toBe('cue 3 · narrow lane, reserved(bit 3)');
     expect(formatCueLabel({ kind: 'cue', event_id: 3, reasons_bitmask: 0 })).toBe('cue 3');
   });
+
+  it('indicates approximate placement only when approx is true', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 9, approx: true })).toBe('cue 9 · approximate position');
+    expect(formatCueLabel({ kind: 'cue', event_id: 9, approx: false })).toBe('cue 9');
+    expect(formatCueLabel({ kind: 'cue', event_id: 9 })).toBe('cue 9');
+  });
 });
 
 describe('formatMarkerLabel', () => {
@@ -105,6 +119,11 @@ describe('formatMarkerLabel', () => {
 
   it('omits an absent ride clock', () => {
     expect(formatMarkerLabel({ kind: 'marker' })).toBe('marked unsafe');
+  });
+
+  it('indicates approximate placement only when approx is true', () => {
+    expect(formatMarkerLabel({ kind: 'marker', approx: true })).toBe('marked unsafe · approximate position');
+    expect(formatMarkerLabel({ kind: 'marker', approx: false })).toBe('marked unsafe');
   });
 });
 
@@ -123,11 +142,12 @@ describe('parseCueEvents', () => {
         delivered: true,
         latency_ms: 752,
         outcome: 'useful',
+        approx: true,
       },
     });
     expect(features[1]).toEqual({
       coordinate: [0.002, 0.001],
-      properties: { kind: 'marker', ride_clock: '55:03' },
+      properties: { kind: 'marker', ride_clock: '55:03', approx: true },
     });
   });
 
@@ -139,6 +159,7 @@ describe('parseCueEvents', () => {
       delivered: undefined,
       latency_ms: undefined,
       outcome: undefined,
+      approx: undefined,
     });
     const features = parseCueEvents(collection(bare));
     expect(features[0]!.properties).toEqual({ kind: 'cue', event_id: 1977782249 });
@@ -169,9 +190,9 @@ describe('parseCueEvents', () => {
 
   it('throws on an unknown kind', () => {
     expect(() => parseCueEvents(collection(syntheticCue({ kind: 'zone' }))))
-      .toThrow('kind must be "cue" or "marker"');
+      .toThrow('kind must be "cue", "marker", or "track"');
     expect(() => parseCueEvents(collection(syntheticCue({ kind: undefined }))))
-      .toThrow('kind must be "cue" or "marker"');
+      .toThrow('kind must be "cue", "marker", or "track"');
   });
 
   it('throws when a cue is missing event_id', () => {
@@ -186,6 +207,41 @@ describe('parseCueEvents', () => {
       .toThrow('delivered must be a boolean');
     expect(() => parseCueEvents(collection(syntheticCue({ ride_clock: 627 }))))
       .toThrow('ride_clock must be a string');
+    expect(() => parseCueEvents(collection(syntheticCue({ approx: 'yes' }))))
+      .toThrow('approx must be a boolean');
+  });
+
+  it('parses a track feature into its coordinate list', () => {
+    const features = parseCueEvents(collection(syntheticTrack(), syntheticCue({ approx: undefined })));
+    expect(features).toHaveLength(2);
+    expect(features[0]).toEqual({
+      coordinates: [[0.001, 0.0005], [0.0011, 0.00055], [0.0012, 0.0006]],
+      properties: { kind: 'track' },
+    });
+  });
+
+  it('throws when a track is not a LineString', () => {
+    const bad = { ...(syntheticTrack() as object), geometry: { type: 'Point', coordinates: [0, 0] } };
+    expect(() => parseCueEvents(collection(bad))).toThrow('track geometry must be a LineString');
+  });
+
+  it('throws when a track has fewer than 2 positions', () => {
+    expect(() => parseCueEvents(collection(syntheticTrack([[0.001, 0.0005]]))))
+      .toThrow('track must have at least 2 positions');
+    expect(() => parseCueEvents(collection(syntheticTrack([]))))
+      .toThrow('track must have at least 2 positions');
+  });
+
+  it('throws when a track position is not a [lng, lat] number pair', () => {
+    expect(() => parseCueEvents(collection(syntheticTrack([[0.001, 0.0005], ['a', 1]]))))
+      .toThrow('track positions must be [lng, lat] number pairs');
+    expect(() => parseCueEvents(collection(syntheticTrack([[0.001, 0.0005], 7]))))
+      .toThrow('track positions must be [lng, lat] number pairs');
+  });
+
+  it('throws on more than one track feature', () => {
+    expect(() => parseCueEvents(collection(syntheticTrack(), syntheticTrack())))
+      .toThrow('feature 1: more than one track feature');
   });
 
   it('throws on an unknown outcome grade', () => {

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -1,7 +1,9 @@
 /**
  * Intent: "Cue events" overlay — points where HEAD_UP cues fired during a cue ride, plus rider-placed
  *         "unsafe here" markers; complementary to squeeze zones (zones show where the map says risk is,
- *         cue points show where the policy actually cued and where the rider disagreed)
+ *         cue points show where the policy actually cued and where the rider disagreed). Traces exported
+ *         with the debug-GPS toggle on also carry a per-sample GPS track (drawn beneath the points as
+ *         context) and exact event positions (approx omitted) instead of segment midpoints (approx: true)
  * Context: Data is user-supplied GeoJSON chosen via a file input (deliberately no bundled data or remote
  *          fetch — cue points reveal the producer's actual rides and webmap.dev is public); persisted to
  *          localStorage so re-enabling the overlay doesn't require re-picking
@@ -30,17 +32,29 @@ export interface CueProps {
   delivered?: boolean;
   latency_ms?: number;
   outcome?: CueOutcome;
+  /** true → point is a segment midpoint, not a GPS fix; absent/false → exact position */
+  approx?: boolean;
 }
 
 export interface RiderMarkerProps {
   kind: 'marker';
   ride_clock?: string;
+  /** true → point is a segment midpoint, not a GPS fix; absent/false → exact position */
+  approx?: boolean;
 }
 
 export interface CueEventFeature {
   coordinate: [number, number]; // GeoJSON order: [lng, lat]
   properties: CueProps | RiderMarkerProps;
 }
+
+/** Per-sample GPS track (zero or one per file) drawn beneath the event points as context. */
+export interface TrackFeature {
+  coordinates: [number, number][]; // GeoJSON order: [lng, lat]
+  properties: { kind: 'track' };
+}
+
+export type CueFileFeature = CueEventFeature | TrackFeature;
 
 export function outcomeColor(outcome: CueOutcome | undefined): string {
   switch (outcome) {
@@ -77,12 +91,14 @@ export function formatCueLabel(props: CueProps): string {
     const reasons = decodeReasons(props.reasons_bitmask).join(', ');
     if (reasons !== '') parts.push(reasons);
   }
+  if (props.approx === true) parts.push('approximate position');
   return parts.join(' · ');
 }
 
 export function formatMarkerLabel(props: RiderMarkerProps): string {
   const parts = ['marked unsafe'];
   if (props.ride_clock !== undefined) parts.push(props.ride_clock);
+  if (props.approx === true) parts.push('approximate position');
   return parts.join(' · ');
 }
 
@@ -114,7 +130,7 @@ function optionalBoolean(p: Record<string, unknown>, key: string, i: number): bo
 // Parse + validate the cue ride-trace FeatureCollection contract. Throws on any
 // malformed feature (all-or-nothing — the caller never partially renders).
 // Returns normalized features so downstream code needs no further guards.
-export function parseCueEvents(text: string): CueEventFeature[] {
+export function parseCueEvents(text: string): CueFileFeature[] {
   let json: unknown;
   try {
     json = JSON.parse(text);
@@ -127,7 +143,8 @@ export function parseCueEvents(text: string): CueEventFeature[] {
     throw new Error('not a GeoJSON FeatureCollection');
   }
 
-  const features: CueEventFeature[] = [];
+  const features: CueFileFeature[] = [];
+  let hasTrack = false;
   for (let i = 0; i < fc.features.length; i++) {
     const f = fc.features[i] as {
       type?: unknown;
@@ -137,6 +154,34 @@ export function parseCueEvents(text: string): CueEventFeature[] {
     if (typeof f !== 'object' || f === null || f.type !== 'Feature') {
       throw new Error(`feature ${i}: not a Feature`);
     }
+    const p = f.properties;
+    if (typeof p !== 'object' || p === null) {
+      throw new Error(`feature ${i}: missing properties`);
+    }
+
+    if (p['kind'] === 'track') {
+      if (hasTrack) {
+        throw new Error(`feature ${i}: more than one track feature`);
+      }
+      if (f.geometry?.type !== 'LineString' || !Array.isArray(f.geometry.coordinates)) {
+        throw new Error(`feature ${i}: track geometry must be a LineString`);
+      }
+      const positions = f.geometry.coordinates as unknown[];
+      if (positions.length < 2) {
+        throw new Error(`feature ${i}: track must have at least 2 positions`);
+      }
+      const coordinates: [number, number][] = [];
+      for (const pos of positions) {
+        if (!Array.isArray(pos) || !isFiniteNumber(pos[0]) || !isFiniteNumber(pos[1])) {
+          throw new Error(`feature ${i}: track positions must be [lng, lat] number pairs`);
+        }
+        coordinates.push([pos[0], pos[1]]);
+      }
+      hasTrack = true;
+      features.push({ coordinates, properties: { kind: 'track' } });
+      continue;
+    }
+
     if (f.geometry?.type !== 'Point' || !Array.isArray(f.geometry.coordinates)) {
       throw new Error(`feature ${i}: geometry must be a Point`);
     }
@@ -145,10 +190,6 @@ export function parseCueEvents(text: string): CueEventFeature[] {
       throw new Error(`feature ${i}: position must be a [lng, lat] number pair`);
     }
     const coordinate: [number, number] = [pos[0], pos[1]];
-    const p = f.properties;
-    if (typeof p !== 'object' || p === null) {
-      throw new Error(`feature ${i}: missing properties`);
-    }
 
     if (p['kind'] === 'cue') {
       if (!isFiniteNumber(p['event_id'])) {
@@ -169,6 +210,7 @@ export function parseCueEvents(text: string): CueEventFeature[] {
           delivered: optionalBoolean(p, 'delivered', i),
           latency_ms: optionalNumber(p, 'latency_ms', i),
           outcome: outcome as CueOutcome | undefined,
+          approx: optionalBoolean(p, 'approx', i),
         },
       });
     } else if (p['kind'] === 'marker') {
@@ -177,10 +219,11 @@ export function parseCueEvents(text: string): CueEventFeature[] {
         properties: {
           kind: 'marker',
           ride_clock: optionalString(p, 'ride_clock', i),
+          approx: optionalBoolean(p, 'approx', i),
         },
       });
     } else {
-      throw new Error(`feature ${i}: kind must be "cue" or "marker"`);
+      throw new Error(`feature ${i}: kind must be "cue", "marker", or "track"`);
     }
   }
   return features;
@@ -193,9 +236,30 @@ const CUE_FILL_OPACITY = 0.85;
 const RING_WEIGHT = 2;
 // Dashed ring signals `delivered: false` — the cue was decided but never reached the wrist.
 const UNDELIVERED_DASH = '3 3';
+// Subtle, muted styling so the GPS track reads as context beneath the event points, not data.
+const TRACK_COLOR = '#78909c';
+const TRACK_WEIGHT = 2;
+const TRACK_OPACITY = 0.6;
 
-function renderCueEvents(group: L.LayerGroup, features: CueEventFeature[]): void {
+function isTrack(f: CueFileFeature): f is TrackFeature {
+  return f.properties.kind === 'track';
+}
+
+function renderCueEvents(group: L.LayerGroup, features: CueFileFeature[]): void {
+  // Track first — vector layers share the overlay pane, so earlier layers draw beneath.
   for (const f of features) {
+    if (!isTrack(f)) continue;
+    group.addLayer(
+      L.polyline(f.coordinates.map((c) => L.latLng(c[1], c[0])), {
+        color: TRACK_COLOR,
+        weight: TRACK_WEIGHT,
+        opacity: TRACK_OPACITY,
+        interactive: false,
+      }),
+    );
+  }
+  for (const f of features) {
+    if (isTrack(f)) continue;
     const latlng = L.latLng(f.coordinate[1], f.coordinate[0]);
     let layer: L.CircleMarker | L.Marker;
     let label: string;
@@ -240,12 +304,16 @@ export function createCueEventsOverlay(
   showToast: (msg: string, durationMs?: number) => void,
   disableOverlay: () => void,
 ): FileBackedOverlay {
-  return createFileBackedOverlay<CueEventFeature>({
+  return createFileBackedOverlay<CueFileFeature>({
     storageKey: STORAGE_KEY,
     toastPrefix: 'Cue events',
     parse: parseCueEvents,
     render: renderCueEvents,
-    describeLoad: (count) => `Loaded ${count} cue event${count === 1 ? '' : 's'}`,
+    // The track is context, not an event — exclude it from the load toast count.
+    describeLoad: (features) => {
+      const count = features.filter((f) => f.properties.kind !== 'track').length;
+      return `Loaded ${count} cue event${count === 1 ? '' : 's'}`;
+    },
     showToast,
     disableOverlay,
   });

--- a/src/file-overlay.test.ts
+++ b/src/file-overlay.test.ts
@@ -30,7 +30,7 @@ function makeOverlay() {
     toastPrefix: 'Test overlay',
     parse: parseItems,
     render,
-    describeLoad: (count) => `Loaded ${count}`,
+    describeLoad: (features) => `Loaded ${features.length}`,
     showToast,
     disableOverlay,
   });

--- a/src/file-overlay.ts
+++ b/src/file-overlay.ts
@@ -20,8 +20,8 @@ export interface FileOverlayConfig<T> {
   parse: (text: string) => T[];
   /** Render parsed features into the (already cleared) group */
   render: (group: L.LayerGroup, features: T[]) => void;
-  /** Success-toast text for a freshly picked file, e.g. count => `Loaded ${count} …` */
-  describeLoad: (count: number) => string;
+  /** Success-toast text for a freshly picked file, e.g. features => `Loaded ${features.length} …` */
+  describeLoad: (features: T[]) => string;
   showToast: (msg: string, durationMs?: number) => void;
   /**
    * Switch the overlay's layers-control checkbox back off (picker cancelled, malformed
@@ -55,9 +55,9 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): FileBacke
   let loaded = false;
   let fileInput: HTMLInputElement | null = null;
 
-  // Returns the feature count on success, or null if the text is malformed
+  // Returns the parsed features on success, or null if the text is malformed
   // (after showing a toast). Never partially renders.
-  function loadFromText(text: string, persist: boolean): number | null {
+  function loadFromText(text: string, persist: boolean): T[] | null {
     let features: T[];
     try {
       features = cfg.parse(text);
@@ -76,7 +76,7 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): FileBacke
         cfg.showToast(`${cfg.toastPrefix} loaded — too large to save; re-pick the file after a reload`);
       }
     }
-    return features.length;
+    return features;
   }
 
   function getFileInput(): HTMLInputElement {
@@ -105,11 +105,11 @@ export function createFileBackedOverlay<T>(cfg: FileOverlayConfig<T>): FileBacke
       const reader = new FileReader();
       reader.onload = () => {
         const text = typeof reader.result === 'string' ? reader.result : '';
-        const count = loadFromText(text, true);
-        if (count === null) {
+        const features = loadFromText(text, true);
+        if (features === null) {
           disableIfNothingLoaded();
         } else {
-          cfg.showToast(cfg.describeLoad(count));
+          cfg.showToast(cfg.describeLoad(features));
         }
       };
       reader.onerror = () => {

--- a/src/squeeze-zones.ts
+++ b/src/squeeze-zones.ts
@@ -177,7 +177,7 @@ export function createSqueezeZonesOverlay(
     toastPrefix: 'Squeeze zones',
     parse: parseSqueezeZones,
     render: renderZones,
-    describeLoad: (count) => `Loaded ${count} squeeze zone segment${count === 1 ? '' : 's'}`,
+    describeLoad: (features) => `Loaded ${features.length} squeeze zone segment${features.length === 1 ? '' : 's'}`,
     showToast,
     disableOverlay,
   });


### PR DESCRIPTION
## Summary

Extends the **Cue events** overlay (#231/#232) to consume the GPS data the cue exporter emits when the debug-GPS toggle was on (producer side: jasoneplumb/cue#113). Two backward-compatible contract additions: an optional `kind: "track"` LineString feature rendered as a subtle context polyline beneath the event points, and exact event positions signaled by an omitted/`false` `approx` property.

Closes #236

## Changes

- **`src/cue-events.ts`**
  - New `TrackFeature` type + `CueFileFeature` union; `parseCueEvents` accepts zero or one `kind: "track"` feature (LineString, ≥ 2 positions, finite `[lng, lat]` pairs). A second track, non-LineString geometry, too-few positions, or a bad pair rejects the whole file (all-or-nothing contract unchanged).
  - `approx?: boolean` parsed on both cue and marker points; `formatCueLabel`/`formatMarkerLabel` append `approximate position` when `approx: true`, so exact-position points no longer read the same as midpoint fallbacks.
  - Track renders first (muted `#78909c`, weight 2, opacity 0.6, `interactive: false`) so it draws beneath the circle markers in the shared overlay pane.
  - Load toast counts only events, excluding the track.
- **`src/file-overlay.ts`** — `describeLoad` now receives the parsed features (`T[]`) instead of a bare count, so overlays can count selectively; `squeeze-zones.ts` and the overlay test updated accordingly (behavior unchanged there).
- **`src/cue-events.test.ts`** — new parse/validation/label tests (29 tests total in the file); synthetic coordinates only.

## Test plan

- [x] `npm run type-check` / `npm run lint` / `npm test` (153 passed) green
- [x] `npm run build && npm run size` — 111.11 kB gzipped, under the 112 kB cap; no new dependencies
- [x] Legacy fixture shape (no track, `approx: true` midpoints) still parses; malformed track variants reject the whole file
- [ ] Manual browser check: track polyline beneath points, tooltips show/omit the approximation hint

## Assumptions

- A file containing **two** `kind: "track"` features is malformed (contract says zero or one; validation is all-or-nothing).
- `approx: true` points now gain an `approximate position` label suffix — the issue's "legacy renders unchanged" criterion is read as geometry/marker rendering; the behavior section explicitly asks that `approx: true` indicate approximate placement.
- The track polyline is fully non-interactive (no tooltip) — the issue offered "non-interactive or minimal tooltip"; non-interactive best matches "context, not data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)