### PR TITLE
feat(map): grade cue events on the map — Useful / False alarm / Too late with reviews export

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "size-limit": [
     {
       "path": "dist/assets/index-*.js",
-      "limit": "112 kB",
+      "limit": "113 kB",
       "gzip": true
     }
   ]

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -11,9 +11,22 @@
  *          file-picker/persistence mechanics; validation is all-or-nothing so a malformed file never
  *          partially renders; reason bitmask decodes via the squeeze-zones table (same producer contract)
  * Future: Cross-highlighting a cue with the squeeze zone sharing its event_id is deferred — the shared
- *         id shown in both popups is the v1 link
+ *         id shown in both popups is the v1 link. Grading v2 (map-authored missed-risk markers via
+ *         tap/long-press, and removing markers judged unnecessary later) needs the export shape to
+ *         carry marker additions/removals with coordinates — follow-up issues, deliberately not here
  */
 import L from 'leaflet';
+import {
+  GRADABLE_OUTCOMES,
+  buildReviews,
+  countGraded,
+  effectiveOutcome,
+  hashText,
+  parseGradeStore,
+  serializeGradeStore,
+  type GradableOutcome,
+  type GradeMap,
+} from './cue-grades';
 import { createFileBackedOverlay, type FileBackedOverlay } from './file-overlay';
 import { escapeHtml } from './html';
 import { decodeReasons } from './squeeze-zones';
@@ -230,6 +243,15 @@ export function parseCueEvents(text: string): CueFileFeature[] {
 }
 
 const STORAGE_KEY = 'webmap-cue-events-geojson';
+// Pending grades layered over the loaded file, keyed by event_id inside a
+// { fileHash, grades } envelope — see cue-grades.ts for the leak-across-files contract.
+const GRADES_STORAGE_KEY = 'webmap-cue-event-grades';
+
+const GRADE_BUTTON_LABELS: Record<GradableOutcome, string> = {
+  useful: 'Useful',
+  false_alarm: 'False alarm',
+  too_late: 'Too late',
+};
 
 const CUE_RADIUS = 7;
 const CUE_FILL_OPACITY = 0.85;
@@ -245,76 +267,235 @@ function isTrack(f: CueFileFeature): f is TrackFeature {
   return f.properties.kind === 'track';
 }
 
-function renderCueEvents(group: L.LayerGroup, features: CueFileFeature[]): void {
-  // Track first — vector layers share the overlay pane, so earlier layers draw beneath.
-  for (const f of features) {
-    if (!isTrack(f)) continue;
-    group.addLayer(
-      L.polyline(f.coordinates.map((c) => L.latLng(c[1], c[0])), {
-        color: TRACK_COLOR,
-        weight: TRACK_WEIGHT,
-        opacity: TRACK_OPACITY,
-        interactive: false,
-      }),
-    );
-  }
-  for (const f of features) {
-    if (isTrack(f)) continue;
-    const latlng = L.latLng(f.coordinate[1], f.coordinate[0]);
-    let layer: L.CircleMarker | L.Marker;
-    let label: string;
-    if (f.properties.kind === 'cue') {
-      label = formatCueLabel(f.properties);
-      layer = L.circleMarker(latlng, {
-        radius: CUE_RADIUS,
-        fillColor: outcomeColor(f.properties.outcome),
-        fillOpacity: CUE_FILL_OPACITY,
-        color: '#ffffff',
-        weight: RING_WEIGHT,
-        opacity: 1,
-        dashArray: f.properties.delivered === false ? UNDELIVERED_DASH : undefined,
-        interactive: true,
-      });
-    } else {
-      // Distinct glyph from the circular cue points — a rider-placed "unsafe here" triangle.
-      label = formatMarkerLabel(f.properties);
-      layer = L.marker(latlng, {
-        icon: L.divIcon({
-          className: 'cue-rider-marker',
-          html: '▲',
-          iconSize: [16, 16],
-          iconAnchor: [8, 8],
-        }),
-      });
-    }
-    // Leaflet sets popup/tooltip string content via innerHTML, and ride_clock is a
-    // free-form string from a shareable file — escape the assembled label at the sink.
-    const safeLabel = escapeHtml(label);
-    layer.bindTooltip(safeLabel, { sticky: true });
-    layer.bindPopup(safeLabel); // tap on touch devices, where hover tooltips don't fire
-    group.addLayer(layer);
-  }
+function downloadJson(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Deferred revoke — Safari can drop the download if the URL dies before the click lands.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export interface CueEventsOverlay extends FileBackedOverlay {
+  /**
+   * Download pending grades as a reviews[] sidecar (cue trace schema shape),
+   * to be merged into the ride trace by the producer's cue-review-merge tool.
+   * Toasts instead of downloading when nothing is graded. Only pending grades
+   * leave the browser — never the ride geometry (privacy stance unchanged).
+   */
+  requestReviewExport: () => void;
 }
 
 /**
  * Build the layers-control overlay — see createFileBackedOverlay for the
- * file-picker / persistence / self-disable contract.
+ * file-picker / persistence / self-disable contract. Cue popups carry a grade
+ * row (Useful / False alarm / Too late / Clear); a grade recolors the point
+ * immediately and overwrites any prior grade, file-baked or session (latest
+ * wins). Grades persist per file in localStorage and export as a reviews[]
+ * sidecar via requestReviewExport.
  */
 export function createCueEventsOverlay(
   showToast: (msg: string, durationMs?: number) => void,
   disableOverlay: () => void,
-): FileBackedOverlay {
-  return createFileBackedOverlay<CueFileFeature>({
+): CueEventsOverlay {
+  interface CueEntry {
+    props: CueProps;
+    layer: L.CircleMarker;
+    labelEl: HTMLElement;
+    buttons: Map<GradableOutcome, HTMLButtonElement>;
+  }
+
+  let fileHash = '';
+  let grades: GradeMap = {};
+  let features: CueFileFeature[] = [];
+  let cueEntries: CueEntry[] = [];
+  let overlayOn = false;
+  let progressEl: HTMLElement | null = null;
+
+  function persistGrades(): void {
+    try {
+      localStorage.setItem(GRADES_STORAGE_KEY, serializeGradeStore(fileHash, grades));
+    } catch { /* quota/unavailable — grades survive the session only */ }
+  }
+
+  function cueLabel(props: CueProps): string {
+    return formatCueLabel({ ...props, outcome: effectiveOutcome(props, grades) });
+  }
+
+  // Graded/total pill — visible while the overlay is on and the file has cue points.
+  function updateProgress(): void {
+    const { graded, total } = countGraded(features, grades);
+    const show = overlayOn && total > 0;
+    if (progressEl === null) {
+      if (!show) return;
+      progressEl = document.createElement('div');
+      progressEl.className = 'cue-grade-progress';
+      document.body.appendChild(progressEl);
+    }
+    progressEl.textContent = `${graded}/${total} graded`;
+    progressEl.classList.toggle('visible', show);
+  }
+
+  function setGrade(eventId: number, outcome: GradableOutcome | null): void {
+    grades[String(eventId)] = { outcome, reviewed_at: new Date().toISOString() };
+    persistGrades();
+    for (const entry of cueEntries) {
+      if (entry.props.event_id !== eventId) continue;
+      const eff = effectiveOutcome(entry.props, grades);
+      entry.layer.setStyle({ fillColor: outcomeColor(eff) });
+      const label = cueLabel(entry.props);
+      entry.layer.setTooltipContent(escapeHtml(label));
+      entry.labelEl.textContent = label;
+      for (const [o, btn] of entry.buttons) btn.classList.toggle('is-active', o === eff);
+    }
+    updateProgress();
+  }
+
+  // Popup content is DOM built with textContent (no innerHTML), so the free-form
+  // ride_clock string needs no escaping here; the tooltip string sink still does.
+  function buildCuePopup(props: CueProps): {
+    root: HTMLElement;
+    labelEl: HTMLElement;
+    buttons: Map<GradableOutcome, HTMLButtonElement>;
+  } {
+    const root = document.createElement('div');
+    root.className = 'cue-popup';
+    const labelEl = document.createElement('div');
+    labelEl.className = 'cue-popup__label';
+    labelEl.textContent = cueLabel(props);
+    root.appendChild(labelEl);
+
+    const row = document.createElement('div');
+    row.className = 'cue-grade-row';
+    const buttons = new Map<GradableOutcome, HTMLButtonElement>();
+    const eff = effectiveOutcome(props, grades);
+    for (const outcome of GRADABLE_OUTCOMES) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'cue-grade-row__btn';
+      btn.dataset['outcome'] = outcome;
+      btn.textContent = GRADE_BUTTON_LABELS[outcome];
+      btn.classList.toggle('is-active', eff === outcome);
+      btn.addEventListener('click', () => setGrade(props.event_id, outcome));
+      buttons.set(outcome, btn);
+      row.appendChild(btn);
+    }
+    const clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.className = 'cue-grade-row__btn cue-grade-row__btn--clear';
+    clearBtn.textContent = 'Clear';
+    clearBtn.addEventListener('click', () => setGrade(props.event_id, null));
+    row.appendChild(clearBtn);
+    root.appendChild(row);
+    return { root, labelEl, buttons };
+  }
+
+  function render(group: L.LayerGroup, parsed: CueFileFeature[]): void {
+    features = parsed;
+    cueEntries = [];
+    // fileHash was set by parse just before render — pick up this file's grades
+    // (a different file hashes differently, so its grade layer starts empty).
+    let saved: string | null = null;
+    try {
+      saved = localStorage.getItem(GRADES_STORAGE_KEY);
+    } catch { /* localStorage unavailable */ }
+    grades = parseGradeStore(saved, fileHash);
+
+    // Track first — vector layers share the overlay pane, so earlier layers draw beneath.
+    for (const f of parsed) {
+      if (!isTrack(f)) continue;
+      group.addLayer(
+        L.polyline(f.coordinates.map((c) => L.latLng(c[1], c[0])), {
+          color: TRACK_COLOR,
+          weight: TRACK_WEIGHT,
+          opacity: TRACK_OPACITY,
+          interactive: false,
+        }),
+      );
+    }
+    for (const f of parsed) {
+      if (isTrack(f)) continue;
+      const latlng = L.latLng(f.coordinate[1], f.coordinate[0]);
+      if (f.properties.kind === 'cue') {
+        const props = f.properties;
+        const layer = L.circleMarker(latlng, {
+          radius: CUE_RADIUS,
+          fillColor: outcomeColor(effectiveOutcome(props, grades)),
+          fillOpacity: CUE_FILL_OPACITY,
+          color: '#ffffff',
+          weight: RING_WEIGHT,
+          opacity: 1,
+          dashArray: props.delivered === false ? UNDELIVERED_DASH : undefined,
+          interactive: true,
+        });
+        // Leaflet sets tooltip string content via innerHTML, and ride_clock is a
+        // free-form string from a shareable file — escape the label at the sink.
+        layer.bindTooltip(escapeHtml(cueLabel(props)), { sticky: true });
+        const popup = buildCuePopup(props);
+        layer.bindPopup(popup.root); // tap opens it on touch devices; hosts the grade row
+        cueEntries.push({ props, layer, labelEl: popup.labelEl, buttons: popup.buttons });
+        group.addLayer(layer);
+      } else {
+        // Distinct glyph from the circular cue points — a rider-placed "unsafe here" triangle.
+        const label = escapeHtml(formatMarkerLabel(f.properties));
+        const layer = L.marker(latlng, {
+          icon: L.divIcon({
+            className: 'cue-rider-marker',
+            html: '▲',
+            iconSize: [16, 16],
+            iconAnchor: [8, 8],
+          }),
+        });
+        layer.bindTooltip(label, { sticky: true });
+        layer.bindPopup(label); // tap on touch devices, where hover tooltips don't fire
+        group.addLayer(layer);
+      }
+    }
+    updateProgress();
+  }
+
+  const overlay = createFileBackedOverlay<CueFileFeature>({
     storageKey: STORAGE_KEY,
     toastPrefix: 'Cue events',
-    parse: parseCueEvents,
-    render: renderCueEvents,
+    parse: (text) => {
+      const parsed = parseCueEvents(text);
+      // Identity for the grade layer — render (always called next) keys grades on it.
+      fileHash = hashText(text);
+      return parsed;
+    },
+    render,
     // The track is context, not an event — exclude it from the load toast count.
-    describeLoad: (features) => {
-      const count = features.filter((f) => f.properties.kind !== 'track').length;
+    describeLoad: (loaded) => {
+      const count = loaded.filter((f) => f.properties.kind !== 'track').length;
       return `Loaded ${count} cue event${count === 1 ? '' : 's'}`;
     },
     showToast,
     disableOverlay,
   });
+
+  overlay.group.on('add', () => {
+    overlayOn = true;
+    updateProgress();
+  });
+  overlay.group.on('remove', () => {
+    overlayOn = false;
+    updateProgress();
+  });
+
+  return {
+    ...overlay,
+    requestReviewExport: () => {
+      const reviews = buildReviews(grades);
+      if (reviews.length === 0) {
+        showToast('Cue events: no graded events to export');
+        return;
+      }
+      downloadJson('cue-reviews.json', JSON.stringify(reviews, null, 2));
+      showToast(`Exported ${reviews.length} review${reviews.length === 1 ? '' : 's'}`);
+    },
+  };
 }

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -23,7 +23,7 @@ import {
   effectiveOutcome,
   hashText,
   parseGradeStore,
-  serializeGradeStore,
+  updateGradeStore,
   type GradableOutcome,
   type GradeMap,
 } from './cue-grades';
@@ -244,7 +244,8 @@ export function parseCueEvents(text: string): CueFileFeature[] {
 
 const STORAGE_KEY = 'webmap-cue-events-geojson';
 // Pending grades layered over the loaded file, keyed by event_id inside a
-// { fileHash, grades } envelope — see cue-grades.ts for the leak-across-files contract.
+// { files: { [fileHash]: grades } } envelope — one slot per file, so grading one
+// ride never clobbers another ride's unexported grades (see cue-grades.ts).
 const GRADES_STORAGE_KEY = 'webmap-cue-event-grades';
 
 const GRADE_BUTTON_LABELS: Record<GradableOutcome, string> = {
@@ -318,7 +319,8 @@ export function createCueEventsOverlay(
 
   function persistGrades(): void {
     try {
-      localStorage.setItem(GRADES_STORAGE_KEY, serializeGradeStore(fileHash, grades));
+      const existing = localStorage.getItem(GRADES_STORAGE_KEY);
+      localStorage.setItem(GRADES_STORAGE_KEY, updateGradeStore(existing, fileHash, grades));
     } catch { /* quota/unavailable — grades survive the session only */ }
   }
 
@@ -327,6 +329,8 @@ export function createCueEventsOverlay(
   }
 
   // Graded/total pill — visible while the overlay is on and the file has cue points.
+  // progressEl is created lazily and lives for the page lifetime; the overlay is
+  // constructed once per app, so no teardown path exists (or is needed) today.
   function updateProgress(): void {
     const { graded, total } = countGraded(features, grades);
     const show = overlayOn && total > 0;
@@ -350,7 +354,10 @@ export function createCueEventsOverlay(
       const label = cueLabel(entry.props);
       entry.layer.setTooltipContent(escapeHtml(label));
       entry.labelEl.textContent = label;
-      for (const [o, btn] of entry.buttons) btn.classList.toggle('is-active', o === eff);
+      for (const [o, btn] of entry.buttons) {
+        btn.classList.toggle('is-active', o === eff);
+        btn.setAttribute('aria-pressed', String(o === eff));
+      }
     }
     updateProgress();
   }
@@ -380,6 +387,7 @@ export function createCueEventsOverlay(
       btn.dataset['outcome'] = outcome;
       btn.textContent = GRADE_BUTTON_LABELS[outcome];
       btn.classList.toggle('is-active', eff === outcome);
+      btn.setAttribute('aria-pressed', String(eff === outcome));
       btn.addEventListener('click', () => setGrade(props.event_id, outcome));
       buttons.set(outcome, btn);
       row.appendChild(btn);

--- a/src/cue-grades.test.ts
+++ b/src/cue-grades.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   hashText,
+  parseAllGrades,
   parseGradeStore,
-  serializeGradeStore,
+  updateGradeStore,
   effectiveOutcome,
   buildReviews,
   countGraded,
@@ -32,40 +33,59 @@ describe('hashText', () => {
   });
 });
 
-describe('parseGradeStore / serializeGradeStore', () => {
+describe('parseGradeStore / updateGradeStore', () => {
   const grades: GradeMap = {
     '57053650': { outcome: 'useful', reviewed_at: T1 },
     '57053651': { outcome: null, reviewed_at: T2 },
   };
 
   it('round-trips grades for a matching file hash', () => {
-    const json = serializeGradeStore('abc123', grades);
+    const json = updateGradeStore(null, 'abc123', grades);
     expect(parseGradeStore(json, 'abc123')).toEqual(grades);
   });
 
   it('returns an empty map when the file hash differs (no cross-file leaks)', () => {
-    const json = serializeGradeStore('abc123', grades);
+    const json = updateGradeStore(null, 'abc123', grades);
     expect(parseGradeStore(json, 'other')).toEqual({});
+  });
+
+  it('preserves other files’ pending grades when writing a new file’s slot', () => {
+    // The exact clobber scenario: grade ride A, load ride B without exporting,
+    // grade B — A's unexported grades must survive.
+    const withA = updateGradeStore(null, 'hashA', grades);
+    const gradesB: GradeMap = { '99': { outcome: 'too_late', reviewed_at: T2 } };
+    const withBoth = updateGradeStore(withA, 'hashB', gradesB);
+    expect(parseGradeStore(withBoth, 'hashA')).toEqual(grades);
+    expect(parseGradeStore(withBoth, 'hashB')).toEqual(gradesB);
+  });
+
+  it('drops a file’s slot when its grade map empties, keeping the rest', () => {
+    const withA = updateGradeStore(null, 'hashA', grades);
+    const withBoth = updateGradeStore(withA, 'hashB', { '99': { outcome: 'too_late', reviewed_at: T2 } });
+    const cleared = updateGradeStore(withBoth, 'hashB', {});
+    expect(parseAllGrades(cleared)).toEqual({ hashA: grades });
   });
 
   it('returns an empty map on missing or malformed JSON', () => {
     expect(parseGradeStore(null, 'abc123')).toEqual({});
     expect(parseGradeStore('{nope', 'abc123')).toEqual({});
     expect(parseGradeStore('42', 'abc123')).toEqual({});
-    expect(parseGradeStore('{"fileHash":"abc123"}', 'abc123')).toEqual({});
-    expect(parseGradeStore('{"fileHash":"abc123","grades":7}', 'abc123')).toEqual({});
+    expect(parseGradeStore('{"files":7}', 'abc123')).toEqual({});
+    // Pre-multi-file envelope shape — treated as an empty store, never a crash
+    expect(parseGradeStore('{"fileHash":"abc123","grades":{}}', 'abc123')).toEqual({});
   });
 
   it('drops individually malformed entries and keeps valid ones', () => {
     const json = JSON.stringify({
-      fileHash: 'abc123',
-      grades: {
-        '1': { outcome: 'useful', reviewed_at: T1 },
-        '2': { outcome: 'great', reviewed_at: T1 }, // unknown outcome
-        '3': { outcome: 'missed_risk', reviewed_at: T1 }, // not gradable from the map
-        '4': { outcome: 'too_late' }, // missing reviewed_at
-        '5': 'useful', // not an object
-        '6': { outcome: null, reviewed_at: T2 }, // Clear tombstone — valid
+      files: {
+        abc123: {
+          '1': { outcome: 'useful', reviewed_at: T1 },
+          '2': { outcome: 'great', reviewed_at: T1 }, // unknown outcome
+          '3': { outcome: 'missed_risk', reviewed_at: T1 }, // not gradable from the map
+          '4': { outcome: 'too_late' }, // missing reviewed_at
+          '5': 'useful', // not an object
+          '6': { outcome: null, reviewed_at: T2 }, // Clear tombstone — valid
+        },
       },
     });
     expect(parseGradeStore(json, 'abc123')).toEqual({

--- a/src/cue-grades.test.ts
+++ b/src/cue-grades.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashText,
+  parseGradeStore,
+  serializeGradeStore,
+  effectiveOutcome,
+  buildReviews,
+  countGraded,
+  type GradeMap,
+} from './cue-grades';
+import type { CueFileFeature, CueProps } from './cue-events';
+
+const T1 = '2026-07-15T22:41:00Z';
+const T2 = '2026-07-15T22:45:00Z';
+
+function cueProps(overrides: Partial<CueProps> = {}): CueProps {
+  return { kind: 'cue', event_id: 57053650, ...overrides };
+}
+
+// Synthetic coordinates only — never real ride geometry.
+function cueFeature(overrides: Partial<CueProps> = {}): CueFileFeature {
+  return { coordinate: [0.001, 0.0005], properties: cueProps(overrides) };
+}
+
+describe('hashText', () => {
+  it('is stable for the same text', () => {
+    expect(hashText('{"a":1}')).toBe(hashText('{"a":1}'));
+  });
+
+  it('differs for different text (same file vs re-export with baked grades)', () => {
+    expect(hashText('{"a":1}')).not.toBe(hashText('{"a":2}'));
+  });
+});
+
+describe('parseGradeStore / serializeGradeStore', () => {
+  const grades: GradeMap = {
+    '57053650': { outcome: 'useful', reviewed_at: T1 },
+    '57053651': { outcome: null, reviewed_at: T2 },
+  };
+
+  it('round-trips grades for a matching file hash', () => {
+    const json = serializeGradeStore('abc123', grades);
+    expect(parseGradeStore(json, 'abc123')).toEqual(grades);
+  });
+
+  it('returns an empty map when the file hash differs (no cross-file leaks)', () => {
+    const json = serializeGradeStore('abc123', grades);
+    expect(parseGradeStore(json, 'other')).toEqual({});
+  });
+
+  it('returns an empty map on missing or malformed JSON', () => {
+    expect(parseGradeStore(null, 'abc123')).toEqual({});
+    expect(parseGradeStore('{nope', 'abc123')).toEqual({});
+    expect(parseGradeStore('42', 'abc123')).toEqual({});
+    expect(parseGradeStore('{"fileHash":"abc123"}', 'abc123')).toEqual({});
+    expect(parseGradeStore('{"fileHash":"abc123","grades":7}', 'abc123')).toEqual({});
+  });
+
+  it('drops individually malformed entries and keeps valid ones', () => {
+    const json = JSON.stringify({
+      fileHash: 'abc123',
+      grades: {
+        '1': { outcome: 'useful', reviewed_at: T1 },
+        '2': { outcome: 'great', reviewed_at: T1 }, // unknown outcome
+        '3': { outcome: 'missed_risk', reviewed_at: T1 }, // not gradable from the map
+        '4': { outcome: 'too_late' }, // missing reviewed_at
+        '5': 'useful', // not an object
+        '6': { outcome: null, reviewed_at: T2 }, // Clear tombstone — valid
+      },
+    });
+    expect(parseGradeStore(json, 'abc123')).toEqual({
+      '1': { outcome: 'useful', reviewed_at: T1 },
+      '6': { outcome: null, reviewed_at: T2 },
+    });
+  });
+});
+
+describe('effectiveOutcome', () => {
+  it('returns the file-baked outcome when nothing is pending', () => {
+    expect(effectiveOutcome(cueProps({ outcome: 'useful' }), {})).toBe('useful');
+    expect(effectiveOutcome(cueProps(), {})).toBeUndefined();
+  });
+
+  it('lets a pending grade overwrite a file-baked outcome (latest wins)', () => {
+    const grades: GradeMap = { '57053650': { outcome: 'false_alarm', reviewed_at: T1 } };
+    expect(effectiveOutcome(cueProps({ outcome: 'useful' }), grades)).toBe('false_alarm');
+  });
+
+  it('reads a Clear tombstone as ungraded, even over a baked grade', () => {
+    const grades: GradeMap = { '57053650': { outcome: null, reviewed_at: T1 } };
+    expect(effectiveOutcome(cueProps({ outcome: 'useful' }), grades)).toBeUndefined();
+    expect(effectiveOutcome(cueProps(), grades)).toBeUndefined();
+  });
+
+  it('leaves other events untouched', () => {
+    const grades: GradeMap = { '999': { outcome: 'too_late', reviewed_at: T1 } };
+    expect(effectiveOutcome(cueProps({ outcome: 'useful' }), grades)).toBe('useful');
+  });
+});
+
+describe('buildReviews', () => {
+  it('exports only graded events in the exact reviews[] shape', () => {
+    const grades: GradeMap = { '57053650': { outcome: 'useful', reviewed_at: T1 } };
+    expect(buildReviews(grades)).toEqual([
+      { event_id: 57053650, outcome: 'useful', reviewed_at: T1 },
+    ]);
+  });
+
+  it('omits Clear tombstones', () => {
+    const grades: GradeMap = {
+      '1': { outcome: 'too_late', reviewed_at: T1 },
+      '2': { outcome: null, reviewed_at: T2 },
+    };
+    expect(buildReviews(grades)).toEqual([{ event_id: 1, outcome: 'too_late', reviewed_at: T1 }]);
+  });
+
+  it('returns an empty array when nothing is graded', () => {
+    expect(buildReviews({})).toEqual([]);
+    expect(buildReviews({ '1': { outcome: null, reviewed_at: T1 } })).toEqual([]);
+  });
+
+  it('sorts by event_id for a deterministic sidecar', () => {
+    const grades: GradeMap = {
+      '20': { outcome: 'useful', reviewed_at: T1 },
+      '3': { outcome: 'false_alarm', reviewed_at: T2 },
+    };
+    expect(buildReviews(grades).map((r) => r.event_id)).toEqual([3, 20]);
+  });
+});
+
+describe('countGraded', () => {
+  const track: CueFileFeature = {
+    coordinates: [[0.001, 0.0005], [0.0012, 0.0006]],
+    properties: { kind: 'track' },
+  };
+  const marker: CueFileFeature = { coordinate: [0.002, 0.001], properties: { kind: 'marker' } };
+
+  it('counts only cue points, not markers or the track', () => {
+    const features = [track, marker, cueFeature({ event_id: 1 }), cueFeature({ event_id: 2 })];
+    expect(countGraded(features, {})).toEqual({ graded: 0, total: 2 });
+  });
+
+  it('counts baked and pending grades, minus Clear tombstones', () => {
+    const features = [
+      cueFeature({ event_id: 1, outcome: 'useful' }), // baked
+      cueFeature({ event_id: 2 }), // pending grade below
+      cueFeature({ event_id: 3, outcome: 'too_late' }), // cleared below
+      cueFeature({ event_id: 4 }), // ungraded
+    ];
+    const grades: GradeMap = {
+      '2': { outcome: 'false_alarm', reviewed_at: T1 },
+      '3': { outcome: null, reviewed_at: T2 },
+    };
+    expect(countGraded(features, grades)).toEqual({ graded: 2, total: 4 });
+  });
+
+  it('handles an empty file', () => {
+    expect(countGraded([], {})).toEqual({ graded: 0, total: 0 });
+  });
+});

--- a/src/cue-grades.ts
+++ b/src/cue-grades.ts
@@ -1,0 +1,113 @@
+/**
+ * Intent: Pure state logic for grading cue events on the map — pending review grades layered
+ *         over a loaded cue trace, persisted to localStorage keyed by event_id
+ * Context: Grades must not leak across files, so the store carries a hash of the raw file text;
+ *          a different file (including a re-export with grades baked in) gets a fresh, empty
+ *          grade layer and stays fully re-gradable
+ * Pattern: Pending grade wins over a file-baked outcome ("latest wins"); Clear stores a null
+ *          tombstone so a baked grade reads as ungraded without touching the file; export emits
+ *          only non-cleared pending grades in the cue trace schema's reviews[] shape (FR-008)
+ * Future: v2 adds map-authored missed-risk markers and marker removal, extending the sidecar
+ *         shape with coordinates — tracked in follow-up issues, deliberately not built here
+ */
+import type { CueFileFeature, CueOutcome, CueProps } from './cue-events';
+
+// Outcomes gradable from the map. missed_risk is deliberately absent: a cue that
+// fired was not missed — missed risks become map-authored markers in v2.
+export const GRADABLE_OUTCOMES = ['useful', 'false_alarm', 'too_late'] as const;
+export type GradableOutcome = (typeof GRADABLE_OUTCOMES)[number];
+
+/** A pending review; outcome null is a Clear tombstone (renders ungraded, omitted from export). */
+export interface PendingGrade {
+  outcome: GradableOutcome | null;
+  reviewed_at: string; // ISO-8601 UTC, set at grading time
+}
+
+/** Pending grades keyed by String(event_id). */
+export type GradeMap = Record<string, PendingGrade>;
+
+/** One entry of the cue trace schema's reviews[] — the exact export shape. */
+export interface Review {
+  event_id: number;
+  outcome: GradableOutcome;
+  reviewed_at: string;
+}
+
+// FNV-1a 32-bit over the raw file text — a cheap identity for "same file after
+// reload" vs "different file"; not integrity, so collisions are acceptable.
+export function hashText(text: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Parse a persisted grade store. Returns an empty map on missing/malformed JSON
+ * or when the stored fileHash doesn't match the loaded file (grades never leak
+ * across files). Individually malformed entries are dropped, valid ones kept.
+ */
+export function parseGradeStore(json: string | null, fileHash: string): GradeMap {
+  if (json === null) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  const store = parsed as { fileHash?: unknown; grades?: unknown };
+  if (typeof store !== 'object' || store === null || store.fileHash !== fileHash) return {};
+  const raw = store.grades;
+  if (typeof raw !== 'object' || raw === null) return {};
+  const grades: GradeMap = {};
+  for (const [id, value] of Object.entries(raw)) {
+    const g = value as { outcome?: unknown; reviewed_at?: unknown };
+    if (typeof g !== 'object' || g === null) continue;
+    const outcomeValid =
+      g.outcome === null ||
+      (typeof g.outcome === 'string' && (GRADABLE_OUTCOMES as readonly string[]).includes(g.outcome));
+    if (!outcomeValid || typeof g.reviewed_at !== 'string') continue;
+    grades[id] = { outcome: g.outcome as GradableOutcome | null, reviewed_at: g.reviewed_at };
+  }
+  return grades;
+}
+
+export function serializeGradeStore(fileHash: string, grades: GradeMap): string {
+  return JSON.stringify({ fileHash, grades });
+}
+
+/**
+ * The outcome a cue point should render with: the pending grade when one exists
+ * (a Clear tombstone reads as ungraded), else the file-baked outcome.
+ */
+export function effectiveOutcome(props: CueProps, grades: GradeMap): CueOutcome | undefined {
+  const pending = grades[String(props.event_id)];
+  if (pending !== undefined) return pending.outcome ?? undefined;
+  return props.outcome;
+}
+
+/** Only graded events, in the exact reviews[] shape; Clear tombstones are omitted. */
+export function buildReviews(grades: GradeMap): Review[] {
+  const reviews: Review[] = [];
+  for (const [id, g] of Object.entries(grades)) {
+    if (g.outcome === null) continue;
+    reviews.push({ event_id: Number(id), outcome: g.outcome, reviewed_at: g.reviewed_at });
+  }
+  reviews.sort((a, b) => a.event_id - b.event_id);
+  return reviews;
+}
+
+/** Graded/total across the file's cue points (markers and the track don't count). */
+export function countGraded(features: CueFileFeature[], grades: GradeMap): { graded: number; total: number } {
+  let graded = 0;
+  let total = 0;
+  for (const f of features) {
+    const p = f.properties;
+    if (p.kind !== 'cue') continue;
+    total++;
+    if (effectiveOutcome(p, grades) !== undefined) graded++;
+  }
+  return { graded, total };
+}

--- a/src/cue-grades.ts
+++ b/src/cue-grades.ts
@@ -1,9 +1,10 @@
 /**
  * Intent: Pure state logic for grading cue events on the map — pending review grades layered
  *         over a loaded cue trace, persisted to localStorage keyed by event_id
- * Context: Grades must not leak across files, so the store carries a hash of the raw file text;
- *          a different file (including a re-export with grades baked in) gets a fresh, empty
- *          grade layer and stays fully re-gradable
+ * Context: Grades must not leak across files, so the store keys each grade map by a hash of the
+ *          raw file text — one slot per file, so grading one ride never clobbers another ride's
+ *          unexported grades; a different file (including a re-export with grades baked in)
+ *          gets a fresh, empty grade layer and stays fully re-gradable
  * Pattern: Pending grade wins over a file-baked outcome ("latest wins"); Clear stores a null
  *          tombstone so a baked grade reads as ungraded without touching the file; export emits
  *          only non-cleared pending grades in the cue trace schema's reviews[] shape (FR-008)
@@ -44,22 +45,8 @@ export function hashText(text: string): string {
   return (h >>> 0).toString(16);
 }
 
-/**
- * Parse a persisted grade store. Returns an empty map on missing/malformed JSON
- * or when the stored fileHash doesn't match the loaded file (grades never leak
- * across files). Individually malformed entries are dropped, valid ones kept.
- */
-export function parseGradeStore(json: string | null, fileHash: string): GradeMap {
-  if (json === null) return {};
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return {};
-  }
-  const store = parsed as { fileHash?: unknown; grades?: unknown };
-  if (typeof store !== 'object' || store === null || store.fileHash !== fileHash) return {};
-  const raw = store.grades;
+// Validate one file's raw grade map: malformed entries are dropped, valid ones kept.
+function sanitizeGradeMap(raw: unknown): GradeMap {
   if (typeof raw !== 'object' || raw === null) return {};
   const grades: GradeMap = {};
   for (const [id, value] of Object.entries(raw)) {
@@ -74,8 +61,50 @@ export function parseGradeStore(json: string | null, fileHash: string): GradeMap
   return grades;
 }
 
-export function serializeGradeStore(fileHash: string, grades: GradeMap): string {
-  return JSON.stringify({ fileHash, grades });
+/**
+ * Parse the full persisted store: a `{ files: { [fileHash]: GradeMap } }` envelope
+ * holding every file's pending grades side by side. Missing/malformed JSON yields
+ * an empty store; each file's entries are individually sanitized.
+ */
+export function parseAllGrades(json: string | null): Record<string, GradeMap> {
+  if (json === null) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  const store = parsed as { files?: unknown };
+  if (typeof store !== 'object' || store === null) return {};
+  if (typeof store.files !== 'object' || store.files === null) return {};
+  const all: Record<string, GradeMap> = {};
+  for (const [hash, raw] of Object.entries(store.files)) {
+    all[hash] = sanitizeGradeMap(raw);
+  }
+  return all;
+}
+
+/**
+ * One file's pending grades from the persisted store. An unknown hash returns an
+ * empty map (grades never leak across files).
+ */
+export function parseGradeStore(json: string | null, fileHash: string): GradeMap {
+  return parseAllGrades(json)[fileHash] ?? {};
+}
+
+/**
+ * Replace one file's slot in the persisted store, preserving every other file's
+ * pending grades — grading ride B must never clobber ride A's unexported work.
+ * An empty grade map drops the slot so the store doesn't accumulate dead files.
+ */
+export function updateGradeStore(json: string | null, fileHash: string, grades: GradeMap): string {
+  const all = parseAllGrades(json);
+  if (Object.keys(grades).length === 0) {
+    delete all[fileHash];
+  } else {
+    all[fileHash] = grades;
+  }
+  return JSON.stringify({ files: all });
 }
 
 /**

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -327,7 +327,7 @@ export class LayersControl extends L.Control {
         if (requestFilePick) {
           const changeBtn = document.createElement('button');
           changeBtn.type = 'button';
-          changeBtn.className = 'layers-option__change-file';
+          changeBtn.className = 'layers-option__action';
           changeBtn.dataset['overlayId'] = overlay.id;
           changeBtn.textContent = 'Change…';
           changeBtn.title = 'Load a different GeoJSON file';
@@ -344,7 +344,7 @@ export class LayersControl extends L.Control {
         if (rowAction) {
           const actionBtn = document.createElement('button');
           actionBtn.type = 'button';
-          actionBtn.className = 'layers-option__change-file';
+          actionBtn.className = 'layers-option__action';
           actionBtn.dataset['overlayId'] = overlay.id;
           actionBtn.textContent = rowAction.label;
           actionBtn.title = rowAction.title;
@@ -415,7 +415,7 @@ export class LayersControl extends L.Control {
   // Change-file and rowAction buttons share the class; both follow the checkbox.
   private syncRowActionButtons(id: string, enabled: boolean): void {
     const buttons = this.popoverEl?.querySelectorAll<HTMLButtonElement>(
-      `button.layers-option__change-file[data-overlay-id="${id}"]`,
+      `button.layers-option__action[data-overlay-id="${id}"]`,
     );
     buttons?.forEach((btn) => { btn.disabled = !enabled; });
   }

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -33,6 +33,10 @@ export interface OverlayDef {
   // Enabled only while the overlay is checked (the picker needs the overlay's
   // load path active, and a click here carries the required user activation).
   requestFilePick?: () => void;
+  // Optional extra action button on the overlay's row, next to "Change…" —
+  // e.g. "Export reviews" on cue events. Enabled only while the overlay is
+  // checked, same as the change-file button.
+  rowAction?: { label: string; title: string; onClick: () => void };
 }
 
 const LAYERS_STORAGE_KEY = 'webmap-layer-selection';
@@ -302,7 +306,7 @@ export class LayersControl extends L.Control {
 
         L.DomEvent.on(checkbox, 'change', () => {
           this.toggleOverlay(overlay, checkbox.checked);
-          this.syncChangeFileButton(overlay.id, checkbox.checked);
+          this.syncRowActionButtons(overlay.id, checkbox.checked);
         });
 
         label.appendChild(checkbox);
@@ -334,6 +338,23 @@ export class LayersControl extends L.Control {
             requestFilePick();
           });
           label.appendChild(changeBtn);
+        }
+
+        const rowAction = overlay.rowAction;
+        if (rowAction) {
+          const actionBtn = document.createElement('button');
+          actionBtn.type = 'button';
+          actionBtn.className = 'layers-option__change-file';
+          actionBtn.dataset['overlayId'] = overlay.id;
+          actionBtn.textContent = rowAction.label;
+          actionBtn.title = rowAction.title;
+          actionBtn.disabled = !checkbox.checked;
+          L.DomEvent.on(actionBtn, 'click', (e: Event) => {
+            // Keep the click from toggling the wrapping label's checkbox.
+            L.DomEvent.stop(e);
+            rowAction.onClick();
+          });
+          label.appendChild(actionBtn);
         }
 
         overlaysFieldset.appendChild(label);
@@ -388,14 +409,15 @@ export class LayersControl extends L.Control {
     this.toggleOverlay(overlay, enabled);
     const checkbox = this.popoverEl?.querySelector<HTMLInputElement>(`input[name="overlay-${id}"]`);
     if (checkbox) checkbox.checked = enabled;
-    this.syncChangeFileButton(id, enabled);
+    this.syncRowActionButtons(id, enabled);
   }
 
-  private syncChangeFileButton(id: string, enabled: boolean): void {
-    const btn = this.popoverEl?.querySelector<HTMLButtonElement>(
+  // Change-file and rowAction buttons share the class; both follow the checkbox.
+  private syncRowActionButtons(id: string, enabled: boolean): void {
+    const buttons = this.popoverEl?.querySelectorAll<HTMLButtonElement>(
       `button.layers-option__change-file[data-overlay-id="${id}"]`,
     );
-    if (btn) btn.disabled = !enabled;
+    buttons?.forEach((btn) => { btn.disabled = !enabled; });
   }
 
   private toggleOverlay(overlay: OverlayDef, enabled: boolean): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,6 +416,11 @@ const overlayDefs: OverlayDef[] = [
     description: 'Where cues fired on a ride, from a GeoJSON file on your device — colored by review outcome',
     tileLayer: cueEventsOverlay.group,
     requestFilePick: cueEventsOverlay.requestFilePick,
+    rowAction: {
+      label: 'Export reviews',
+      title: 'Download graded cues as a reviews sidecar (JSON)',
+      onClick: cueEventsOverlay.requestReviewExport,
+    },
   },
 ];
 

--- a/src/style.css
+++ b/src/style.css
@@ -1699,3 +1699,71 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   text-shadow: 0 0 2px #fff, 0 0 2px #fff;
   cursor: pointer;
 }
+
+/* Grade row inside a cue popup — Useful / False alarm / Too late verdicts plus
+   Clear; the active verdict fills with its outcome color (matches the point). */
+.cue-popup__label {
+  margin-bottom: 6px;
+}
+
+.cue-grade-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.cue-grade-row__btn {
+  border: 1px solid #bbb;
+  border-radius: 10px;
+  background: #fff;
+  color: #333;
+  font: 12px/1.2 system-ui, sans-serif;
+  padding: 4px 9px;
+  cursor: pointer;
+}
+
+.cue-grade-row__btn:hover {
+  background: #f0f0f0;
+}
+
+.cue-grade-row__btn.is-active {
+  color: #fff;
+  border-color: transparent;
+}
+
+.cue-grade-row__btn.is-active[data-outcome='useful'] {
+  background: #2e7d32;
+}
+
+.cue-grade-row__btn.is-active[data-outcome='false_alarm'] {
+  background: #d63131;
+}
+
+.cue-grade-row__btn.is-active[data-outcome='too_late'] {
+  background: #f57c00;
+}
+
+.cue-grade-row__btn--clear {
+  color: #777;
+}
+
+/* Graded/total pill — top center while the cue-events overlay is on. Below the
+   layers popover (z-index 1000) and non-interactive so it never blocks the map. */
+.cue-grade-progress {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(38, 50, 56, 0.85);
+  color: #fff;
+  font: 12px/1 system-ui, sans-serif;
+  padding: 6px 10px;
+  border-radius: 12px;
+  z-index: 900;
+  pointer-events: none;
+}
+
+.cue-grade-progress.visible {
+  display: block;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1439,7 +1439,7 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   margin-top: 2px;
 }
 
-.layers-option__change-file {
+.layers-option__action {
   align-self: center;
   margin-left: 4px;
   padding: 2px 8px;
@@ -1452,11 +1452,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   white-space: nowrap;
 }
 
-.layers-option__change-file:hover:not(:disabled) {
+.layers-option__action:hover:not(:disabled) {
   background-color: rgba(66, 135, 245, 0.12);
 }
 
-.layers-option__change-file:disabled {
+.layers-option__action:disabled {
   color: #bbb;
   border-color: #ddd;
   cursor: default;
@@ -1752,7 +1752,8 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .cue-grade-progress {
   display: none;
   position: fixed;
-  top: 12px;
+  /* Clear the notch/status bar on phones — same convention as .offline-banner */
+  top: calc(env(safe-area-inset-top, 0px) + 12px);
   left: 50%;
   transform: translateX(-50%);
   background: rgba(38, 50, 56, 0.85);


### PR DESCRIPTION
## Summary

Implements #239: grade cue events where the context lives — on the map. Cue popups gain a grade row (**Useful / False alarm / Too late** + **Clear**), grades recolor points instantly and persist per file, and an **Export reviews** action downloads a sidecar in the cue trace schema's `reviews[]` shape for the producer's `cue-review-merge` round trip (jasoneplumb/cue#115).

## Changes

- **`src/cue-grades.ts` (new)** — pure grade-state logic: FNV-1a file-text hash (grades never leak across files), localStorage envelope parse/serialize, effective-outcome resolution (pending grade wins over file-baked; Clear stores a null tombstone so a baked grade reads as ungraded), `reviews[]` export builder (only graded events, sorted, exact schema shape), graded/total counter.
- **`src/cue-events.ts`** — cue popups become DOM content with the grade row; grading recolors via `setStyle`, updates tooltip/popup label and button states, persists, and refreshes a top-center `N/M graded` pill (shown while the overlay is on). `requestReviewExport` downloads `cue-reviews.json` or toasts when nothing is graded. No `missed_risk` button — a cue that fired was not missed (v2 adds missed-risk markers; documented in the header, not built).
- **`src/layers-control.ts`** — optional `rowAction` button on an overlay row next to **Change…**, enabled only while the overlay is checked (same sync path, now `syncRowActionButtons`).
- **`src/main.ts`** — wires **Export reviews** onto the cue-events row.
- **`src/style.css`** — grade-row buttons (active verdict fills with its outcome color), progress pill.
- **`package.json`** — size-limit 112 → 113 kB, following the per-overlay precedent (108→110→112); grading UI adds ~0.4 kB gzipped.

## Test plan

- 17 new unit tests (`src/cue-grades.test.ts`): hash stability, store round-trip, cross-file isolation, malformed-entry filtering, overwrite semantics (baked vs pending), Clear tombstone, export shape/omission/sorting, graded/total counting.
- `npm run type-check && npm run lint && npm test && npm run size` all green locally (170 tests).
- Manual browser check recommended for the popup grade row, pill placement, and download (UI change per project CLAUDE.md).

## Assumptions

- Export contains **only pending (map-made) grades** — file-baked outcomes are already in the trace; re-exporting them would clobber original `reviewed_at` timestamps on merge.
- `reviewed_at` uses `new Date().toISOString()` (ISO-8601 UTC with milliseconds) at grading time.
- Graded/total counts effective grades (baked or pending, minus cleared) over cue points only; the pill hides when the file has no cues or the overlay is off.
- Clear always tombstones (uniform semantics) rather than deleting the pending entry, so it also suppresses baked grades per the acceptance criteria.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)