### PR TITLE
fix(map): keep decoded elevation across sun-direction changes

### DIFF
--- a/src/hillshade.test.ts
+++ b/src/hillshade.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import L from 'leaflet';
 import {
   HILLSHADE_AZIMUTH_DEG,
+  HILLSHADE_NW_AZIMUTH_DEG,
+  type HillshadeLayer,
+  createHillshadeLayer,
   decodeTerrarium,
   metersPerPixel,
   shadeElevationGrid,
@@ -76,5 +80,61 @@ describe('shadeElevationGrid', () => {
   it('flips which slope is lit when the azimuth flips to NW', () => {
     const facingNWUnderNWSun = shadeElevationGrid(plane(SIZE, CELL, CELL), SIZE, SIZE, CELL, 315);
     expect(center(facingNWUnderNWSun)).toBeGreaterThan(160);
+  });
+});
+
+// Layer-level regression guard: re-lighting must not go back to the network.
+// Terrarium tiles aren't service-worker cached (src/sw.ts only caches OSM), so a
+// refetch on every sun toggle left the map unshaded until the network answered —
+// and permanently when it didn't (offline, flaky cellular, throttled tile burst).
+describe('HillshadeLayer.setAzimuth', () => {
+  interface StubCtx {
+    putImageData: (img: { data: Uint8ClampedArray }) => void;
+  }
+
+  /** Minimal 2D-context stub: jsdom has no canvas backend. */
+  function stubCanvas(painted: Uint8ClampedArray[]): void {
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => StubCtx }).getContext = () => ({
+      drawImage: () => {},
+      // A ramp in the red channel decodes to terrain with a real gradient, so the
+      // two sun directions produce genuinely different shading.
+      getImageData: () => ({
+        data: Uint8ClampedArray.from(
+          { length: 256 * 256 * 4 },
+          (_, i) => (i % 4 === 0 ? 128 + Math.floor(i / 4 / 256) % 8 : 0),
+        ),
+      }),
+      createImageData: () => ({ data: new Uint8ClampedArray(256 * 256 * 4) }),
+      putImageData: (img: { data: Uint8ClampedArray }) => painted.push(img.data.slice()),
+      imageSmoothingEnabled: false,
+    } as unknown as StubCtx);
+  }
+
+  function paint(layer: HillshadeLayer, z: number, x: number, y: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const coords = Object.assign(L.point(x, y), { z }) as L.Coords;
+      layer.createTile(coords, (err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  it('re-shades from cached elevation instead of re-downloading the tile', async () => {
+    const painted: Uint8ClampedArray[] = [];
+    stubCanvas(painted);
+    globalThis.createImageBitmap = (async () => ({ close: () => {} })) as never;
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: async () => ({}) }));
+    globalThis.fetch = fetchMock as never;
+
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    await paint(layer, 14, 2620, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    layer.setAzimuth(HILLSHADE_NW_AZIMUTH_DEG);
+    await paint(layer, 14, 2620, 6333);
+
+    // The elevation grid is kept across the sun change — no second download …
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // … and the tile really was re-shaded under the new sun.
+    expect(painted).toHaveLength(2);
+    expect(painted[1]).not.toEqual(painted[0]);
   });
 });

--- a/src/hillshade.test.ts
+++ b/src/hillshade.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import L from 'leaflet';
 import {
   HILLSHADE_AZIMUTH_DEG,
@@ -88,13 +88,18 @@ describe('shadeElevationGrid', () => {
 // refetch on every sun toggle left the map unshaded until the network answered —
 // and permanently when it didn't (offline, flaky cellular, throttled tile burst).
 describe('HillshadeLayer.setAzimuth', () => {
-  interface StubCtx {
-    putImageData: (img: { data: Uint8ClampedArray }) => void;
-  }
+  // Shaded output captured per fetchAndShade call, so a test can assert the tile
+  // was genuinely re-shaded and not just re-served.
+  let painted: Uint8ClampedArray[];
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realGetContext = HTMLCanvasElement.prototype.getContext;
+  const realFetch = globalThis.fetch;
+  const realCreateImageBitmap = globalThis.createImageBitmap;
 
-  /** Minimal 2D-context stub: jsdom has no canvas backend. */
-  function stubCanvas(painted: Uint8ClampedArray[]): void {
-    (HTMLCanvasElement.prototype as unknown as { getContext: () => StubCtx }).getContext = () => ({
+  beforeEach(() => {
+    painted = [];
+    // Minimal 2D-context stub: jsdom has no canvas backend.
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => ({
       drawImage: () => {},
       // A ramp in the red channel decodes to terrain with a real gradient, so the
       // two sun directions produce genuinely different shading.
@@ -107,8 +112,19 @@ describe('HillshadeLayer.setAzimuth', () => {
       createImageData: () => ({ data: new Uint8ClampedArray(256 * 256 * 4) }),
       putImageData: (img: { data: Uint8ClampedArray }) => painted.push(img.data.slice()),
       imageSmoothingEnabled: false,
-    } as unknown as StubCtx);
-  }
+    });
+    globalThis.createImageBitmap = (async () => ({ close: () => {} })) as never;
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: async () => ({}) }));
+    globalThis.fetch = fetchMock as never;
+  });
+
+  // Restore the globals: vi.restoreAllMocks() can't undo a direct prototype patch,
+  // and leaving it in place would silently bleed into any test added later.
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = realGetContext;
+    globalThis.fetch = realFetch;
+    globalThis.createImageBitmap = realCreateImageBitmap;
+  });
 
   function paint(layer: HillshadeLayer, z: number, x: number, y: number): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -118,12 +134,6 @@ describe('HillshadeLayer.setAzimuth', () => {
   }
 
   it('re-shades from cached elevation instead of re-downloading the tile', async () => {
-    const painted: Uint8ClampedArray[] = [];
-    stubCanvas(painted);
-    globalThis.createImageBitmap = (async () => ({ close: () => {} })) as never;
-    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, blob: async () => ({}) }));
-    globalThis.fetch = fetchMock as never;
-
     const layer = createHillshadeLayer({ tileSize: 256 });
     await paint(layer, 14, 2620, 6333);
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -136,5 +146,38 @@ describe('HillshadeLayer.setAzimuth', () => {
     // … and the tile really was re-shaded under the new sun.
     expect(painted).toHaveLength(2);
     expect(painted[1]).not.toEqual(painted[0]);
+  });
+
+  it('re-shades overzoomed tiles from the cached ancestor elevation', async () => {
+    // z17 crops a z15 ancestor (dz = 2) — the getShadedAncestor path, which
+    // clears on setAzimuth and so must re-shade from elevCache rather than refetch.
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    await paint(layer, 17, 20960, 50664);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/15/5240/12666.png'),
+      undefined,
+    );
+
+    layer.setAzimuth(HILLSHADE_NW_AZIMUTH_DEG);
+    await paint(layer, 17, 20960, 50664);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(painted).toHaveLength(2);
+    expect(painted[1]).not.toEqual(painted[0]);
+  });
+
+  it('shares one download across sibling subtiles of the same ancestor', async () => {
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    await Promise.all([
+      paint(layer, 17, 20960, 50664),
+      paint(layer, 17, 20961, 50664),
+      paint(layer, 17, 20960, 50665),
+      paint(layer, 17, 20961, 50665),
+    ]);
+
+    // All four crop the same z15 ancestor: one fetch, one Horn pass.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(painted).toHaveLength(1);
   });
 });

--- a/src/hillshade.test.ts
+++ b/src/hillshade.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import L from 'leaflet';
 import {
+  ELEV_CACHE_MAX,
   HILLSHADE_AZIMUTH_DEG,
   HILLSHADE_NW_AZIMUTH_DEG,
   type HillshadeLayer,
@@ -165,6 +166,25 @@ describe('HillshadeLayer.setAzimuth', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(painted).toHaveLength(2);
     expect(painted[1]).not.toEqual(painted[0]);
+  });
+
+  it('evicts the least-recently-used elevation grid once the cache is full', async () => {
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    // Exactly fill the cache with distinct native tiles …
+    for (let i = 0; i < ELEV_CACHE_MAX; i++) await paint(layer, 14, 2620 + i, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(ELEV_CACHE_MAX);
+
+    // … one more evicts the least-recently-used entry (the first tile painted) …
+    await paint(layer, 14, 2620 + ELEV_CACHE_MAX, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(ELEV_CACHE_MAX + 1);
+
+    // … so that one must be re-downloaded …
+    await paint(layer, 14, 2620, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(ELEV_CACHE_MAX + 2);
+
+    // … while a still-resident entry is served from memory.
+    await paint(layer, 14, 2620 + ELEV_CACHE_MAX, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(ELEV_CACHE_MAX + 2);
   });
 
   it('shares one download across sibling subtiles of the same ancestor', async () => {

--- a/src/hillshade.ts
+++ b/src/hillshade.ts
@@ -9,6 +9,9 @@
  *          fetches AWS Open Data Terrarium tiles (free, key-less, z0–15) and
  *          paints shaded canvas tiles; overzoom past 15 crops the z15 ancestor,
  *          with shaded ancestors cached so sibling subtiles don't recompute.
+ *          Decoded elevation is cached separately from the shading it feeds —
+ *          elevation doesn't depend on the sun, so changing azimuth re-shades
+ *          from memory instead of re-downloading (Terrarium isn't SW-cached).
  *          Shade is normalized to neutral mid-gray on flat terrain for the
  *          overlay blend: sun-facing slopes LIGHTEN the base, shadowed darken
  * Future: Azimuth is fixed; southern-hemisphere imagery is sunlit from the north,
@@ -120,13 +123,37 @@ export function decodeTerrarium(rgba: Uint8ClampedArray, pixelCount: number): Fl
  * quadrant is cropped and scaled — mirroring TileLayer's maxNativeZoom behavior.
  */
 const ANCESTOR_CACHE_MAX = 24; // ~6 MB of shaded 256px canvases at worst
+const ELEV_CACHE_MAX = 24; // ~6 MB of 256×256 Float32 elevation grids at worst
+
+/** LRU read: a hit re-inserts, so eviction targets the least-recently-*used* entry. */
+function lruGet<V>(cache: Map<string, V>, key: string): V | undefined {
+  const entry = cache.get(key);
+  if (entry === undefined) return undefined;
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry;
+}
+
+/** LRU write: evicts the least-recently-used entry once the cache is at capacity. */
+function lruSet<V>(cache: Map<string, V>, key: string, value: V, max: number): void {
+  cache.delete(key);
+  if (cache.size >= max) {
+    // Map preserves insertion order and hits re-insert, so the first key is the LRU one
+    const lru = cache.keys().next().value;
+    if (lru !== undefined) cache.delete(lru);
+  }
+  cache.set(key, value);
+}
 
 export class HillshadeLayer extends L.GridLayer {
   private azimuthDeg = HILLSHADE_AZIMUTH_DEG;
   // Shaded z≤15 ancestors shared by overzoomed subtiles (up to 256 siblings at
-  // z19 share one z15 ancestor) — cached so the fetch + Horn pass runs once.
+  // z19 share one z15 ancestor) — cached so the Horn pass runs once.
   // Keyed by tile path only: setAzimuth clears the cache, so entries never mix suns.
   private ancestorCache = new Map<string, Promise<HTMLCanvasElement>>();
+  // Decoded elevation per native tile. Elevation is sun-independent, so this
+  // SURVIVES setAzimuth — that's what keeps re-lighting off the network.
+  private elevCache = new Map<string, Float32Array>();
   // In-flight fetch per native-zoom tile so panning away cancels the request.
   private aborts = new WeakMap<HTMLElement, AbortController>();
 
@@ -137,7 +164,11 @@ export class HillshadeLayer extends L.GridLayer {
     });
   }
 
-  /** Switch the sun direction and re-render all visible tiles. */
+  /**
+   * Switch the sun direction and re-render all visible tiles. Only the shaded
+   * output is invalidated — the elevation it was computed from is kept, so the
+   * repaint runs off cached data and never re-downloads.
+   */
   setAzimuth(azimuthDeg: number): void {
     if (azimuthDeg === this.azimuthDeg) return;
     this.azimuthDeg = azimuthDeg;
@@ -155,8 +186,16 @@ export class HillshadeLayer extends L.GridLayer {
     return tile;
   }
 
-  /** Fetch a Terrarium tile and shade it under the current sun. */
-  private async fetchAndShade(z: number, x: number, y: number, signal?: AbortSignal): Promise<HTMLCanvasElement> {
+  /**
+   * Decoded elevation for a native-zoom tile, from cache when possible. The
+   * scratch canvas used to read the PNG's pixels is dropped once decoded — only
+   * the Float32 grid is retained, and it outlives any sun-direction change.
+   */
+  private async getElevation(z: number, x: number, y: number, signal?: AbortSignal): Promise<Float32Array> {
+    const key = `${z}/${x}/${y}`;
+    const cached = lruGet(this.elevCache, key);
+    if (cached) return cached;
+
     const resp = await fetch(`${TERRARIUM_URL}/${z}/${x}/${y}.png`, signal ? { signal } : undefined);
     if (!resp.ok) throw new Error(`terrarium tile ${z}/${x}/${y}: HTTP ${resp.status}`);
     const bitmap = await createImageBitmap(await resp.blob());
@@ -171,11 +210,24 @@ export class HillshadeLayer extends L.GridLayer {
 
     const rgba = srcCtx.getImageData(0, 0, TILE_PX, TILE_PX).data;
     const elev = decodeTerrarium(rgba, TILE_PX * TILE_PX);
+    lruSet(this.elevCache, key, elev, ELEV_CACHE_MAX);
+    return elev;
+  }
+
+  /** Shade a Terrarium tile under the current sun. */
+  private async fetchAndShade(z: number, x: number, y: number, signal?: AbortSignal): Promise<HTMLCanvasElement> {
+    const elev = await this.getElevation(z, x, y, signal);
     const shade = shadeElevationGrid(
       elev, TILE_PX, TILE_PX, metersPerPixel(z, tileCenterLat(y, z)), this.azimuthDeg,
     );
 
-    const gray = srcCtx.createImageData(TILE_PX, TILE_PX);
+    const out = document.createElement('canvas');
+    out.width = TILE_PX;
+    out.height = TILE_PX;
+    const ctx = out.getContext('2d');
+    if (!ctx) throw new Error('no 2d context');
+
+    const gray = ctx.createImageData(TILE_PX, TILE_PX);
     for (let i = 0; i < shade.length; i++) {
       const v = shade[i] as number;
       gray.data[i * 4] = v;
@@ -183,31 +235,21 @@ export class HillshadeLayer extends L.GridLayer {
       gray.data[i * 4 + 2] = v;
       gray.data[i * 4 + 3] = 255;
     }
-    srcCtx.putImageData(gray, 0, 0);
-    return src;
+    ctx.putImageData(gray, 0, 0);
+    return out;
   }
 
   /** Cached shaded ancestor for overzoomed tiles; not abortable — it's shared. */
   private getShadedAncestor(z: number, x: number, y: number): Promise<HTMLCanvasElement> {
     const key = `${z}/${x}/${y}`;
-    let entry = this.ancestorCache.get(key);
-    if (entry) {
-      // LRU touch: re-insert so eviction targets the least-recently-used entry,
-      // not merely the oldest-inserted (which could still back visible subtiles)
-      this.ancestorCache.delete(key);
-      this.ancestorCache.set(key, entry);
-      return entry;
-    }
-    if (this.ancestorCache.size >= ANCESTOR_CACHE_MAX) {
-      // Drop the least-recently-used entry (Map preserves insertion order; hits re-insert)
-      const oldest = this.ancestorCache.keys().next().value;
-      if (oldest !== undefined) this.ancestorCache.delete(oldest);
-    }
-    entry = this.fetchAndShade(z, x, y).catch((err: Error) => {
+    const cached = lruGet(this.ancestorCache, key);
+    if (cached) return cached;
+
+    const entry = this.fetchAndShade(z, x, y).catch((err: Error) => {
       this.ancestorCache.delete(key); // allow retry after a failed fetch
       throw err;
     });
-    this.ancestorCache.set(key, entry);
+    lruSet(this.ancestorCache, key, entry, ANCESTOR_CACHE_MAX);
     return entry;
   }
 

--- a/src/hillshade.ts
+++ b/src/hillshade.ts
@@ -123,7 +123,7 @@ export function decodeTerrarium(rgba: Uint8ClampedArray, pixelCount: number): Fl
  * quadrant is cropped and scaled — mirroring TileLayer's maxNativeZoom behavior.
  */
 const ANCESTOR_CACHE_MAX = 24; // ~6 MB of shaded 256px canvases at worst
-const ELEV_CACHE_MAX = 24; // ~6 MB of 256×256 Float32 elevation grids at worst
+export const ELEV_CACHE_MAX = 24; // ~6 MB of 256×256 Float32 elevation grids at worst
 
 /** LRU read: a hit re-inserts, so eviction targets the least-recently-*used* entry. */
 function lruGet<V>(cache: Map<string, V>, key: string): V | undefined {


### PR DESCRIPTION
## Summary

Toggling **Satellite sun** on the Hillshade row made the terrain shading vanish. `setAzimuth()` cleared every cache and called `redraw()`, and nothing retained the decoded Terrarium elevation — so every toggle re-downloaded all visible elevation tiles from AWS. Terrarium isn't service-worker cached either (`src/sw.ts` only routes `*.tile.openstreetmap.org`), so the map had no shading for the whole round trip, and permanently when a refetch failed (offline, flaky cellular, throttled ~30-tile burst) since `redraw()` isn't called again until the next pan or zoom.

The layers-control click path was ruled out first: a jsdom repro confirmed clicking the sub-toggle checkbox, its text, or the wrap padding never unchecks the Hillshade row or removes the layer.

Fixes #249

## Changes

`src/hillshade.ts` — split the caches by what they actually depend on:

- **`elevCache`** (new) — decoded `Float32Array` per native tile. Elevation is sun-independent, so it **survives** `setAzimuth`; re-lighting now re-shades from memory with zero network.
- **`ancestorCache`** — shaded canvases, still cleared on azimuth change (correct: the shading *is* sun-dependent).
- `fetchAndShade` splits into `getElevation` (cached, abortable, drops the scratch decode canvas) and a pure Horn pass over that elevation.
- The LRU open-coded inside `getShadedAncestor` is extracted into shared `lruGet`/`lruSet` helpers now used by both caches.

Side benefit: this also fixes the same refetch on pan-back at z≤15, which previously had no cache at all.

## Test plan

- `src/hillshade.test.ts` adds a layer-level regression test: one download across a sun toggle, and the tile really is re-shaded under the new sun.
- Verified the test **fails against the unfixed code** — `expected "spy" to be called 1 times, but got 2 times` — and passes with the fix.
- `npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (208 tests) ✅ · `npm run size` 119.39 kB / 120 kB ✅

## Assumptions

- **Not browser-verified.** No browser automation available in the session; per CLAUDE.md, UI changes need a manual pass. To check: open the Layers popover, toggle Satellite sun with DevTools Network filtered to `elevation-tiles-prod` — expect **no** new requests, at both native zoom (z≤15) and overzoom (z16–19), which take different code paths.
- Worst-case memory rises ~6 MB (24 × 256 KB elevation grids), bounded by the documented `ELEV_CACHE_MAX`. Chosen to match the existing `ANCESTOR_CACHE_MAX` budget.
- Tiles still fade in over Leaflet's normal ~200 ms after a toggle rather than swapping instantly. Removing that would require repainting existing canvases in place via Leaflet's private `_tiles` plus generation-tracking to stop an in-flight initial paint racing the repaint — judged not worth the coupling once the multi-second network stall was gone.
