### PR TITLE
feat(map): add Custom squeeze zones overlay — draw your own zones

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "size-limit": [
     {
       "path": "dist/assets/index-*.js",
-      "limit": "114 kB",
+      "limit": "116 kB",
       "gzip": true
     }
   ]

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -27,7 +27,7 @@ import {
   type GradableOutcome,
   type GradeMap,
 } from './cue-grades';
-import { createFileBackedOverlay, type FileBackedOverlay } from './file-overlay';
+import { createFileBackedOverlay, downloadJson, type FileBackedOverlay } from './file-overlay';
 import { escapeHtml } from './html';
 import { decodeReasons } from './squeeze-zones';
 
@@ -266,19 +266,6 @@ const TRACK_OPACITY = 0.6;
 
 function isTrack(f: CueFileFeature): f is TrackFeature {
   return f.properties.kind === 'track';
-}
-
-function downloadJson(filename: string, text: string): void {
-  const blob = new Blob([text], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  // Deferred revoke — Safari can drop the download if the URL dies before the click lands.
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 export interface CueEventsOverlay extends FileBackedOverlay {

--- a/src/custom-zones.test.ts
+++ b/src/custom-zones.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { encodeCustomZones, parseCustomZones, zoneDisplayLabel, type CustomZoneFeature } from './custom-zones';
+
+function syntheticFeature(overrides: Record<string, unknown> = {}, coordinates?: unknown): unknown {
+  return {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: coordinates ?? [[0, 0], [0.001, 0.0005]],
+    },
+    properties: {
+      kind: 'custom_zone',
+      id: 'zone-1',
+      created_at: '2026-07-21T00:00:00.000Z',
+      ...overrides,
+    },
+  };
+}
+
+function collection(...features: unknown[]): string {
+  return JSON.stringify({ type: 'FeatureCollection', features });
+}
+
+describe('zoneDisplayLabel', () => {
+  it('returns the label when present', () => {
+    expect(zoneDisplayLabel({ kind: 'custom_zone', id: '1', created_at: 'x', label: 'Bad shoulder' }))
+      .toBe('Bad shoulder');
+  });
+
+  it('falls back to a generic label when absent or blank', () => {
+    expect(zoneDisplayLabel({ kind: 'custom_zone', id: '1', created_at: 'x' })).toBe('Custom zone');
+    expect(zoneDisplayLabel({ kind: 'custom_zone', id: '1', created_at: 'x', label: '   ' })).toBe('Custom zone');
+  });
+});
+
+describe('parseCustomZones', () => {
+  it('parses a valid FeatureCollection into normalized features', () => {
+    const features = parseCustomZones(collection(syntheticFeature({ label: 'Narrow bridge' })));
+    expect(features).toHaveLength(1);
+    expect(features[0]).toEqual({
+      coordinates: [[0, 0], [0.001, 0.0005]],
+      properties: {
+        kind: 'custom_zone',
+        id: 'zone-1',
+        created_at: '2026-07-21T00:00:00.000Z',
+        label: 'Narrow bridge',
+      },
+    });
+  });
+
+  it('accepts a feature with no label', () => {
+    const features = parseCustomZones(collection(syntheticFeature()));
+    expect(features[0]!.properties.label).toBeUndefined();
+  });
+
+  it('accepts an empty FeatureCollection', () => {
+    expect(parseCustomZones(collection())).toEqual([]);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseCustomZones('{nope')).toThrow('not valid JSON');
+  });
+
+  it('throws when the root is not a FeatureCollection', () => {
+    expect(() => parseCustomZones('[]')).toThrow('not a GeoJSON FeatureCollection');
+    expect(() => parseCustomZones('{"type":"Feature"}')).toThrow('not a GeoJSON FeatureCollection');
+  });
+
+  it('throws on non-LineString geometry', () => {
+    const bad = { ...(syntheticFeature() as object), geometry: { type: 'Point', coordinates: [0, 0] } };
+    expect(() => parseCustomZones(collection(bad))).toThrow('geometry must be a LineString');
+  });
+
+  it('throws on a LineString with fewer than 2 positions', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({}, [[0, 0]])))).toThrow('at least 2 positions');
+  });
+
+  it('throws on non-numeric coordinate positions', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({}, [[0, 0], ['a', 1]])))).toThrow('number pairs');
+  });
+
+  it('throws when kind is not custom_zone', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({ kind: 'squeeze_zone' }))))
+      .toThrow('kind must be "custom_zone"');
+  });
+
+  it('throws when id is missing or not a string', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({ id: undefined }))))
+      .toThrow('id must be a non-empty string');
+    expect(() => parseCustomZones(collection(syntheticFeature({ id: 42 }))))
+      .toThrow('id must be a non-empty string');
+  });
+
+  it('throws when created_at is missing or not a string', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({ created_at: undefined }))))
+      .toThrow('created_at must be a non-empty string');
+  });
+
+  it('throws when label is present but not a string', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature({ label: 42 }))))
+      .toThrow('label must be a string');
+  });
+
+  it('throws (all-or-nothing) when only a later feature is malformed', () => {
+    expect(() => parseCustomZones(collection(syntheticFeature(), syntheticFeature({ id: null }))))
+      .toThrow('feature 1: property id must be a non-empty string');
+  });
+});
+
+describe('encodeCustomZones', () => {
+  it('round-trips through parseCustomZones', () => {
+    const zones: CustomZoneFeature[] = [
+      {
+        coordinates: [[0, 0], [0.001, 0.0005]],
+        properties: { kind: 'custom_zone', id: 'zone-1', created_at: '2026-07-21T00:00:00.000Z', label: 'Bad shoulder' },
+      },
+    ];
+    expect(parseCustomZones(encodeCustomZones(zones))).toEqual(zones);
+  });
+
+  it('encodes an empty list as an empty FeatureCollection', () => {
+    expect(JSON.parse(encodeCustomZones([]))).toEqual({ type: 'FeatureCollection', features: [] });
+  });
+});

--- a/src/custom-zones.ts
+++ b/src/custom-zones.ts
@@ -1,0 +1,433 @@
+/**
+ * Intent: "Custom squeeze zones" overlay — zones the rider draws directly on the map, distinct from
+ *         the derived Squeeze zones overlay (OSM-scored, loaded from a cue-zone-export file). Rendered
+ *         in one fixed color + dashed stroke so "mine" and "derived" are unambiguous at a glance.
+ * Context: A drawn zone is the rider's own judgment, not a policy output — no severity/confidence/
+ *          reasons_bitmask (that's the scorer's vocabulary). Persisted to localStorage like the other
+ *          overlays; also exportable/importable as GeoJSON so a rider can back zones up or move them to
+ *          another device. Import REPLACES the current set — same load-a-file contract as the other
+ *          overlays, no merge semantics to reason about.
+ * Pattern: Pure parse/encode functions (unit-tested) for the data path; a small imperative draw-mode
+ *          state machine drives the map interaction (click to add a vertex, Finish/Cancel or Enter/Esc).
+ *          Kept separate from file-overlay.ts's createFileBackedOverlay since drawing has no
+ *          file-picker-on-toggle step — toggling this overlay only shows/hides what's already drawn.
+ * Future: No edit-existing-zone-geometry — delete and redraw is the only path today.
+ */
+import L from 'leaflet';
+import { downloadJson } from './file-overlay';
+import { escapeHtml } from './html';
+
+export interface CustomZoneProps {
+  kind: 'custom_zone';
+  id: string;
+  created_at: string;
+  label?: string;
+}
+
+export interface CustomZoneFeature {
+  coordinates: [number, number][]; // GeoJSON order: [lng, lat]
+  properties: CustomZoneProps;
+}
+
+// Blue — deliberately outside the derived-zone severity palette (yellow/orange/red) and the
+// cue-events outcome palette (green/red/orange/purple/gray), so a custom zone never gets mistaken
+// for a scored one.
+export const CUSTOM_ZONE_COLOR = '#1e88e5';
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+export function zoneDisplayLabel(props: CustomZoneProps): string {
+  return props.label && props.label.trim() !== '' ? props.label : 'Custom zone';
+}
+
+// Parse + validate this overlay's own FeatureCollection contract. Throws on any malformed feature
+// (all-or-nothing — the caller never partially renders).
+export function parseCustomZones(text: string): CustomZoneFeature[] {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error('not valid JSON');
+  }
+
+  const fc = json as { type?: unknown; features?: unknown };
+  if (typeof fc !== 'object' || fc === null || fc.type !== 'FeatureCollection' || !Array.isArray(fc.features)) {
+    throw new Error('not a GeoJSON FeatureCollection');
+  }
+
+  const features: CustomZoneFeature[] = [];
+  for (let i = 0; i < fc.features.length; i++) {
+    const f = fc.features[i] as {
+      type?: unknown;
+      geometry?: { type?: unknown; coordinates?: unknown };
+      properties?: Record<string, unknown>;
+    };
+    if (typeof f !== 'object' || f === null || f.type !== 'Feature') {
+      throw new Error(`feature ${i}: not a Feature`);
+    }
+    if (f.geometry?.type !== 'LineString' || !Array.isArray(f.geometry.coordinates)) {
+      throw new Error(`feature ${i}: geometry must be a LineString`);
+    }
+    if (f.geometry.coordinates.length < 2) {
+      throw new Error(`feature ${i}: LineString needs at least 2 positions`);
+    }
+    const coordinates: [number, number][] = [];
+    for (const pos of f.geometry.coordinates as unknown[]) {
+      if (!Array.isArray(pos) || !isFiniteNumber(pos[0]) || !isFiniteNumber(pos[1])) {
+        throw new Error(`feature ${i}: positions must be [lng, lat] number pairs`);
+      }
+      coordinates.push([pos[0], pos[1]]);
+    }
+    const p = f.properties;
+    if (typeof p !== 'object' || p === null) {
+      throw new Error(`feature ${i}: missing properties`);
+    }
+    if (p['kind'] !== 'custom_zone') {
+      throw new Error(`feature ${i}: property kind must be "custom_zone"`);
+    }
+    if (typeof p['id'] !== 'string' || p['id'] === '') {
+      throw new Error(`feature ${i}: property id must be a non-empty string`);
+    }
+    if (typeof p['created_at'] !== 'string' || p['created_at'] === '') {
+      throw new Error(`feature ${i}: property created_at must be a non-empty string`);
+    }
+    const label = p['label'];
+    if (label !== undefined && typeof label !== 'string') {
+      throw new Error(`feature ${i}: property label must be a string`);
+    }
+    features.push({
+      coordinates,
+      properties: { kind: 'custom_zone', id: p['id'], created_at: p['created_at'], label },
+    });
+  }
+  return features;
+}
+
+export function encodeCustomZones(zones: CustomZoneFeature[]): string {
+  return JSON.stringify({
+    type: 'FeatureCollection',
+    features: zones.map((z) => ({
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: z.coordinates },
+      properties: z.properties,
+    })),
+  });
+}
+
+function newZoneId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  return `zone-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const STORAGE_KEY = 'webmap-custom-squeeze-zones-geojson';
+
+const ZONE_WEIGHT = 5;
+const ZONE_OPACITY = 0.85;
+const ZONE_DASH = '6 4'; // dashed — visually distinct from the derived overlay's solid lines
+
+export interface CustomZonesOverlay {
+  /** The layer group to register with the layers control */
+  group: L.LayerGroup;
+  /** Open a file picker to replace the current zones with an exported GeoJSON file */
+  requestFilePick: () => void;
+  /** Download the current zones as a GeoJSON file; toasts instead if there are none yet */
+  requestExport: () => void;
+  /** Add a freshly drawn zone (called by the draw-mode control on Finish) */
+  addZone: (coordinates: [number, number][]) => void;
+}
+
+/**
+ * Build the layers-control overlay for rider-drawn zones. Unlike the file-backed overlays, this one
+ * starts from whatever localStorage has (possibly nothing) and never opens a file picker on its own —
+ * drawing (addZone) and requestFilePick are the only ways new zones arrive.
+ */
+export function createCustomZonesOverlay(showToast: (msg: string, durationMs?: number) => void): CustomZonesOverlay {
+  const group = L.layerGroup();
+  let zones: CustomZoneFeature[] = [];
+  let fileInput: HTMLInputElement | null = null;
+
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved !== null) zones = parseCustomZones(saved);
+  } catch {
+    zones = []; // corrupted/unavailable storage — start empty rather than fail to load the app
+  }
+
+  function persist(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, encodeCustomZones(zones));
+    } catch {
+      showToast('Custom squeeze zones: too large to save — zones will not survive a reload');
+    }
+  }
+
+  function buildZonePopup(zone: CustomZoneFeature): HTMLElement {
+    const root = document.createElement('div');
+    root.className = 'custom-zone-popup';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'custom-zone-popup__label';
+    input.placeholder = 'Label (optional)';
+    input.value = zone.properties.label ?? '';
+    root.appendChild(input);
+
+    const actions = document.createElement('div');
+    actions.className = 'custom-zone-popup__actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.textContent = 'Save';
+    saveBtn.addEventListener('click', () => {
+      const label = input.value.trim();
+      zone.properties.label = label === '' ? undefined : label;
+      persist();
+      renderAll();
+      showToast('Custom zone updated');
+    });
+    actions.appendChild(saveBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'custom-zone-popup__delete';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', () => {
+      zones = zones.filter((z) => z.properties.id !== zone.properties.id);
+      persist();
+      renderAll();
+      showToast('Custom zone deleted');
+    });
+    actions.appendChild(deleteBtn);
+
+    root.appendChild(actions);
+    return root;
+  }
+
+  function renderAll(): void {
+    group.clearLayers();
+    for (const zone of zones) {
+      const latlngs = zone.coordinates.map(([lng, lat]) => L.latLng(lat, lng));
+      const line = L.polyline(latlngs, {
+        color: CUSTOM_ZONE_COLOR,
+        weight: ZONE_WEIGHT,
+        opacity: ZONE_OPACITY,
+        dashArray: ZONE_DASH,
+        interactive: true,
+      });
+      // Tooltip content is set via innerHTML by Leaflet; label is free-form user/file text — escape it.
+      line.bindTooltip(escapeHtml(zoneDisplayLabel(zone.properties)), { sticky: true });
+      line.bindPopup(buildZonePopup(zone)); // tap on touch devices; hosts the label/delete controls
+      group.addLayer(line);
+    }
+  }
+  renderAll();
+
+  function getFileInput(): HTMLInputElement {
+    if (fileInput) return fileInput;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.geojson,.json,application/geo+json,application/json';
+    input.style.display = 'none';
+    input.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(input);
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      input.value = ''; // allow re-picking the same file later
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = typeof reader.result === 'string' ? reader.result : '';
+        try {
+          zones = parseCustomZones(text);
+        } catch (err: unknown) {
+          const detail = err instanceof Error ? err.message : 'invalid file';
+          showToast(`Custom squeeze zones: ${detail}`);
+          return;
+        }
+        persist();
+        renderAll();
+        showToast(`Loaded ${zones.length} custom zone${zones.length === 1 ? '' : 's'}`);
+      };
+      reader.onerror = () => showToast('Custom squeeze zones: could not read file');
+      reader.readAsText(file);
+    });
+    fileInput = input;
+    return input;
+  }
+
+  return {
+    group,
+    requestFilePick: () => getFileInput().click(),
+    requestExport: () => {
+      if (zones.length === 0) {
+        showToast('Custom squeeze zones: nothing to export yet');
+        return;
+      }
+      downloadJson('custom-squeeze-zones.geojson', encodeCustomZones(zones));
+      showToast(`Exported ${zones.length} custom zone${zones.length === 1 ? '' : 's'}`);
+    },
+    addZone: (coordinates) => {
+      zones.push({
+        coordinates,
+        properties: { kind: 'custom_zone', id: newZoneId(), created_at: new Date().toISOString() },
+      });
+      persist();
+      renderAll();
+    },
+  };
+}
+
+const MIN_ZONE_POINTS = 2;
+
+/**
+ * Adds the "Draw zone" map control. Click to start: each map click/tap adds a vertex; Finish (button
+ * or Enter) commits the zone via overlay.addZone and switches the custom-zones overlay on; Cancel
+ * (button or Esc) discards the in-progress zone. No dblclick-to-finish shortcut — Leaflet/browsers
+ * fire a plain 'click' for each half of a double-click too, which would add a spurious near-duplicate
+ * vertex right before finishing; the toolbar's Finish button and Enter avoid that entirely.
+ */
+export function addDrawZoneControl(
+  map: L.Map,
+  overlay: CustomZonesOverlay,
+  showToast: (msg: string, durationMs?: number) => void,
+  showOverlay: () => void,
+): void {
+  let drawing = false;
+  let points: L.LatLng[] = [];
+  let draftLine: L.Polyline | null = null;
+  let vertexMarkers: L.CircleMarker[] = [];
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'draw-zone-toolbar';
+  const hint = document.createElement('span');
+  hint.className = 'draw-zone-toolbar__hint';
+  hint.textContent = 'Tap the map to add points to your zone';
+  const finishBtn = document.createElement('button');
+  finishBtn.type = 'button';
+  finishBtn.className = 'draw-zone-toolbar__finish';
+  finishBtn.textContent = 'Finish';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'draw-zone-toolbar__cancel';
+  cancelBtn.textContent = 'Cancel';
+  toolbar.append(hint, finishBtn, cancelBtn);
+  document.body.appendChild(toolbar);
+
+  function updateDraft(): void {
+    if (draftLine) {
+      map.removeLayer(draftLine);
+      draftLine = null;
+    }
+    if (points.length >= 2) {
+      draftLine = L.polyline(points, {
+        color: CUSTOM_ZONE_COLOR,
+        weight: 4,
+        opacity: 0.9,
+        dashArray: ZONE_DASH,
+        interactive: false,
+      });
+      draftLine.addTo(map);
+    }
+  }
+
+  function addPoint(latlng: L.LatLng): void {
+    points.push(latlng);
+    const marker = L.circleMarker(latlng, {
+      radius: 5,
+      color: CUSTOM_ZONE_COLOR,
+      fillColor: '#fff',
+      fillOpacity: 1,
+      weight: 2,
+      interactive: false,
+    });
+    marker.addTo(map);
+    vertexMarkers.push(marker);
+    updateDraft();
+  }
+
+  function onMapClick(e: L.LeafletMouseEvent): void {
+    addPoint(e.latlng);
+  }
+
+  function teardown(): void {
+    drawing = false;
+    points = [];
+    if (draftLine) {
+      map.removeLayer(draftLine);
+      draftLine = null;
+    }
+    for (const marker of vertexMarkers) map.removeLayer(marker);
+    vertexMarkers = [];
+    map.getContainer().style.cursor = '';
+    map.doubleClickZoom.enable();
+    map.off('click', onMapClick);
+    document.removeEventListener('keydown', onKeyDown);
+    toolbar.classList.remove('visible');
+  }
+
+  function onFinish(): void {
+    if (points.length < MIN_ZONE_POINTS) {
+      showToast('Draw at least 2 points before finishing');
+      return;
+    }
+    const coordinates: [number, number][] = points.map((p) => [p.lng, p.lat]);
+    teardown();
+    overlay.addZone(coordinates);
+    showOverlay();
+    showToast('Custom zone added');
+  }
+
+  function onCancel(): void {
+    teardown();
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') onCancel();
+    else if (e.key === 'Enter') onFinish();
+  }
+
+  finishBtn.addEventListener('click', onFinish);
+  cancelBtn.addEventListener('click', onCancel);
+
+  function startDrawing(): void {
+    if (drawing) {
+      onCancel(); // clicking the control again mid-draw cancels it
+      return;
+    }
+    drawing = true;
+    map.getContainer().style.cursor = 'crosshair';
+    map.doubleClickZoom.disable();
+    map.on('click', onMapClick);
+    document.addEventListener('keydown', onKeyDown);
+    toolbar.classList.add('visible');
+  }
+
+  // tradeoff: factory function rather than a class, matching makeToggleControl in controls.ts —
+  // avoids typing L.Control.extend()'s return value in strict TypeScript.
+  const DrawZoneControl = L.Control.extend({
+    onAdd(): HTMLElement {
+      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      container.title = 'Draw a custom squeeze zone';
+
+      const icon = L.DomUtil.create('span', 'leaflet-control-toggle__icon') as HTMLSpanElement;
+      icon.textContent = '✏';
+      container.appendChild(icon);
+
+      const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
+      label.textContent = 'Draw zone';
+      container.appendChild(label);
+
+      L.DomEvent.disableClickPropagation(container);
+      L.DomEvent.on(container, 'click', (e: Event) => {
+        startDrawing();
+        e.stopImmediatePropagation();
+      });
+
+      return container;
+    },
+  });
+
+  new (DrawZoneControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topleft' }).addTo(map);
+}

--- a/src/custom-zones.ts
+++ b/src/custom-zones.ts
@@ -215,6 +215,10 @@ export function createCustomZonesOverlay(showToast: (msg: string, durationMs?: n
         opacity: ZONE_OPACITY,
         dashArray: ZONE_DASH,
         interactive: true,
+        // Leaflet Path layers bubble clicks to the map by default — without this, tapping an
+        // existing zone while drawing a new one would both open this zone's popup AND add a
+        // spurious vertex to the in-progress zone via addDrawZoneControl's map click handler.
+        bubblingMouseEvents: false,
       });
       // Tooltip content is set via innerHTML by Leaflet; label is free-form user/file text — escape it.
       line.bindTooltip(escapeHtml(zoneDisplayLabel(zone.properties)), { sticky: true });

--- a/src/custom-zones.ts
+++ b/src/custom-zones.ts
@@ -316,20 +316,19 @@ export function addDrawZoneControl(
   document.body.appendChild(toolbar);
 
   function updateDraft(): void {
+    if (points.length < 2) return;
     if (draftLine) {
-      map.removeLayer(draftLine);
-      draftLine = null;
+      draftLine.setLatLngs(points);
+      return;
     }
-    if (points.length >= 2) {
-      draftLine = L.polyline(points, {
-        color: CUSTOM_ZONE_COLOR,
-        weight: 4,
-        opacity: 0.9,
-        dashArray: ZONE_DASH,
-        interactive: false,
-      });
-      draftLine.addTo(map);
-    }
+    draftLine = L.polyline(points, {
+      color: CUSTOM_ZONE_COLOR,
+      weight: 4,
+      opacity: 0.9,
+      dashArray: ZONE_DASH,
+      interactive: false,
+    });
+    draftLine.addTo(map);
   }
 
   function addPoint(latlng: L.LatLng): void {
@@ -361,7 +360,6 @@ export function addDrawZoneControl(
     for (const marker of vertexMarkers) map.removeLayer(marker);
     vertexMarkers = [];
     map.getContainer().style.cursor = '';
-    map.doubleClickZoom.enable();
     map.off('click', onMapClick);
     document.removeEventListener('keydown', onKeyDown);
     toolbar.classList.remove('visible');
@@ -384,6 +382,9 @@ export function addDrawZoneControl(
   }
 
   function onKeyDown(e: KeyboardEvent): void {
+    // Ignore keys typed into an unrelated focused control (e.g. the address search box) —
+    // otherwise looking up an address mid-draw would finish/cancel the in-progress zone.
+    if (e.target instanceof HTMLElement && e.target.closest('input, textarea')) return;
     if (e.key === 'Escape') onCancel();
     else if (e.key === 'Enter') onFinish();
   }
@@ -398,7 +399,9 @@ export function addDrawZoneControl(
     }
     drawing = true;
     map.getContainer().style.cursor = 'crosshair';
-    map.doubleClickZoom.disable();
+    // No doubleClickZoom.disable()/enable() here — geocoding.ts already disables it for the
+    // app's lifetime (dblclick drops a reverse-geocode pin instead), so toggling it per draw
+    // session would re-enable map-zoom-on-dblclick and silently break that feature.
     map.on('click', onMapClick);
     document.addEventListener('keydown', onKeyDown);
     toolbar.classList.add('visible');

--- a/src/file-overlay.ts
+++ b/src/file-overlay.ts
@@ -11,6 +11,20 @@
  */
 import L from 'leaflet';
 
+/** Trigger a browser download of `text` as a file named `filename`. */
+export function downloadJson(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Deferred revoke — Safari can drop the download if the URL dies before the click lands.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
 export interface FileOverlayConfig<T> {
   /** localStorage key holding the raw GeoJSON text */
   storageKey: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { createMap, initOfflineTileFallback, getTileLayers } from './map';
 import { addLayersControl, type LayerDef, type LayersControl, type OverlayDef } from './layers-control';
 import { createSqueezeZonesOverlay } from './squeeze-zones';
 import { createCueEventsOverlay } from './cue-events';
+import { createCustomZonesOverlay, addDrawZoneControl } from './custom-zones';
 import { addLocateControl, updateLocateIcon } from './controls';
 import { addSearchControl, addReverseGeocoding } from './geocoding';
 import { onLocationFound, onLocationError, clearLocationMarkers } from './location';
@@ -386,6 +387,7 @@ const squeezeZonesOverlay = createSqueezeZonesOverlay(showToast, () => {
 const cueEventsOverlay = createCueEventsOverlay(showToast, () => {
   setTimeout(() => layersControl?.setOverlayEnabled('cue-events', false), 0);
 });
+const customZonesOverlay = createCustomZonesOverlay(showToast);
 
 const overlayDefs: OverlayDef[] = [
   {
@@ -422,6 +424,18 @@ const overlayDefs: OverlayDef[] = [
       onClick: cueEventsOverlay.requestReviewExport,
     },
   },
+  {
+    id: 'custom-squeeze-zones',
+    name: 'Custom squeeze zones',
+    description: 'Zones you draw yourself with the Draw zone map button — shown in blue, separate from the derived overlay above',
+    tileLayer: customZonesOverlay.group,
+    requestFilePick: customZonesOverlay.requestFilePick,
+    rowAction: {
+      label: 'Export',
+      title: 'Download your custom zones as a GeoJSON file',
+      onClick: customZonesOverlay.requestExport,
+    },
+  },
 ];
 
 layersControl = addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'hiking-routes', 'cycling-routes']);
@@ -431,6 +445,7 @@ addSearchControl(map, state, showToast);
 addReverseGeocoding(map, state, showToast);
 addGuidanceControl(map, state, activatePolling, deactivatePolling);
 addCompassControl(map, state);
+addDrawZoneControl(map, customZonesOverlay, showToast, () => layersControl?.setOverlayEnabled('custom-squeeze-zones', true));
 
 // ── Version badge + changelog panel ───────────────────────────────────────────
 const versionBadge = document.createElement('button');

--- a/src/style.css
+++ b/src/style.css
@@ -1768,3 +1768,91 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 .cue-grade-progress.visible {
   display: block;
 }
+
+/* Popup on a rendered custom zone — optional label + Save/Delete, matches the grade-row's plain
+   button styling but doesn't need outcome coloring (custom zones carry no outcome). */
+.custom-zone-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+}
+
+.custom-zone-popup__label {
+  font: 13px system-ui, sans-serif;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.custom-zone-popup__actions {
+  display: flex;
+  gap: 6px;
+}
+
+.custom-zone-popup__actions button {
+  flex: 1;
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  background: #fff;
+  color: #333;
+  font: 12px system-ui, sans-serif;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.custom-zone-popup__actions button:hover {
+  background: #f0f0f0;
+}
+
+.custom-zone-popup__delete {
+  color: #d63131;
+  border-color: #d63131;
+}
+
+/* Draw-mode toolbar — bottom center, interactive (unlike .cue-grade-progress), visible only while
+   the "Draw zone" control is actively collecting vertices. */
+.draw-zone-toolbar {
+  display: none;
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  background: rgba(38, 50, 56, 0.9);
+  color: #fff;
+  font: 13px/1.3 system-ui, sans-serif;
+  padding: 8px 12px;
+  border-radius: 10px;
+  z-index: 900;
+}
+
+.draw-zone-toolbar.visible {
+  display: flex;
+}
+
+.draw-zone-toolbar__hint {
+  white-space: nowrap;
+}
+
+.draw-zone-toolbar button {
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font: 13px/1 system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.draw-zone-toolbar__finish {
+  background: #1e88e5;
+  color: #fff;
+}
+
+.draw-zone-toolbar__cancel {
+  background: #eee;
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- New "Custom squeeze zones" overlay: a **Draw zone** map control lets you click points to draw a zone (Finish/Cancel or Enter/Esc to commit/discard), rendered dashed blue — visually distinct from the derived Squeeze zones overlay's severity-colored solid lines
- Tap a drawn zone to edit its label or delete it; zones persist to localStorage like the other overlays
- Row actions: **Export** downloads the current set as GeoJSON; **Change…** imports a previously-exported file (replaces the current set, same contract as the other file-backed overlays)
- Hoisted `downloadJson` out of `cue-events.ts` into `file-overlay.ts` so both overlays share it
- Bumped the JS size-limit cap 114kB → 116kB (bundle is 114.89kB gzipped) — same adjustment made for the prior 0.38 feature wave

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 189 passed (17 new for `custom-zones.ts`)
- [x] `npm run build` — succeeds
- [x] `npm run size` — under the new 116kB cap (114.89kB gzipped)
- [x] Manual browser check (Playwright + headless Chromium against `npm run dev`): draw a 3-point zone, confirm it renders dashed blue and the overlay auto-enables; edit its label and Save; confirm the label persisted; Delete and confirm the popup no longer opens there; draw a second zone and Export, confirm a valid single-feature .geojson downloads; start a draw, Escape mid-draw, confirm nothing was added. No console errors. Two bugs found and fixed this pass (see commits): doubleClickZoom clobbering reverse-geocode pin-drop, and existing-zone clicks bubbling into the draw-mode click handler.

## Assumptions
- Drawing happens in webmap.dev itself (not a second externally-prepared GeoJSON file) — confirmed with the requester
- Importing a custom-zones file replaces the current set rather than merging, matching the existing Squeeze zones / Cue events overlays' contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
