### PR TITLE
fix(map): right-anchor the geocode sheet so bottom-left controls stay usable

### DIFF
--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -8,6 +8,7 @@ import {
   DRAG_PAST_BOTTOM_PX,
   MIN_BELOW_PEEK_PX,
   sheetSettleTarget,
+  sheetTransform,
 } from './geocoding';
 
 // ── Minimal stubs ─────────────────────────────────────────────────────────────
@@ -240,5 +241,22 @@ describe('sheetSettleTarget', () => {
     const dismissThreshold = MIN + DISMISS_BELOW_MIN_PX;
     expect(clampMax - dismissThreshold).toBeGreaterThanOrEqual(30);
     expect(sheetSettleTarget(clampMax, PEEK, MIN)).toBe('dismiss');
+  });
+});
+
+describe('sheetTransform', () => {
+  it('carries only the vertical offset', () => {
+    expect(sheetTransform(0)).toBe('translateY(0px)');
+    expect(sheetTransform(137)).toBe('translateY(137px)');
+    expect(sheetTransform(-20)).toBe('translateY(-20px)');
+  });
+
+  it('never emits a horizontal component', () => {
+    // The sheet is right-anchored in CSS (#253). A translateX here would fight
+    // that anchor and push it off-screen — and because four call sites write
+    // this transform, a stale one is invisible until the user drags.
+    for (const offset of [0, 137, -20, 999]) {
+      expect(sheetTransform(offset)).not.toContain('translateX');
+    }
   });
 });

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -394,6 +394,18 @@ export const DRAG_PAST_BOTTOM_PX = 80;
 export const DISMISS_BELOW_MIN_PX = 40;
 export const MIN_BELOW_PEEK_PX = 80;
 
+/**
+ * Transform for the geocode-bar at a given vertical offset. The sheet is
+ * right-anchored (see .geocode-bar in style.css), so the transform carries ONLY
+ * the vertical offset — a horizontal component here would fight the CSS anchor
+ * and push the sheet off-screen. Centralized because four call sites write this
+ * (snap, open, touch-drag, mouse-drag) and one missed edit is invisible until
+ * the user drags.
+ */
+export function sheetTransform(offsetPx: number): string {
+  return `translateY(${offsetPx}px)`;
+}
+
 /** Pure end-of-drag snap decision for the geocode-bar bottom sheet. */
 export function sheetSettleTarget(
   currentOffset: number,
@@ -580,7 +592,7 @@ export function addReverseGeocoding(
   function animateTo(offsetPx: number): void {
     geocodeBar.style.willChange = 'transform';
     geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
-    geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
+    geocodeBar.style.transform = sheetTransform(offsetPx);
     geocodeBar.addEventListener('transitionend', () => {
       geocodeBar.style.willChange = '';
     }, { once: true });
@@ -634,7 +646,7 @@ export function addReverseGeocoding(
       // starting the transition (single-rAF can batch both into one paint frame).
       geocodeBar.style.display = 'flex';
       geocodeBar.style.transition = 'none';
-      geocodeBar.style.transform = `translateX(-50%) translateY(${geocodeBar.offsetHeight}px)`;
+      geocodeBar.style.transform = sheetTransform(geocodeBar.offsetHeight);
       barHandle.setAttribute('aria-expanded', 'false');
       requestAnimationFrame(() => {
         requestAnimationFrame(() => { snapTo('peek'); });
@@ -676,7 +688,7 @@ export function addReverseGeocoding(
     const delta = touch.clientY - dragStartY;
     // Upward travel stops just past peek — there is no larger state to reach
     const clamped = Math.max(getPeekOffset() - 20, Math.min(geocodeBar.offsetHeight + DRAG_PAST_BOTTOM_PX, dragStartOffset + delta));
-    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+    geocodeBar.style.transform = sheetTransform(clamped);
   }, { passive: true });
 
   // Shared end-of-drag settle: full dismiss only from below the minimized
@@ -727,7 +739,7 @@ export function addReverseGeocoding(
     if (Math.abs(delta) > 3) dragMoved = true;
     // Upward travel stops just past peek — there is no larger state to reach
     const clamped = Math.max(getPeekOffset() - 20, Math.min(geocodeBar.offsetHeight + DRAG_PAST_BOTTOM_PX, dragStartOffset + delta));
-    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+    geocodeBar.style.transform = sheetTransform(clamped);
   });
 
   document.addEventListener('mouseup', () => {

--- a/src/style.css
+++ b/src/style.css
@@ -428,16 +428,24 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* ── Reverse geocode bottom sheet ── */
+/* Right-anchored, not centred, and never full-width: the bottom-left control
+   cluster (zoom / locate / scale / version / attribution) sits under a centred
+   full-width sheet, and in peek every pixel of the visible band belongs to an
+   interactive child, so those controls are unreachable until the sheet is
+   minimized (#253). 67vw leaves a clear left column at phone widths; the 480px
+   cap keeps the sheet from ballooning on desktop.
+   The transform carries only translateY — see sheetTransform() in geocoding.ts. */
 .geocode-bar {
   position: fixed;
   bottom: 0;
-  left: 50%;
-  transform: translateX(-50%) translateY(0);
-  width: min(480px, 100vw);
+  right: env(safe-area-inset-right, 0px);
+  left: auto;
+  transform: translateY(0);
+  width: min(480px, 67vw);
   height: 60vh;
   min-height: calc(130px + var(--sai-bottom));
   background: #fff;
-  border-radius: 12px 12px 0 0;
+  border-radius: 12px 0 0 0;
   box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);
   z-index: 1500;
   font-family: system-ui, sans-serif;
@@ -850,6 +858,15 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      (zoom, version-badge) from stretching to match wider siblings like
      the attribution. */
   align-items: flex-start;
+  /* Stay clear of the right-anchored geocode-bar. The buttons are all narrow
+     enough to fit regardless, but the attribution runs ~330px with a base map
+     plus Hillshade and would otherwise sit permanently under the sheet — OSM's
+     tile usage policy wants that credit visible, so cap the column and let it
+     wrap instead. Mirrors the sheet's own width formula. */
+  max-width: calc(
+    100vw - min(480px, 67vw)
+    - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 20px
+  );
 }
 
 .leaflet-bottom.leaflet-left .leaflet-control-toggle {


### PR DESCRIPTION
## Summary

The geocode sheet was centred and full-width on phones (`width: min(480px, 100vw)`), sitting on top of the bottom-left control cluster.

It was **not** merely a visibility problem. `.geocode-bar--peek` sets `pointer-events: none`, but the children that re-enable `pointer-events: auto` (handle, dashboard, profile row, nav, copy, addr, close) fill the entire visible 130 px band — there is no pass-through area. So zoom, scale, version badge and attribution were genuinely unreachable until the sheet was minimized. Locate sits highest in the cluster and stayed usable, which is the signature that made it read as "zoom is broken" specifically.

Fixes #253

## Changes

**`src/style.css`** — `.geocode-bar` anchors to the right edge instead of centring:

```css
right: env(safe-area-inset-right, 0px);
left: auto;
transform: translateY(0);
width: min(480px, 67vw);
border-radius: 12px 0 0 0;
```

`min(480px, 67vw)` gives ~2/3 width where it matters (251 px on a 375 px phone) while keeping the existing 480 px cap so the sheet doesn't balloon on a wide monitor. Right-anchoring applies at **all** widths per maintainer direction, so the sheet doesn't jump layout at a breakpoint. Top-right radius squared off now that it's flush to the edge.

**`src/geocoding.ts`** — four call sites (snap, open, touch-drag, mouse-drag) wrote the transform as a literal string containing `translateX(-50%)`. All now route through `sheetTransform()`. This was the sharp edge: a single missed edit leaves the sheet half off-screen, and only once the user drags — the initial render looks fine.

**Cluster max-width** — mirrors the sheet's own width formula. Every *button* already fit the freed column (locate 28 px, zoom 28 px, version ~50 px, scale ~80–100 px vs ~124 px free), but `.leaflet-control-attribution` has no `max-width` in Leaflet's CSS or ours and runs ~330 px with a base map plus Hillshade. It sits at `order: 6`, so it would have stayed permanently covered. Since OSM's tile usage policy wants that credit visible, the column is capped and the attribution wraps.

## Test plan

2 new unit tests (220 total) asserting `sheetTransform()` emits only a vertical component and never a `translateX` — the guard against the four-site drift described above.

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (220) ✅

**Verified on desktop** by the maintainer: sheet renders bottom-right, controls clear.

## Assumptions and gaps

- **Mobile not yet re-verified.** The geometry is the whole point of this change and jsdom can't assert it — no layout engine, so `getBoundingClientRect()` returns zeros. Worth confirming on a phone: tap zoom +/−, locate and the version badge with the sheet in peek; then drag the handle through peek↔min, dismiss, and re-open, since that exercises all four transform sites and a horizontal jump would reveal a missed one.
- **Sheet content at 251 px** — Drive/Bike/Walk plus Start/Copy is the tightest fit; worth a look for wrapping or clipping.
- **Desktop layout changes for existing users** — the sheet moves from centred to bottom-right. Intended, but it's the most visible change here.
- Rejected alternatives (raise z-index, shrink peek height, move zoom to top-left) are recorded on #253 with reasons.
