### PR TITLE
fix(consent): never let a persistence failure wedge the boot gate

### DIFF
--- a/src/consent.test.ts
+++ b/src/consent.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The consent promise is the app's boot gate — main.ts awaits it before
+ * bootApp(). Anything that stops it resolving leaves a blank page with no error
+ * path, so these tests pin the failure modes that used to do exactly that.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hasConsent, showConsentModal } from './consent';
+
+const realRandomUUID = crypto.randomUUID;
+
+/** Accept the modal: scroll the terms to the bottom, then click through. */
+function accept(): void {
+  const body = document.querySelector<HTMLElement>('#consent-body')!;
+  // jsdom reports every dimension as 0, so the modal's atBottom() check already
+  // passes and the button is enabled — no scrolling needed.
+  const btn = document.querySelector<HTMLButtonElement>('#consent-accept')!;
+  expect(btn.disabled).toBe(false);
+  void body;
+  btn.click();
+}
+
+describe('showConsentModal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    Object.defineProperty(crypto, 'randomUUID', { value: realRandomUUID, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('resolves and records consent on accept', async () => {
+    const pending = showConsentModal();
+    accept();
+    await expect(pending).resolves.toBe(true);
+    expect(hasConsent()).toBe(true);
+    expect(document.querySelector('#consent-overlay')).toBeNull();
+  });
+
+  it('resolves without crypto.randomUUID (insecure context)', async () => {
+    // Serving over plain HTTP to a LAN IP — a phone testing the dev server —
+    // leaves crypto.randomUUID undefined. It used to throw inside the click
+    // handler, so the promise never settled and the app never booted.
+    Object.defineProperty(crypto, 'randomUUID', { value: undefined, configurable: true });
+
+    const pending = showConsentModal();
+    accept();
+    await expect(pending).resolves.toBe(true);
+    expect(hasConsent()).toBe(true);
+    expect(localStorage.getItem('webmap-consent-install-id')).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('still resolves when storage rejects the write', async () => {
+    // iOS Safari private browsing throws QuotaExceededError on setItem. Booting
+    // matters more than remembering: re-prompting next load beats a blank page.
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const pending = showConsentModal();
+    accept();
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('unbinds the keydown listener once closed', async () => {
+    const pending = showConsentModal();
+    accept();
+    await pending;
+
+    // A leaked listener would keep firing cleanup() against a detached modal.
+    const removed = vi.spyOn(document, 'removeEventListener');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(removed).not.toHaveBeenCalled();
+  });
+});

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -13,9 +13,24 @@ export function hasConsent(): boolean {
   return localStorage.getItem(KEY_VERSION) === CONSENT_VERSION;
 }
 
+/**
+ * UUID v4 without requiring a secure context. crypto.randomUUID() is
+ * secure-context-only, so it is undefined over plain HTTP — e.g. a phone
+ * hitting a dev server at http://192.168.x.x:5173. crypto.getRandomValues()
+ * carries no such restriction, so derive the same shape from it when needed.
+ */
+function randomId(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = ((bytes[6] as number) & 0x0f) | 0x40; // version 4
+  bytes[8] = ((bytes[8] as number) & 0x3f) | 0x80; // variant 10xx
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 function ensureInstallId(): void {
   if (!localStorage.getItem(KEY_INSTALL_ID)) {
-    localStorage.setItem(KEY_INSTALL_ID, crypto.randomUUID());
+    localStorage.setItem(KEY_INSTALL_ID, randomId());
   }
 }
 
@@ -100,12 +115,27 @@ export function showConsentModal(): Promise<boolean> {
     }
 
     function cleanup(accepted: boolean): void {
-      // Symmetric teardown — tear down both listeners regardless of which path closes
+      // Symmetric teardown — tear down every listener regardless of which path closes
       // the modal (e.g. decline-before-scroll leaves the scroll listener attached).
       body.removeEventListener('scroll', onScrollOrResize);
       window.removeEventListener('resize', onScrollOrResize);
+      document.removeEventListener('keydown', onKey);
       overlay.remove();
-      if (accepted) recordConsent();
+      // Persisting must never block resolution. This promise is the app's boot
+      // gate (main.ts awaits it before bootApp), so a throw here used to remove
+      // the modal and then hang forever on a blank page — with consent unsaved,
+      // so the next load re-prompted. Storage can fail for real: iOS Safari
+      // private browsing throws QuotaExceededError on setItem.
+      if (accepted) {
+        try {
+          recordConsent();
+        } catch (err) {
+          console.error(
+            '[webmap] could not persist consent — continuing; terms will be shown again next load',
+            err,
+          );
+        }
+      }
       resolve(accepted);
     }
 
@@ -115,12 +145,11 @@ export function showConsentModal(): Promise<boolean> {
       if (e.target === overlay) cleanup(false);
     });
 
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        document.removeEventListener('keydown', onKey);
-        cleanup(false);
-      }
-    };
+    // Declared (not assigned to a const) so cleanup() above can unbind it on
+    // every close path, including accept.
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') cleanup(false);
+    }
     document.addEventListener('keydown', onKey);
 
     // Focus the scrollable terms so keyboard users can scroll to read (and thereby


### PR DESCRIPTION
## Summary

`showConsentModal()` returns the promise that gates boot — `main.ts:57` does `waitForConsent().then(() => bootApp())`. In `cleanup()`, persistence ran *before* resolution:

```ts
overlay.remove();
if (accepted) recordConsent();   // ← throws here …
resolve(accepted);               // ← … so this never runs
```

A throw left the promise permanently **unsettled**, not rejected. The `.catch` at `main.ts:59` never fired, so there was no reload and no console error, and the modal had already been removed. Blank page, no way out. And because the throw preceded `localStorage.setItem(KEY_VERSION, …)`, consent was never recorded — so reloading re-prompted, indefinitely.

Fixes #255

## Why this is a real production bug

Found while loading the dev server from a phone over plain `http://<LAN-IP>` — an insecure context, where `crypto.randomUUID` is undefined and `ensureInstallId()` threw. That trigger is environmental and doesn't apply to production.

The wedge it exposed is not. `localStorage.setItem` throws `QuotaExceededError` in **iOS Safari private browsing** and with **"Block All Cookies"** enabled. Same line, same unsettled promise, same blank page. That path is reachable on the deployed site today.

Distinct from #224 — that failure is below the JS layer. They produce the same symptom and shouldn't be conflated when triaging.

## Changes

`src/consent.ts`:
1. **`recordConsent()` wrapped in try/catch**, logging and continuing. Booting without a saved consent record — re-prompting next load — is strictly better than not booting. This is the fix; the rest is supporting.
2. **`randomId()`** falls back to `crypto.getRandomValues` when `crypto.randomUUID` is unavailable, assembling a spec-shaped v4 UUID (version and variant bits set). Removes the insecure-context throw entirely and unblocks phone testing against the dev server.
3. **`keydown` listener unbound on every close path**, including accept. It was only removed on the Escape path, leaking a document-level listener bound to a detached modal.

## Test plan

New `src/consent.test.ts`, 4 tests (220 total):
- Accept resolves and records consent
- Accept resolves with `crypto.randomUUID` undefined, and the install ID is still a valid v4 UUID
- Accept resolves when `Storage.setItem` throws `QuotaExceededError`
- No leaked `keydown` listener after close

**All three failure-mode tests fail against the unfixed code**, and the two wedge tests fail *by timing out at 5000 ms* — the promise never settles. That's the reported blank page, reproduced as a test.

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (220) ✅

## Assumptions

- The jsdom modal reports zero dimensions, so `atBottom()` passes immediately and the accept button starts enabled — the tests assert this rather than simulating a scroll. If the scroll gate is ever changed, these tests need revisiting.
- Not browser-verified. The fix is pure control flow with no visual surface; the failure modes are covered by tests. Real-device confirmation would mean iOS Safari private browsing, which is worth doing before relying on this for #224 triage.
