### PR TITLE
perf(map): coalesce concurrent elevation downloads

### DIFF
--- a/src/hillshade.test.ts
+++ b/src/hillshade.test.ts
@@ -198,6 +198,20 @@ describe('HillshadeLayer.setAzimuth', () => {
     expect(painted).toHaveLength(1);
   });
 
+  it('retries after a failed download instead of caching the rejection', async () => {
+    // The cache holds pending promises now, so a rejected entry must be dropped
+    // or the tile would be permanently unshaded until eviction.
+    fetchMock.mockImplementationOnce(async () => ({ ok: false, status: 503, blob: async () => ({}) }));
+    const layer = createHillshadeLayer({ tileSize: 256 });
+
+    await expect(paint(layer, 14, 2620, 6333)).rejects.toThrow('HTTP 503');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await paint(layer, 14, 2620, 6333);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(painted).toHaveLength(1);
+  });
+
   it('coalesces concurrent requests for the same native tile', async () => {
     const layer = createHillshadeLayer({ tileSize: 256 });
     // Both paints start before either fetch resolves — the elevation cache holds

--- a/src/hillshade.test.ts
+++ b/src/hillshade.test.ts
@@ -155,10 +155,7 @@ describe('HillshadeLayer.setAzimuth', () => {
     const layer = createHillshadeLayer({ tileSize: 256 });
     await paint(layer, 17, 20960, 50664);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/15/5240/12666.png'),
-      undefined,
-    );
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/15/5240/12666.png'));
 
     layer.setAzimuth(HILLSHADE_NW_AZIMUTH_DEG);
     await paint(layer, 17, 20960, 50664);
@@ -199,5 +196,22 @@ describe('HillshadeLayer.setAzimuth', () => {
     // All four crop the same z15 ancestor: one fetch, one Horn pass.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(painted).toHaveLength(1);
+  });
+
+  it('coalesces concurrent requests for the same native tile', async () => {
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    // Both paints start before either fetch resolves — the elevation cache holds
+    // the pending promise, so the second must join the first rather than refetch.
+    await Promise.all([paint(layer, 14, 2620, 6333), paint(layer, 14, 2620, 6333)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces a native tile with an overzoomed descendant of it', async () => {
+    const layer = createHillshadeLayer({ tileSize: 256 });
+    // z15/5240/12666 is both directly visible and the ancestor z17/20960/50664
+    // crops — the two paths race for one tile, which is why the abortable
+    // per-tile fetch had to go: a shared request belongs to no single tile.
+    await Promise.all([paint(layer, 15, 5240, 12666), paint(layer, 17, 20960, 50664)]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hillshade.ts
+++ b/src/hillshade.ts
@@ -12,10 +12,17 @@
  *          Decoded elevation is cached separately from the shading it feeds —
  *          elevation doesn't depend on the sun, so changing azimuth re-shades
  *          from memory instead of re-downloading (Terrarium isn't SW-cached).
+ *          Both caches hold the pending promise, so concurrent callers for one
+ *          tile share a single download. Downloads are deliberately NOT
+ *          cancelled on pan-away: a shared request can't be attributed to one
+ *          tile, and a completed fetch is kept for the pan back (see below).
  *          Shade is normalized to neutral mid-gray on flat terrain for the
  *          overlay blend: sun-facing slopes LIGHTEN the base, shadowed darken
  * Future: Azimuth is fixed; southern-hemisphere imagery is sunlit from the north,
- *         so a latitude-dependent azimuth flip is a possible refinement
+ *         so a latitude-dependent azimuth flip is a possible refinement.
+ *         Panning fast over new ground queues downloads that are no longer
+ *         wanted; if that shows up on cellular, gate new fetches on the tile
+ *         still being current rather than reinstating per-tile abort.
  */
 import L from 'leaflet';
 
@@ -153,16 +160,10 @@ export class HillshadeLayer extends L.GridLayer {
   private ancestorCache = new Map<string, Promise<HTMLCanvasElement>>();
   // Decoded elevation per native tile. Elevation is sun-independent, so this
   // SURVIVES setAzimuth — that's what keeps re-lighting off the network.
-  private elevCache = new Map<string, Float32Array>();
-  // In-flight fetch per native-zoom tile so panning away cancels the request.
-  private aborts = new WeakMap<HTMLElement, AbortController>();
-
-  constructor(options?: L.GridLayerOptions) {
-    super(options);
-    this.on('tileunload', (e: L.LeafletEvent) => {
-      this.aborts.get((e as L.TileEvent).tile)?.abort();
-    });
-  }
+  // Holds the PENDING promise, inserted before the fetch starts, so every
+  // caller for a tile shares one request: a directly-visible z≤15 tile and an
+  // overzoomed descendant's ancestor lookup can both want the same tile at once.
+  private elevCache = new Map<string, Promise<Float32Array>>();
 
   /**
    * Switch the sun direction and re-render all visible tiles. Only the shaded
@@ -187,16 +188,30 @@ export class HillshadeLayer extends L.GridLayer {
   }
 
   /**
-   * Decoded elevation for a native-zoom tile, from cache when possible. The
-   * scratch canvas used to read the PNG's pixels is dropped once decoded — only
-   * the Float32 grid is retained, and it outlives any sun-direction change.
+   * Decoded elevation for a native-zoom tile, shared by every caller. Not async:
+   * the pending promise must reach the cache before the first await, or two
+   * callers racing the same tile would each start a download.
    */
-  private async getElevation(z: number, x: number, y: number, signal?: AbortSignal): Promise<Float32Array> {
+  private getElevation(z: number, x: number, y: number): Promise<Float32Array> {
     const key = `${z}/${x}/${y}`;
     const cached = lruGet(this.elevCache, key);
     if (cached) return cached;
 
-    const resp = await fetch(`${TERRARIUM_URL}/${z}/${x}/${y}.png`, signal ? { signal } : undefined);
+    const entry = this.fetchElevation(z, x, y).catch((err: Error) => {
+      this.elevCache.delete(key); // allow retry after a failed fetch
+      throw err;
+    });
+    lruSet(this.elevCache, key, entry, ELEV_CACHE_MAX);
+    return entry;
+  }
+
+  /**
+   * Download and decode one Terrarium tile. The scratch canvas used to read the
+   * PNG's pixels is dropped once decoded — only the Float32 grid is retained,
+   * and it outlives any sun-direction change.
+   */
+  private async fetchElevation(z: number, x: number, y: number): Promise<Float32Array> {
+    const resp = await fetch(`${TERRARIUM_URL}/${z}/${x}/${y}.png`);
     if (!resp.ok) throw new Error(`terrarium tile ${z}/${x}/${y}: HTTP ${resp.status}`);
     const bitmap = await createImageBitmap(await resp.blob());
 
@@ -209,14 +224,12 @@ export class HillshadeLayer extends L.GridLayer {
     bitmap.close();
 
     const rgba = srcCtx.getImageData(0, 0, TILE_PX, TILE_PX).data;
-    const elev = decodeTerrarium(rgba, TILE_PX * TILE_PX);
-    lruSet(this.elevCache, key, elev, ELEV_CACHE_MAX);
-    return elev;
+    return decodeTerrarium(rgba, TILE_PX * TILE_PX);
   }
 
   /** Shade a Terrarium tile under the current sun. */
-  private async fetchAndShade(z: number, x: number, y: number, signal?: AbortSignal): Promise<HTMLCanvasElement> {
-    const elev = await this.getElevation(z, x, y, signal);
+  private async fetchAndShade(z: number, x: number, y: number): Promise<HTMLCanvasElement> {
+    const elev = await this.getElevation(z, x, y);
     const shade = shadeElevationGrid(
       elev, TILE_PX, TILE_PX, metersPerPixel(z, tileCenterLat(y, z)), this.azimuthDeg,
     );
@@ -239,7 +252,7 @@ export class HillshadeLayer extends L.GridLayer {
     return out;
   }
 
-  /** Cached shaded ancestor for overzoomed tiles; not abortable — it's shared. */
+  /** Cached shaded ancestor, shared by every overzoomed subtile that crops it. */
   private getShadedAncestor(z: number, x: number, y: number): Promise<HTMLCanvasElement> {
     const key = `${z}/${x}/${y}`;
     const cached = lruGet(this.ancestorCache, key);
@@ -260,9 +273,7 @@ export class HillshadeLayer extends L.GridLayer {
     if (!ctx) throw new Error('no 2d context');
 
     if (dz === 0) {
-      const controller = new AbortController();
-      this.aborts.set(tile, controller);
-      const src = await this.fetchAndShade(coords.z, coords.x, coords.y, controller.signal);
+      const src = await this.fetchAndShade(coords.z, coords.x, coords.y);
       ctx.drawImage(src, 0, 0);
     } else {
       const src = await this.getShadedAncestor(

--- a/src/hillshade.ts
+++ b/src/hillshade.ts
@@ -188,17 +188,23 @@ export class HillshadeLayer extends L.GridLayer {
   }
 
   /**
-   * Decoded elevation for a native-zoom tile, shared by every caller. Not async:
-   * the pending promise must reach the cache before the first await, or two
-   * callers racing the same tile would each start a download.
+   * Decoded elevation for a native-zoom tile, shared by every caller. The
+   * invariant that makes the sharing work: NO await may precede the cache
+   * write below, or two callers racing the same tile would both miss and each
+   * start a download. (Marking this `async` would be harmless on its own — an
+   * async function still runs synchronously up to its first await — but any
+   * await added above the write reopens the race.)
    */
   private getElevation(z: number, x: number, y: number): Promise<Float32Array> {
     const key = `${z}/${x}/${y}`;
     const cached = lruGet(this.elevCache, key);
     if (cached) return cached;
 
-    const entry = this.fetchElevation(z, x, y).catch((err: Error) => {
-      this.elevCache.delete(key); // allow retry after a failed fetch
+    const entry: Promise<Float32Array> = this.fetchElevation(z, x, y).catch((err: Error) => {
+      // Evict by identity, not just key: if this entry was dropped by the LRU
+      // mid-flight and a newer fetch for the same tile replaced it, that one
+      // must survive our failure.
+      if (this.elevCache.get(key) === entry) this.elevCache.delete(key);
       throw err;
     });
     lruSet(this.elevCache, key, entry, ELEV_CACHE_MAX);
@@ -258,8 +264,9 @@ export class HillshadeLayer extends L.GridLayer {
     const cached = lruGet(this.ancestorCache, key);
     if (cached) return cached;
 
-    const entry = this.fetchAndShade(z, x, y).catch((err: Error) => {
-      this.ancestorCache.delete(key); // allow retry after a failed fetch
+    const entry: Promise<HTMLCanvasElement> = this.fetchAndShade(z, x, y).catch((err: Error) => {
+      // Evict by identity so a stale failure can't drop a newer entry (see getElevation)
+      if (this.ancestorCache.get(key) === entry) this.ancestorCache.delete(key);
       throw err;
     });
     lruSet(this.ancestorCache, key, entry, ANCESTOR_CACHE_MAX);


### PR DESCRIPTION
## Summary

Implements **option 1** of #251: promise-cache `elevCache`, drop the per-tile abort.

`elevCache` stored the *resolved* `Float32Array`, written only after the fetch settled — so two callers racing the same tile each started a download, while `ancestorCache` (which caches the pending promise) already coalesced correctly. `elevCache` now stores the pending promise too, inserted before the fetch begins.

`getElevation` is deliberately **not** `async`: the entry has to reach the cache before the first `await`, or the race it fixes reopens. That subtlety is called out in a comment so it survives future edits.

Closes #251

## The tradeoff this accepts

Promise-caching required removing the per-tile `AbortController` that cancelled in-flight fetches on pan-away. This isn't incidental — the two are mutually exclusive. A shared request can't be attributed to one tile: a directly-visible z≤15 tile and an overzoomed descendant's ancestor lookup can want the same tile concurrently, so one tile's abort would reject the other's waiter. There's now a test for exactly that pairing.

- **Cost:** panning fast over new ground queues downloads that are no longer wanted.
- **Mitigation:** a completed fetch is no longer wasted — `elevCache` keeps it for the pan back, which wasn't true when this behavior was written.
- **If it bites:** the module header points at gating new fetches on the tile still being current, rather than reinstating per-tile abort.

This is a deliberate behavior change, not a silent one — flagging it for review since it removes a bandwidth optimization on mobile.

## Changes

`src/hillshade.ts`
- `elevCache` becomes `Map<string, Promise<Float32Array>>`; `getElevation` is sync, inserts the pending entry, and deletes it on rejection so a failed fetch can retry (mirrors `getShadedAncestor`)
- Download/decode split out into `fetchElevation`
- Removes the `aborts` WeakMap, the `tileunload` listener, and the now-empty constructor
- Header documents why fetches aren't cancelled, and what to do instead if bandwidth becomes a problem

## Test plan

Two new tests, both of which **fail against the pre-change code** with `expected "spy" to be called 1 times, but got 2 times`:
- Concurrent paints of the same native tile issue one request (the #251 acceptance criterion)
- A native z15 tile and an overzoomed z17 descendant of it, painted concurrently, issue one request (the cross-path race that makes abort unsafe)

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (213 tests) ✅ · `npm run size` 119.61 kB / 120 kB ✅

## Assumptions

- Not browser-verified. The behavior change to watch for is bandwidth on a fast pan, which is a devtools-Network observation rather than a visual one; correctness of the caching is covered by tests.
- Bundle is 0.4 kB under the size cap. Worth noting the cap is getting tight independently of this PR.
