### PR TITLE
feat(map): cue events — direction-of-travel arrows and Too early grade

### DIFF
--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -106,6 +106,8 @@ describe('formatCueLabel', () => {
   it('renders heading rounded to whole degrees, omitted when absent', () => {
     expect(formatCueLabel({ kind: 'cue', event_id: 4, heading_deg: 245.3 })).toBe('cue 4 · heading 245°');
     expect(formatCueLabel({ kind: 'cue', event_id: 4, heading_deg: 0 })).toBe('cue 4 · heading 0°');
+    // 359.7 rounds to 360, which must wrap — the label always reads [0, 359].
+    expect(formatCueLabel({ kind: 'cue', event_id: 4, heading_deg: 359.7 })).toBe('cue 4 · heading 0°');
     expect(formatCueLabel({ kind: 'cue', event_id: 4 })).toBe('cue 4');
   });
 

--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -55,6 +55,7 @@ describe('outcomeColor', () => {
     expect(outcomeColor('useful')).toBe('#2e7d32');
     expect(outcomeColor('false_alarm')).toBe('#d63131');
     expect(outcomeColor('too_late')).toBe('#f57c00');
+    expect(outcomeColor('too_early')).toBe('#fbc02d');
     expect(outcomeColor('missed_risk')).toBe('#7b1fa2');
     expect(outcomeColor('unrecognized')).toBe('#00838f');
   });
@@ -97,8 +98,15 @@ describe('formatCueLabel', () => {
 
   it('renders outcomes with spaces, not underscores', () => {
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'false_alarm' })).toBe('cue 1 · false alarm');
+    expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'too_early' })).toBe('cue 1 · too early');
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'missed_risk' })).toBe('cue 1 · missed risk');
     expect(formatCueLabel({ kind: 'cue', event_id: 1, outcome: 'unrecognized' })).toBe('cue 1 · unrecognized');
+  });
+
+  it('renders heading rounded to whole degrees, omitted when absent', () => {
+    expect(formatCueLabel({ kind: 'cue', event_id: 4, heading_deg: 245.3 })).toBe('cue 4 · heading 245°');
+    expect(formatCueLabel({ kind: 'cue', event_id: 4, heading_deg: 0 })).toBe('cue 4 · heading 0°');
+    expect(formatCueLabel({ kind: 'cue', event_id: 4 })).toBe('cue 4');
   });
 
   it('includes reserved labels for unknown reason bits and omits a zero bitmask', () => {
@@ -202,9 +210,16 @@ describe('parseCueEvents', () => {
       .toThrow('event_id must be a number');
   });
 
+  it('parses an optional heading_deg through to the cue props', () => {
+    const features = parseCueEvents(collection(syntheticCue({ heading_deg: 245.3 })));
+    expect((features[0]!.properties as { heading_deg?: number }).heading_deg).toBe(245.3);
+  });
+
   it('throws when an optional field has the wrong type', () => {
     expect(() => parseCueEvents(collection(syntheticCue({ latency_ms: '752' }))))
       .toThrow('latency_ms must be a number');
+    expect(() => parseCueEvents(collection(syntheticCue({ heading_deg: '245' }))))
+      .toThrow('heading_deg must be a number');
     expect(() => parseCueEvents(collection(syntheticCue({ delivered: 'yes' }))))
       .toThrow('delivered must be a boolean');
     expect(() => parseCueEvents(collection(syntheticCue({ ride_clock: 627 }))))
@@ -248,7 +263,7 @@ describe('parseCueEvents', () => {
 
   it('throws on an unknown outcome grade', () => {
     expect(() => parseCueEvents(collection(syntheticCue({ outcome: 'great' }))))
-      .toThrow('outcome must be one of useful, false_alarm, too_late, missed_risk, unrecognized');
+      .toThrow('outcome must be one of useful, false_alarm, too_late, too_early, missed_risk, unrecognized');
   });
 
   it('throws (all-or-nothing) when only a later feature is malformed', () => {

--- a/src/cue-events.test.ts
+++ b/src/cue-events.test.ts
@@ -215,6 +215,15 @@ describe('parseCueEvents', () => {
     expect((features[0]!.properties as { heading_deg?: number }).heading_deg).toBe(245.3);
   });
 
+  it('accepts due-north heading_deg 0 and rejects values outside [0, 360)', () => {
+    const dueNorth = parseCueEvents(collection(syntheticCue({ heading_deg: 0 })));
+    expect((dueNorth[0]!.properties as { heading_deg?: number }).heading_deg).toBe(0);
+    expect(() => parseCueEvents(collection(syntheticCue({ heading_deg: 360 }))))
+      .toThrow('heading_deg must be in [0, 360)');
+    expect(() => parseCueEvents(collection(syntheticCue({ heading_deg: -1 }))))
+      .toThrow('heading_deg must be in [0, 360)');
+  });
+
   it('throws when an optional field has the wrong type', () => {
     expect(() => parseCueEvents(collection(syntheticCue({ latency_ms: '752' }))))
       .toThrow('latency_ms must be a number');

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -33,7 +33,7 @@ import { decodeReasons } from './squeeze-zones';
 
 // FR-008 review grades from the cue ride trace; a cue without a grade renders as "ungraded" gray.
 // missed_risk is retired in the trace schema (replaced by unrecognized) but kept for older exports.
-export const CUE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'missed_risk', 'unrecognized'] as const;
+export const CUE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'too_early', 'missed_risk', 'unrecognized'] as const;
 export type CueOutcome = (typeof CUE_OUTCOMES)[number];
 
 export interface CueProps {
@@ -46,6 +46,8 @@ export interface CueProps {
   delivered?: boolean;
   latency_ms?: number;
   outcome?: CueOutcome;
+  /** rider's direction of travel at cue time, degrees clockwise from north; absent when unknown */
+  heading_deg?: number;
   /** true → point is a segment midpoint, not a GPS fix; absent/false → exact position */
   approx?: boolean;
 }
@@ -75,6 +77,7 @@ export function outcomeColor(outcome: CueOutcome | undefined): string {
     case 'useful': return '#2e7d32'; // green
     case 'false_alarm': return '#d63131'; // red — matches squeeze-zone red
     case 'too_late': return '#f57c00'; // orange — matches squeeze-zone orange
+    case 'too_early': return '#fbc02d'; // yellow — too_late's timing pair, one step lighter
     case 'missed_risk': return '#7b1fa2'; // purple
     case 'unrecognized': return '#00838f'; // teal — distinct from the custom-zone blue
     default: return '#757575'; // ungraded gray
@@ -85,6 +88,7 @@ const OUTCOME_LABELS: Record<CueOutcome, string> = {
   useful: 'useful',
   false_alarm: 'false alarm',
   too_late: 'too late',
+  too_early: 'too early',
   missed_risk: 'missed risk',
   unrecognized: 'unrecognized',
 };
@@ -107,6 +111,9 @@ export function formatCueLabel(props: CueProps): string {
     const reasons = decodeReasons(props.reasons_bitmask).join(', ');
     if (reasons !== '') parts.push(reasons);
   }
+  // Whole degrees — the tenth of a degree the producer preserves is below
+  // what a rider can act on in a tooltip.
+  if (props.heading_deg !== undefined) parts.push(`heading ${Math.round(props.heading_deg)}°`);
   if (props.approx === true) parts.push('approximate position');
   return parts.join(' · ');
 }
@@ -226,6 +233,7 @@ export function parseCueEvents(text: string): CueFileFeature[] {
           delivered: optionalBoolean(p, 'delivered', i),
           latency_ms: optionalNumber(p, 'latency_ms', i),
           outcome: outcome as CueOutcome | undefined,
+          heading_deg: optionalNumber(p, 'heading_deg', i),
           approx: optionalBoolean(p, 'approx', i),
         },
       });
@@ -255,6 +263,7 @@ const GRADE_BUTTON_LABELS: Record<GradableOutcome, string> = {
   useful: 'Useful',
   false_alarm: 'False alarm',
   too_late: 'Too late',
+  too_early: 'Too early',
   unrecognized: 'Unrecognized',
 };
 
@@ -285,7 +294,7 @@ export interface CueEventsOverlay extends FileBackedOverlay {
 /**
  * Build the layers-control overlay — see createFileBackedOverlay for the
  * file-picker / persistence / self-disable contract. Cue popups carry a grade
- * row (Useful / False alarm / Too late / Clear); a grade recolors the point
+ * row (Useful / False alarm / Too late / Too early / Unrecognized / Clear); a grade recolors the point
  * immediately and overwrites any prior grade, file-baked or session (latest
  * wins). Grades persist per file in localStorage and export as a reviews[]
  * sidecar via requestReviewExport.
@@ -438,6 +447,21 @@ export function createCueEventsOverlay(
         layer.bindPopup(popup.root); // tap opens it on touch devices; hosts the grade row
         cueEntries.push({ props, layer, labelEl: popup.labelEl, buttons: popup.buttons });
         group.addLayer(layer);
+        if (props.heading_deg !== undefined) {
+          // Direction-of-travel tick just outside the dot, rotated via the
+          // --heading-deg custom-property convention (see .blue-dot__heading).
+          // heading_deg is parse-validated finite, safe to interpolate.
+          group.addLayer(L.marker(latlng, {
+            icon: L.divIcon({
+              className: 'cue-heading-arrow',
+              html: `<span class="cue-heading-arrow__glyph" style="--heading-deg: ${props.heading_deg}deg">▲</span>`,
+              iconSize: [16, 16],
+              iconAnchor: [8, 8],
+            }),
+            interactive: false,
+            keyboard: false,
+          }));
+        }
       } else {
         // Distinct glyph from the circular cue points — a rider-placed "unsafe here" triangle.
         const label = escapeHtml(formatMarkerLabel(f.properties));

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -112,8 +112,9 @@ export function formatCueLabel(props: CueProps): string {
     if (reasons !== '') parts.push(reasons);
   }
   // Whole degrees — the tenth of a degree the producer preserves is below
-  // what a rider can act on in a tooltip.
-  if (props.heading_deg !== undefined) parts.push(`heading ${Math.round(props.heading_deg)}°`);
+  // what a rider can act on in a tooltip. Rounding can hit 360 (e.g. 359.7),
+  // which wraps to 0 so the label always reads [0, 359].
+  if (props.heading_deg !== undefined) parts.push(`heading ${Math.round(props.heading_deg) % 360}°`);
   if (props.approx === true) parts.push('approximate position');
   return parts.join(' · ');
 }
@@ -461,7 +462,7 @@ export function createCueEventsOverlay(
           group.addLayer(L.marker(latlng, {
             icon: L.divIcon({
               className: 'cue-heading-arrow',
-              html: `<span class="cue-heading-arrow__glyph" style="--heading-deg: ${props.heading_deg}deg">▲</span>`,
+              html: `<span class="cue-heading-arrow__glyph" aria-hidden="true" style="--heading-deg: ${props.heading_deg}deg">▲</span>`,
               iconSize: [16, 16],
               iconAnchor: [8, 8],
             }),

--- a/src/cue-events.ts
+++ b/src/cue-events.ts
@@ -222,6 +222,13 @@ export function parseCueEvents(text: string): CueFileFeature[] {
       if (outcome !== undefined && !(CUE_OUTCOMES as readonly string[]).includes(outcome)) {
         throw new Error(`feature ${i}: outcome must be one of ${CUE_OUTCOMES.join(', ')}`);
       }
+      // The producer emits bearings in [0, 360) and omits unknowns — a value
+      // outside that range is a malformed export, rejected loudly like an
+      // unknown outcome rather than rendered as a silently-wrong label.
+      const headingDeg = optionalNumber(p, 'heading_deg', i);
+      if (headingDeg !== undefined && (headingDeg < 0 || headingDeg >= 360)) {
+        throw new Error(`feature ${i}: heading_deg must be in [0, 360)`);
+      }
       features.push({
         coordinate,
         properties: {
@@ -233,7 +240,7 @@ export function parseCueEvents(text: string): CueFileFeature[] {
           delivered: optionalBoolean(p, 'delivered', i),
           latency_ms: optionalNumber(p, 'latency_ms', i),
           outcome: outcome as CueOutcome | undefined,
-          heading_deg: optionalNumber(p, 'heading_deg', i),
+          heading_deg: headingDeg,
           approx: optionalBoolean(p, 'approx', i),
         },
       });

--- a/src/cue-grades.test.ts
+++ b/src/cue-grades.test.ts
@@ -102,6 +102,15 @@ describe('parseGradeStore / updateGradeStore', () => {
       '7': { outcome: 'unrecognized', reviewed_at: T1 },
     });
   });
+
+  it('accepts the too_early grade as a valid stored outcome', () => {
+    const json = JSON.stringify({
+      files: { abc123: { '8': { outcome: 'too_early', reviewed_at: T1 } } },
+    });
+    expect(parseGradeStore(json, 'abc123')).toEqual({
+      '8': { outcome: 'too_early', reviewed_at: T1 },
+    });
+  });
 });
 
 describe('effectiveOutcome', () => {
@@ -139,6 +148,13 @@ describe('buildReviews', () => {
     const grades: GradeMap = { '2502598877': { outcome: 'unrecognized', reviewed_at: T1 } };
     expect(buildReviews(grades)).toEqual([
       { event_id: 2502598877, outcome: 'unrecognized', reviewed_at: T1 },
+    ]);
+  });
+
+  it('round-trips a too_early grade into the sidecar', () => {
+    const grades: GradeMap = { '4273742981': { outcome: 'too_early', reviewed_at: T1 } };
+    expect(buildReviews(grades)).toEqual([
+      { event_id: 4273742981, outcome: 'too_early', reviewed_at: T1 },
     ]);
   });
 

--- a/src/cue-grades.ts
+++ b/src/cue-grades.ts
@@ -17,7 +17,7 @@ import type { CueFileFeature, CueOutcome, CueProps } from './cue-events';
 // sidecar can express any grade the phone can. missed_risk is deliberately
 // absent: a cue that fired was not missed — missed risks become map-authored
 // markers in v2.
-export const GRADABLE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'unrecognized'] as const;
+export const GRADABLE_OUTCOMES = ['useful', 'false_alarm', 'too_late', 'too_early', 'unrecognized'] as const;
 export type GradableOutcome = (typeof GRADABLE_OUTCOMES)[number];
 
 /** A pending review; outcome null is a Clear tombstone (renders ungraded, omitted from export). */

--- a/src/style.css
+++ b/src/style.css
@@ -1719,8 +1719,31 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   cursor: pointer;
 }
 
-/* Grade row inside a cue popup — Useful / False alarm / Too late verdicts plus
-   Clear; the active verdict fills with its outcome color (matches the point). */
+/* Direction-of-travel tick on a cue point — sits just outside the dot in the
+   direction of travel, rotated by --heading-deg set inline per feature (same
+   convention as .blue-dot__heading). Non-interactive: hover/tap belong to the
+   circle marker beneath. */
+.cue-heading-arrow {
+  pointer-events: none;
+}
+
+.cue-heading-arrow__glyph {
+  display: block;
+  width: 16px;
+  height: 16px;
+  color: #37474f;
+  font-size: 11px;
+  line-height: 16px;
+  text-align: center;
+  text-shadow: 0 0 2px #fff, 0 0 2px #fff;
+  /* Right-to-left: offset outward first, then rotate about the dot center —
+     the glyph lands 13px from center along the heading, pointing outward. */
+  transform: rotate(var(--heading-deg, 0deg)) translateY(-13px);
+}
+
+/* Grade row inside a cue popup — Useful / False alarm / Too late / Too early /
+   Unrecognized verdicts plus Clear; the active verdict fills with its outcome
+   color (matches the point). */
 .cue-popup__label {
   margin-bottom: 6px;
 }
@@ -1760,6 +1783,17 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .cue-grade-row__btn.is-active[data-outcome='too_late'] {
   background: #f57c00;
+}
+
+.cue-grade-row__btn.is-active[data-outcome='too_early'] {
+  background: #fbc02d;
+  /* The one light fill in the outcome palette — the shared white active
+     text fails contrast on yellow. */
+  color: #263238;
+}
+
+.cue-grade-row__btn.is-active[data-outcome='unrecognized'] {
+  background: #00838f;
 }
 
 .cue-grade-row__btn--clear {


### PR DESCRIPTION
## Summary

Consumer side of two cue producer changes (#245):

1. **Direction of travel** — cue features may now carry `heading_deg` (jasoneplumb/cue#144): degrees clockwise from north, presence-keyed (absent = unknown or approximate position).
2. **Too early grade** — the FR-008 vocabulary gained `too_early` (jasoneplumb/cue#143): the cue fired correctly but so far ahead it felt disconnected from the hazard.

## Changes

- `cue-events.ts` — `heading_deg` in `CueProps` + parse validation; label gains `heading N°` (whole degrees); a non-interactive tick glyph renders just outside each heading-carrying cue dot, rotated via the existing `--heading-deg` custom-property convention (`.blue-dot__heading`); `too_early` in `CUE_OUTCOMES`, labels, color (`#fbc02d`, Material yellow-700 — too_late's timing pair, distinct from its orange)
- `cue-grades.ts` — `too_early` in `GRADABLE_OUTCOMES` → grade button + sidecar export
- `style.css` — `.cue-heading-arrow` styles; active-state backgrounds for the **Too early** button (dark text — white fails contrast on yellow) and the **Unrecognized** button (pre-existing gap: `.is-active` sets white text but `unrecognized` had no background rule, so the active button was white-on-white)
- tests — color/label/parse coverage for both features, including wrong-type `heading_deg` and the updated unknown-outcome message; `too_early` store + sidecar round-trips

## Test plan

`npm run type-check` ✓ · `npm run lint` ✓ · `npm test` (15 files, 202 tests) ✓

## Assumptions

- Heading tick sits 13 px from the dot center along the heading (rotate-then-translate), pointing outward; hover/tap stay on the circle beneath (`interactive: false`)
- Label heading is rounded to whole degrees — tenths are below what a rider can act on
- `missed_risk` stays in `CUE_OUTCOMES` (legacy baked exports) but remains absent from `GRADABLE_OUTCOMES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)