### PR TITLE
feat(map): Satellite base layer + accept unrecognized cue grade

### DIFF
--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -56,6 +56,7 @@ describe('outcomeColor', () => {
     expect(outcomeColor('false_alarm')).toBe('#d63131');
     expect(outcomeColor('too_late')).toBe('#f57c00');
     expect(outcomeColor('missed_risk')).toBe('#7b1fa2');
+    expect(outcomeColor('unrecognized')).toBe('#00838f');
   });
 
   it('maps ungraded (absent outcome) to gray', () => {
@@ -97,6 +98,7 @@ describe('formatCueLabel', () => {
   it('renders outcomes with spaces, not underscores', () => {
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'false_alarm' })).toBe('cue 1 · false alarm');
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'missed_risk' })).toBe('cue 1 · missed risk');
+    expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'unrecognized' })).toBe('cue 1 · unrecognized');
   });
 
   it('includes reserved labels for unknown reason bits and omits a zero bitmask', () => {
@@ -246,7 +248,7 @@ describe('parseCueEvents', () => {
 
   it('throws on an unknown outcome grade', () => {
     expect(() => parseCueEvents(collection(syntheticCue({ outcome: 'great' }))))
-      .toThrow('outcome must be one of useful, false_alarm, too_late, missed_risk');
+      .toThrow('outcome must be one of useful, false_alarm, too_late, missed_risk, unrecognized');
   });
 
   it('throws (all-or-nothing) when only a later feature is malformed', () => {

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -32,7 +32,8 @@ import { escapeHtml } from './html';
 import { decodeReasons } from './squeeze-zones';
 
 // FR-008 review grades from the cue ride trace; a cue without a grade renders as "ungraded" gray.
-export const CUE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'missed_risk'] as const;
+// missed_risk is retired in the trace schema (replaced by unrecognized) but kept for older exports.
+export const CUE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'missed_risk', 'unrecognized'] as const;
 export type CueOutcome = (typeof CUE_OUTCOMES)[number];
 
 export interface CueProps {
@@ -75,6 +76,7 @@ export function outcomeColor(outcome: CueOutcome | undefined): string {
     case 'false_alarm': return '#d63131'; // red — matches squeeze-zone red
     case 'too_late': return '#f57c00'; // orange — matches squeeze-zone orange
     case 'missed_risk': return '#7b1fa2'; // purple
+    case 'unrecognized': return '#00838f'; // teal — distinct from the custom-zone blue
     default: return '#757575'; // ungraded gray
   }
 }
@@ -84,6 +86,7 @@ const OUTCOME_LABELS: Record<CueOutcome, string> = {
   false_alarm: 'false alarm',
   too_late: 'too late',
   missed_risk: 'missed risk',
+  unrecognized: 'unrecognized',
 };
 
 // Tooltip/popup line: `cue <id> · <clock> · lead N s · delivered N ms · <outcome> · <reasons>`,
@@ -252,6 +255,7 @@ const GRADE_BUTTON_LABELS: Record<GradableOutcome, string> = {
   useful: 'Useful',
   false_alarm: 'False alarm',
   too_late: 'Too late',
+  unrecognized: 'Unrecognized',
 };
 
 const CUE_RADIUS = 7;

--- a/src/cue-grades.test.ts
+++ b/src/cue-grades.test.ts
@@ -93,6 +93,15 @@ describe('parseGradeStore / updateGradeStore', () => {
       '6': { outcome: null, reviewed_at: T2 },
     });
   });
+
+  it('accepts the unrecognized grade as a valid stored outcome', () => {
+    const json = JSON.stringify({
+      files: { abc123: { '7': { outcome: 'unrecognized', reviewed_at: T1 } } },
+    });
+    expect(parseGradeStore(json, 'abc123')).toEqual({
+      '7': { outcome: 'unrecognized', reviewed_at: T1 },
+    });
+  });
 });
 
 describe('effectiveOutcome', () => {
@@ -123,6 +132,13 @@ describe('buildReviews', () => {
     const grades: GradeMap = { '57053650': { outcome: 'useful', reviewed_at: T1 } };
     expect(buildReviews(grades)).toEqual([
       { event_id: 57053650, outcome: 'useful', reviewed_at: T1 },
+    ]);
+  });
+
+  it('round-trips an unrecognized grade into the sidecar', () => {
+    const grades: GradeMap = { '2502598877': { outcome: 'unrecognized', reviewed_at: T1 } };
+    expect(buildReviews(grades)).toEqual([
+      { event_id: 2502598877, outcome: 'unrecognized', reviewed_at: T1 },
     ]);
   });
 

--- a/src/cue-grades.ts
+++ b/src/cue-grades.ts
@@ -13,9 +13,11 @@
  */
 import type { CueFileFeature, CueOutcome, CueProps } from './cue-events';
 
-// Outcomes gradable from the map. missed_risk is deliberately absent: a cue that
-// fired was not missed — missed risks become map-authored markers in v2.
-export const GRADABLE_OUTCOMES = ['useful', 'false_alarm', 'too_late'] as const;
+// Outcomes gradable from the map — matches the app's grade vocabulary so a map
+// sidecar can express any grade the phone can. missed_risk is deliberately
+// absent: a cue that fired was not missed — missed risks become map-authored
+// markers in v2.
+export const GRADABLE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'unrecognized'] as const;
 export type GradableOutcome = (typeof GRADABLE_OUTCOMES)[number];
 
 /** A pending review; outcome null is a Clear tombstone (renders ungraded, omitted from export). */

--- a/src/main.ts
+++ b/src/main.ts
@@ -402,6 +402,12 @@ const overlayDefs: OverlayDef[] = [
     tileLayer: tileLayers.hillshadeLayer,
   },
   {
+    id: 'cycle-blend',
+    name: 'Cycle blend',
+    description: 'The Cycle base map composited over any base — lighter colors turn transparent',
+    tileLayer: tileLayers.cycleBlendLayer,
+  },
+  {
     id: 'hiking-routes',
     name: 'Hiking routes',
     tileLayer: tileLayers.hikingLayer,

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,6 +373,12 @@ const layerDefs: LayerDef[] = [
     description: 'Highlights parks and amenities',
     tileLayer: tileLayers.humanitarianLayer,
   },
+  {
+    id: 'satellite',
+    name: 'Satellite',
+    description: 'Aerial imagery (Esri World Imagery)',
+    tileLayer: tileLayers.satelliteLayer,
+  },
 ];
 
 // File-backed overlays must be able to switch themselves off (file picker

--- a/src/main.ts
+++ b/src/main.ts
@@ -450,7 +450,7 @@ const overlayDefs: OverlayDef[] = [
   },
 ];
 
-layersControl = addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'hiking-routes', 'cycling-routes']);
+layersControl = addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'cycle-blend', 'hiking-routes', 'cycling-routes']);
 
 addOfflineDownloadControl(map, showToast);
 addSearchControl(map, state, showToast);

--- a/src/map.ts
+++ b/src/map.ts
@@ -10,6 +10,7 @@ import { OSM_TILE_CACHE_NAME } from './sw-constants';
 // Module-level tile layer refs — set during createMap(), read by initOfflineTileFallback()
 let osmStreetsLayer: L.TileLayer | null = null;
 let cycleLayer: L.TileLayer | null = null;
+let cycleBlendLayer: L.TileLayer | null = null;
 let outdoorsLayer: L.TileLayer | null = null;
 let humanitarianLayer: L.TileLayer | null = null;
 let satelliteLayer: L.TileLayer | null = null;
@@ -41,7 +42,7 @@ let osmCachePromise: Promise<Cache> | null = null;
 export function initOfflineTileFallback(
   showToast: (msg: string, durationMs?: number) => void,
 ): void {
-  const layers = [osmStreetsLayer, cycleLayer, outdoorsLayer, humanitarianLayer, satelliteLayer, hillshadeLayer].filter(
+  const layers = [osmStreetsLayer, cycleLayer, cycleBlendLayer, outdoorsLayer, humanitarianLayer, satelliteLayer, hillshadeLayer].filter(
     (l): l is L.TileLayer => l !== null,
   );
   if (layers.length === 0) {
@@ -238,6 +239,18 @@ export function createMap(): L.Map {
     },
   );
 
+  // Cycle base tiles reused as an overlay: multiply blend turns the style's
+  // light ground colors near-transparent so its route ink composites over any
+  // base (e.g. bike routes over Satellite). See .multiply-blend in style.css.
+  cycleBlendLayer = L.tileLayer(
+    'https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + tfKey,
+    {
+      attribution: tfAttribution,
+      className: 'multiply-blend',
+      ...stdConfig,
+    },
+  );
+
   // Waymarked route highlights — transparent overlays that compose over any base.
   // Exposed as TWO independent toggles (Hiking routes / Cycling routes) rather
   // than one combined layer: Waymarked colors routes by network hierarchy, not by
@@ -283,8 +296,8 @@ export function createMap(): L.Map {
     'https://server.arcgisonline.com/ArcGIS/rest/services/Elevation/World_Hillshade/MapServer/tile/{z}/{y}/{x}',
     {
       attribution: 'Esri',
-      // multiply: flat/lit pixels (near-white) pass through; slopes darken. See .hillshade-blend in style.css.
-      className: 'hillshade-blend',
+      // multiply: flat/lit pixels (near-white) pass through; slopes darken. See .multiply-blend in style.css.
+      className: 'multiply-blend',
       tileSize: 256,
       zoomOffset: 0,
       maxZoom: 18,
@@ -302,6 +315,7 @@ export function createMap(): L.Map {
 export function getTileLayers(): {
   osmStreetsLayer: L.TileLayer;
   cycleLayer: L.TileLayer;
+  cycleBlendLayer: L.TileLayer;
   outdoorsLayer: L.TileLayer;
   humanitarianLayer: L.TileLayer;
   satelliteLayer: L.TileLayer;
@@ -309,12 +323,13 @@ export function getTileLayers(): {
   hikingLayer: L.TileLayer;
   cyclingLayer: L.TileLayer;
 } {
-  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !satelliteLayer || !hillshadeLayer || !hikingLayer || !cyclingLayer) {
+  if (!osmStreetsLayer || !cycleLayer || !cycleBlendLayer || !outdoorsLayer || !humanitarianLayer || !satelliteLayer || !hillshadeLayer || !hikingLayer || !cyclingLayer) {
     throw new Error('Tile layers not initialized — call createMap() first');
   }
   return {
     osmStreetsLayer,
     cycleLayer,
+    cycleBlendLayer,
     outdoorsLayer,
     humanitarianLayer,
     satelliteLayer,

--- a/src/map.ts
+++ b/src/map.ts
@@ -12,6 +12,7 @@ let osmStreetsLayer: L.TileLayer | null = null;
 let cycleLayer: L.TileLayer | null = null;
 let outdoorsLayer: L.TileLayer | null = null;
 let humanitarianLayer: L.TileLayer | null = null;
+let satelliteLayer: L.TileLayer | null = null;
 let hillshadeLayer: L.TileLayer | null = null;
 let hikingLayer: L.TileLayer | null = null;
 let cyclingLayer: L.TileLayer | null = null;
@@ -40,7 +41,7 @@ let osmCachePromise: Promise<Cache> | null = null;
 export function initOfflineTileFallback(
   showToast: (msg: string, durationMs?: number) => void,
 ): void {
-  const layers = [osmStreetsLayer, cycleLayer, outdoorsLayer, humanitarianLayer, hillshadeLayer].filter(
+  const layers = [osmStreetsLayer, cycleLayer, outdoorsLayer, humanitarianLayer, satelliteLayer, hillshadeLayer].filter(
     (l): l is L.TileLayer => l !== null,
   );
   if (layers.length === 0) {
@@ -260,6 +261,24 @@ export function createMap(): L.Map {
     },
   );
 
+  // Esri World Imagery — same free ArcGIS Online host as the hillshade layer,
+  // no API key required. Native 256px tiles, so it skips stdConfig's 512/offset
+  // scheme. Global coverage tops out around z18; metro areas go deeper but 18
+  // keeps behavior uniform.
+  satelliteLayer = L.tileLayer(
+    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    {
+      attribution: 'Esri, Maxar, Earthstar Geographics',
+      tileSize: 256,
+      zoomOffset: 0,
+      maxZoom: 18,
+      maxNativeZoom: 18,
+      minZoom: 2,
+      minNativeZoom: 2,
+      ...tilePerf,
+    },
+  );
+
   hillshadeLayer = L.tileLayer(
     'https://server.arcgisonline.com/ArcGIS/rest/services/Elevation/World_Hillshade/MapServer/tile/{z}/{y}/{x}',
     {
@@ -285,11 +304,12 @@ export function getTileLayers(): {
   cycleLayer: L.TileLayer;
   outdoorsLayer: L.TileLayer;
   humanitarianLayer: L.TileLayer;
+  satelliteLayer: L.TileLayer;
   hillshadeLayer: L.TileLayer;
   hikingLayer: L.TileLayer;
   cyclingLayer: L.TileLayer;
 } {
-  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !hillshadeLayer || !hikingLayer || !cyclingLayer) {
+  if (!osmStreetsLayer || !cycleLayer || !outdoorsLayer || !humanitarianLayer || !satelliteLayer || !hillshadeLayer || !hikingLayer || !cyclingLayer) {
     throw new Error('Tile layers not initialized — call createMap() first');
   }
   return {
@@ -297,6 +317,7 @@ export function getTileLayers(): {
     cycleLayer,
     outdoorsLayer,
     humanitarianLayer,
+    satelliteLayer,
     hillshadeLayer,
     hikingLayer,
     cyclingLayer,

--- a/src/style.css
+++ b/src/style.css
@@ -14,8 +14,9 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
    full-screen map is a no-op. */
 #map { position: absolute; top: 0; bottom: 0; right: 0; left: 0; }
 
-/* Blend at the layer container so multiply composites against the base-layer sibling below. */
-.hillshade-blend { mix-blend-mode: multiply; }
+/* Blend at the layer container so multiply composites against the base-layer sibling below.
+   Shared by the Hillshade and Cycle blend overlays: near-white pixels pass through, darker ink shows. */
+.multiply-blend { mix-blend-mode: multiply; }
 
 /* Icon state classes for GPS accuracy filter visual feedback */
 #disabled {


### PR DESCRIPTION
## Summary
Three map changes:
1. **Satellite base layer** — new "Satellite" option in the layers popover, backed by Esri World Imagery from the same free, key-less ArcGIS Online host the hillshade overlay already uses.
2. **Accept the `unrecognized` cue grade** — the cue trace schema replaced `missed_risk` with `unrecognized` as the fourth review grade; the phone app now exports it and the Cue events overlay rejected such files wholesale (`feature N: outcome must be one of …`).
3. **Cycle blend overlay** — the Cycle base tiles reused as a multiply-blended overlay, so lighter colors turn near-transparent and the route ink composites over any base (e.g. bike routes over Satellite).

## Changes
- `src/map.ts` — new `satelliteLayer` (native 256px tiles, capped at z18 for uniform global coverage) and `cycleBlendLayer` (Cycle tiles with `multiply-blend`), both exported via `getTileLayers()` and wired into offline tile-error handling
- `src/main.ts` — "Satellite" base radio after Parks & POIs; "Cycle blend" overlay checkbox after Hillshade (default off)
- `src/style.css` — `.hillshade-blend` generalized to `.multiply-blend`, shared by Hillshade and Cycle blend
- `src/cue-events.ts` — `unrecognized` added to `CUE_OUTCOMES` (teal `#00838f`, distinct from the outcome palette and custom-zone blue), label, and grade-row button; `missed_risk` kept render-only for older exports
- `src/cue-grades.ts` — `unrecognized` added to `GRADABLE_OUTCOMES` so map sidecar exports match the app's grade vocabulary
- `src/cue-events.test.ts` — coverage for the new color, label, and validator message

## Test plan
- `npm run type-check && npm run lint && npm test` — 189 tests pass
- `npm run size` — 114.91 kB gzipped, under the 116 kB cap
- Manual: Satellite base renders and composes with hillshade/route overlays; Cycle blend over Satellite shows route ink with transparent ground; today's ride export (4 cues, 2 graded `unrecognized`) loads and renders teal

## Assumptions
- Satellite is a base map, not an overlay — opaque imagery would fully cover any base beneath it
- `missed_risk` stays non-gradable from the map per the existing #240 design note (a fired cue was not missed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)