### PR TITLE
fix(map): map chrome pass — sheet, controls, and turn-by-turn banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webmap-dev",
-  "version": "0.38.0-beta",
+  "version": "0.44.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webmap-dev",
-      "version": "0.38.0-beta",
+      "version": "0.44.1-beta",
       "dependencies": {
         "esri-leaflet": "^3.0.12",
         "esri-leaflet-geocoder": "^3.1.4",
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@size-limit/file": "^12.1.0",
         "@types/leaflet": "^1.9.14",
+        "@vitejs/plugin-basic-ssl": "^1.2.0",
         "eslint": "^9.0.0",
         "globals": "^15.0.0",
         "jsdom": "^29.0.1",
@@ -3797,6 +3798,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.2.0.tgz",
+      "integrity": "sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "size-limit": [
     {
       "path": "dist/assets/index-*.js",
-      "limit": "120 kB",
+      "limit": "122 kB",
       "gzip": true
     }
   ]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@size-limit/file": "^12.1.0",
     "@types/leaflet": "^1.9.14",
+    "@vitejs/plugin-basic-ssl": "^1.2.0",
     "eslint": "^9.0.0",
     "globals": "^15.0.0",
     "jsdom": "^29.0.1",

--- a/src/custom-zones.ts
+++ b/src/custom-zones.ts
@@ -418,13 +418,12 @@ export function addDrawZoneControl(
       const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
       container.title = 'Draw a custom squeeze zone';
 
+      // Icon only — the title attribute carries the description. U+FE0E is the
+      // text-presentation variation selector: without it iOS renders the pencil
+      // as a colour emoji, while desktop already shows the monochrome glyph.
       const icon = L.DomUtil.create('span', 'leaflet-control-toggle__icon') as HTMLSpanElement;
-      icon.textContent = '✏';
+      icon.textContent = '✏︎';
       container.appendChild(icon);
-
-      const label = L.DomUtil.create('span', 'leaflet-control-toggle__label') as HTMLSpanElement;
-      label.textContent = 'Draw zone';
-      container.appendChild(label);
 
       L.DomEvent.disableClickPropagation(container);
       L.DomEvent.on(container, 'click', (e: Event) => {
@@ -436,5 +435,9 @@ export function addDrawZoneControl(
     },
   });
 
-  new (DrawZoneControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topleft' }).addTo(map);
+  // Top-right, joining the download and layers controls. Top-left is the search
+  // bar's column, where a second button crowded the input on narrow screens.
+  // Leaflet stacks a corner's controls in registration order, so this lands
+  // below both (see the addDrawZoneControl call in main.ts).
+  new (DrawZoneControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topright' }).addTo(map);
 }

--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -8,6 +8,7 @@ import {
   DRAG_PAST_BOTTOM_PX,
   MIN_BELOW_PEEK_PX,
   sheetSettleTarget,
+  sheetTransform,
 } from './geocoding';
 
 // ── Minimal stubs ─────────────────────────────────────────────────────────────
@@ -240,5 +241,22 @@ describe('sheetSettleTarget', () => {
     const dismissThreshold = MIN + DISMISS_BELOW_MIN_PX;
     expect(clampMax - dismissThreshold).toBeGreaterThanOrEqual(30);
     expect(sheetSettleTarget(clampMax, PEEK, MIN)).toBe('dismiss');
+  });
+});
+
+describe('sheetTransform', () => {
+  it('carries only the vertical offset', () => {
+    expect(sheetTransform(0)).toBe('translateY(0px)');
+    expect(sheetTransform(137)).toBe('translateY(137px)');
+    expect(sheetTransform(-20)).toBe('translateY(-20px)');
+  });
+
+  it('never emits a horizontal component', () => {
+    // The sheet is right-anchored in CSS (#253). A translateX here would fight
+    // that anchor and push it off-screen — and because four call sites write
+    // this transform, a stale one is invisible until the user drags.
+    for (const offset of [0, 137, -20, 999]) {
+      expect(sheetTransform(offset)).not.toContain('translateX');
+    }
   });
 });

--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -9,6 +9,7 @@ import {
   MIN_BELOW_PEEK_PX,
   sheetSettleTarget,
   sheetTransform,
+  isReplyForPin,
 } from './geocoding';
 
 // ── Minimal stubs ─────────────────────────────────────────────────────────────
@@ -258,5 +259,22 @@ describe('sheetTransform', () => {
     for (const offset of [0, 137, -20, 999]) {
       expect(sheetTransform(offset)).not.toContain('translateX');
     }
+  });
+});
+
+describe('isReplyForPin', () => {
+  it('accepts a reply for the pin the sheet points at', () => {
+    expect(isReplyForPin({ lat: 47.6, lng: -122.3 }, { lat: 47.6, lng: -122.3 })).toBe(true);
+  });
+
+  it('drops a reply for a position the pin has moved on from', () => {
+    // A slow reverse-geocode landing after the user dragged the pin elsewhere
+    // must not overwrite the newer address.
+    expect(isReplyForPin({ lat: 47.6, lng: -122.3 }, { lat: 47.7, lng: -122.3 })).toBe(false);
+    expect(isReplyForPin({ lat: 47.6, lng: -122.3 }, { lat: 47.6, lng: -122.4 })).toBe(false);
+  });
+
+  it('drops any reply once the pin is cleared', () => {
+    expect(isReplyForPin(null, { lat: 47.6, lng: -122.3 })).toBe(false);
   });
 });

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -394,6 +394,18 @@ export const DRAG_PAST_BOTTOM_PX = 80;
 export const DISMISS_BELOW_MIN_PX = 40;
 export const MIN_BELOW_PEEK_PX = 80;
 
+/**
+ * Transform for the geocode-bar at a given vertical offset. The sheet is
+ * right-anchored (see .geocode-bar in style.css), so the transform carries ONLY
+ * the vertical offset — a horizontal component here would fight the CSS anchor
+ * and push the sheet off-screen. Centralized because four call sites write this
+ * (snap, open, touch-drag, mouse-drag) and one missed edit is invisible until
+ * the user drags.
+ */
+export function sheetTransform(offsetPx: number): string {
+  return `translateY(${offsetPx}px)`;
+}
+
 /** Pure end-of-drag snap decision for the geocode-bar bottom sheet. */
 export function sheetSettleTarget(
   currentOffset: number,
@@ -580,7 +592,7 @@ export function addReverseGeocoding(
   function animateTo(offsetPx: number): void {
     geocodeBar.style.willChange = 'transform';
     geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
-    geocodeBar.style.transform = `translateX(-50%) translateY(${offsetPx}px)`;
+    geocodeBar.style.transform = sheetTransform(offsetPx);
     geocodeBar.addEventListener('transitionend', () => {
       geocodeBar.style.willChange = '';
     }, { once: true });
@@ -634,7 +646,7 @@ export function addReverseGeocoding(
       // starting the transition (single-rAF can batch both into one paint frame).
       geocodeBar.style.display = 'flex';
       geocodeBar.style.transition = 'none';
-      geocodeBar.style.transform = `translateX(-50%) translateY(${geocodeBar.offsetHeight}px)`;
+      geocodeBar.style.transform = sheetTransform(geocodeBar.offsetHeight);
       barHandle.setAttribute('aria-expanded', 'false');
       requestAnimationFrame(() => {
         requestAnimationFrame(() => { snapTo('peek'); });
@@ -676,7 +688,7 @@ export function addReverseGeocoding(
     const delta = touch.clientY - dragStartY;
     // Upward travel stops just past peek — there is no larger state to reach
     const clamped = Math.max(getPeekOffset() - 20, Math.min(geocodeBar.offsetHeight + DRAG_PAST_BOTTOM_PX, dragStartOffset + delta));
-    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+    geocodeBar.style.transform = sheetTransform(clamped);
   }, { passive: true });
 
   // Shared end-of-drag settle: full dismiss only from below the minimized
@@ -727,7 +739,7 @@ export function addReverseGeocoding(
     if (Math.abs(delta) > 3) dragMoved = true;
     // Upward travel stops just past peek — there is no larger state to reach
     const clamped = Math.max(getPeekOffset() - 20, Math.min(geocodeBar.offsetHeight + DRAG_PAST_BOTTOM_PX, dragStartOffset + delta));
-    geocodeBar.style.transform = `translateX(-50%) translateY(${clamped}px)`;
+    geocodeBar.style.transform = sheetTransform(clamped);
   });
 
   document.addEventListener('mouseup', () => {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -626,7 +626,12 @@ export function addReverseGeocoding(
       const finishHide = (e?: TransitionEvent): void => {
         // transitionend bubbles: a child's transition (the Copy button's colour
         // swap, a profile button) would otherwise tear the sheet down mid-flight.
+        // Returning early here rather than using { once: true } matters — once
+        // would let a child's event consume the listener before the sheet's own.
         if (e && e.target !== geocodeBar) return;
+        // Unbind on the first real invocation, including the timer path, so
+        // repeated dismissals don't pile up listeners for the life of the page.
+        geocodeBar.removeEventListener('transitionend', finishHide);
         if (sheetState !== 'hidden') return; // re-opened before the transition ended
         geocodeBar.style.display = 'none';
         geocodeBar.style.transform = '';
@@ -890,9 +895,21 @@ export function addReverseGeocoding(
     // Debounced reverse geocode as pin is dragged to a new location
     let dragDebounce: ReturnType<typeof setTimeout> | undefined;
     pin.on('dragend', () => {
+      const moved = pin.getLatLng();
+      // Move the sheet's destination with the pin, synchronously. currentPinLatLng
+      // is what Start routes to, and it also gates the stale-reply guard in
+      // updateGeocodeBarAddress — leaving it at the drop point would both freeze
+      // the address label and silently route to where the pin used to be.
+      currentPinLatLng = moved;
+      const label = coordLabel(moved);
+      currentPinLabel = label;
+      barAddrEl.textContent = label;
+      barAddrEl.title = label;
+      barCopyBtn.dataset['copy'] = label;
+
       if (dragDebounce !== undefined) clearTimeout(dragDebounce);
       dragDebounce = setTimeout(() => {
-        reverseGeocode(pin.getLatLng());
+        reverseGeocode(moved);
       }, 300);
     });
   }

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -391,6 +391,10 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
 // no safe-area inset — the min offset sits only ~a handle-height above the
 // clamp floor, so the old +20 clamp left a ~2px window.
 export const DRAG_PAST_BOTTOM_PX = 80;
+
+/** Sheet snap animation duration (ms). Mirrored by the cluster's
+ *  `transition: bottom` in style.css so the two move together. */
+export const SHEET_ANIM_MS = 300;
 export const DISMISS_BELOW_MIN_PX = 40;
 export const MIN_BELOW_PEEK_PX = 80;
 
@@ -587,14 +591,31 @@ export function addReverseGeocoding(
   // duration of the animation only, then cleared to avoid pinning a GPU layer.
   function animateTo(offsetPx: number): void {
     geocodeBar.style.willChange = 'transform';
-    geocodeBar.style.transition = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)';
+    geocodeBar.style.transition = `transform ${SHEET_ANIM_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
     geocodeBar.style.transform = sheetTransform(offsetPx);
     geocodeBar.addEventListener('transitionend', () => {
       geocodeBar.style.willChange = '';
     }, { once: true });
   }
 
+  /**
+   * Publish how much of the bottom edge the sheet occupies, so the control
+   * cluster can sit above it. Horizontal separation can't work: the attribution
+   * runs ~330px with a base map plus Hillshade, which is most of a phone's
+   * width, so the sheet and the cluster have to be stacked, not side by side.
+   * Set on snap only — `bottom` is a layout property, so writing it on every
+   * pointermove would reflow the cluster each frame.
+   */
+  function publishSheetHeight(target: SheetState): void {
+    const occupied =
+      target === 'hidden' ? 0 :
+      target === 'min' ? barHandle.offsetHeight + getSafeAreaBottom() :
+      getPeekHeight();
+    document.documentElement.style.setProperty('--sheet-h', `${occupied}px`);
+  }
+
   function snapTo(target: SheetState): void {
+    publishSheetHeight(target);
     if (target === 'hidden') {
       // Update sheetState immediately so any concurrent showGeocodeBar call
       // takes the correct 'hidden' branch rather than calling snapTo('peek')
@@ -602,11 +623,22 @@ export function addReverseGeocoding(
       // fire at the end of the NEW transition, hiding the freshly-opened sheet.
       sheetState = 'hidden';
       animateTo(geocodeBar.offsetHeight + 20);
-      geocodeBar.addEventListener('transitionend', () => {
-        if (sheetState !== 'hidden') return; // re-opened before transition ended
+      const finishHide = (e?: TransitionEvent): void => {
+        // transitionend bubbles: a child's transition (the Copy button's colour
+        // swap, a profile button) would otherwise tear the sheet down mid-flight.
+        if (e && e.target !== geocodeBar) return;
+        if (sheetState !== 'hidden') return; // re-opened before the transition ended
         geocodeBar.style.display = 'none';
         geocodeBar.style.transform = '';
-      }, { once: true });
+      };
+      geocodeBar.addEventListener('transitionend', finishHide);
+      // transitionend is not guaranteed: it never fires if the transition doesn't
+      // start (setting transition and transform in one frame straight after
+      // transition:none, which is exactly what a drag-dismiss does) and it is
+      // replaced by transitioncancel if a re-open interrupts it. Without a
+      // fallback the sheet keeps display:flex with a stale inline transform,
+      // leaving the reopen path to fight state that should already be cleared.
+      setTimeout(finishHide, SHEET_ANIM_MS + 50);
       geocodeBar.classList.remove('geocode-bar--peek', 'geocode-bar--min');
       barHandle.setAttribute('aria-expanded', 'false');
     } else {
@@ -793,24 +825,39 @@ export function addReverseGeocoding(
   // Disable double-click zoom so dblclick can drop a pin instead
   map.doubleClickZoom.disable();
 
-  function reverseGeocode(latlng: L.LatLng): void {
-    const lat = latlng.lat;
-    const lng = latlng.lng;
+  /** Human-readable coordinates — shown immediately, and kept if the geocoder
+   *  has nothing better to offer. */
+  function coordLabel(latlng: L.LatLng): string {
+    const { lat, lng } = latlng;
     const latStr = `${Math.abs(lat).toFixed(5)}\u00b0\u00a0${lat >= 0 ? 'N' : 'S'}`;
     const lngStr = `${Math.abs(lng).toFixed(5)}\u00b0\u00a0${lng >= 0 ? 'E' : 'W'}`;
-    const coordLabel = `${latStr},  ${lngStr}`;
+    return `${latStr},  ${lngStr}`;
+  }
 
+  /**
+   * Upgrade the address of an already-open sheet. Deliberately does not snap:
+   * a slow response must not yank a sheet the user has since minimized back up
+   * to peek. Ignored when the pin has moved on, so a late reply for an old
+   * location can't overwrite a newer one.
+   */
+  function updateGeocodeBarAddress(label: string, copyText: string, latlng: L.LatLng): void {
+    if (currentPinLatLng === null) return;
+    if (currentPinLatLng.lat !== latlng.lat || currentPinLatLng.lng !== latlng.lng) return;
+    barAddrEl.textContent = label;
+    barAddrEl.title = label;
+    barCopyBtn.dataset['copy'] = copyText;
+    currentPinLabel = label;
+  }
+
+  function reverseGeocode(latlng: L.LatLng): void {
     geocoder
       .reverse()
       .latlng(latlng)
       .run((error, result) => {
-        if (error || !result) {
-          // Geocoding failed — fall back to coordinates.
-          showGeocodeBar(coordLabel, coordLabel, latlng);
-          return;
-        }
+        // No fallback needed: the sheet is already open showing coordinates.
+        if (error || !result) return;
         const addr = result.address.Match_addr;
-        showGeocodeBar(addr, addr, latlng);
+        if (addr) updateGeocodeBarAddress(addr, addr, latlng);
       });
   }
 
@@ -831,6 +878,13 @@ export function addReverseGeocoding(
     const pin = L.marker(latlng, { draggable: true, icon: redIcon });
     pinLayer.addLayer(pin);
 
+    // Open the sheet synchronously. Previously the only calls to showGeocodeBar
+    // were inside the geocoder callback, so a request that never came back left
+    // no sheet at all — and the ESRI key is referrer-restricted, which fails
+    // silently on an origin that isn't allowlisted. The pin is the user's
+    // action; the sheet should not depend on a third party answering.
+    const label = coordLabel(latlng);
+    showGeocodeBar(label, label, latlng);
     reverseGeocode(latlng);
 
     // Debounced reverse geocode as pin is dragged to a new location
@@ -857,8 +911,9 @@ export function addReverseGeocoding(
 
   // iOS Safari long-press fallback: contextmenu fires inconsistently on iOS,
   // so we implement our own long-press via touch events. If the touch holds for
-  // 500ms without moving more than ~10px and contextmenu has not already fired
-  // (to avoid double-drop on browsers that do support it), drop a pin.
+  // LONG_PRESS_MS without moving more than ~10px and contextmenu has not already
+  // fired (to avoid double-drop on browsers that do support it), drop a pin.
+  const LONG_PRESS_MS = 250;
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
   let longPressStartX = 0;
   let longPressStartY = 0;
@@ -892,7 +947,7 @@ export function addReverseGeocoding(
       const point = L.point(longPressStartX - mapRect.left, longPressStartY - mapRect.top);
       const latlng = map.containerPointToLatLng(point);
       dropPin(latlng);
-    }, 500);
+    }, LONG_PRESS_MS);
   }, { passive: true });
 
   function cancelLongPress(): void {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -392,9 +392,25 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
 // clamp floor, so the old +20 clamp left a ~2px window.
 export const DRAG_PAST_BOTTOM_PX = 80;
 
-/** Sheet snap animation duration (ms). Mirrored by the cluster's
- *  `transition: bottom` in style.css so the two move together. */
+/**
+ * Sheet snap animation duration (ms). Published to CSS as --sheet-anim so the
+ * control cluster's `transition: bottom` uses this exact value rather than a
+ * second hardcoded copy that could silently drift.
+ */
 export const SHEET_ANIM_MS = 300;
+
+/** Structural latlng so callers (and tests) don't need a Leaflet instance. */
+interface LatLngLike { lat: number; lng: number }
+
+/**
+ * True when a geocoder reply still describes the pin the sheet points at.
+ * Exported for testing: a late reply for a pin the user has moved on from must
+ * not overwrite a newer address.
+ */
+export function isReplyForPin(current: LatLngLike | null, reply: LatLngLike): boolean {
+  if (current === null) return false;
+  return current.lat === reply.lat && current.lng === reply.lng;
+}
 export const DISMISS_BELOW_MIN_PX = 40;
 export const MIN_BELOW_PEEK_PX = 80;
 
@@ -593,9 +609,13 @@ export function addReverseGeocoding(
     geocodeBar.style.willChange = 'transform';
     geocodeBar.style.transition = `transform ${SHEET_ANIM_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
     geocodeBar.style.transform = sheetTransform(offsetPx);
-    geocodeBar.addEventListener('transitionend', () => {
+    geocodeBar.addEventListener('transitionend', function clearWillChange(e: TransitionEvent) {
+      // Same bubbling hazard as finishHide below: .geocode-bar__handle-pill has
+      // its own transition, and its events would clear willChange mid-animation.
+      if (e.target !== geocodeBar) return;
+      geocodeBar.removeEventListener('transitionend', clearWillChange);
       geocodeBar.style.willChange = '';
-    }, { once: true });
+    });
   }
 
   /**
@@ -606,6 +626,9 @@ export function addReverseGeocoding(
    * Set on snap only — `bottom` is a layout property, so writing it on every
    * pointermove would reflow the cluster each frame.
    */
+  // Publish the snap duration once so style.css can't hold a second copy.
+  document.documentElement.style.setProperty('--sheet-anim', `${SHEET_ANIM_MS}ms`);
+
   function publishSheetHeight(target: SheetState): void {
     const occupied =
       target === 'hidden' ? 0 :
@@ -846,8 +869,7 @@ export function addReverseGeocoding(
    * location can't overwrite a newer one.
    */
   function updateGeocodeBarAddress(label: string, copyText: string, latlng: L.LatLng): void {
-    if (currentPinLatLng === null) return;
-    if (currentPinLatLng.lat !== latlng.lat || currentPinLatLng.lng !== latlng.lng) return;
+    if (!isReplyForPin(currentPinLatLng, latlng)) return;
     barAddrEl.textContent = label;
     barAddrEl.title = label;
     barCopyBtn.dataset['copy'] = copyText;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -605,17 +605,37 @@ export function addReverseGeocoding(
 
   // Animate to offsetPx with a CSS transition. willChange is enabled for the
   // duration of the animation only, then cleared to avoid pinning a GPU layer.
+  /**
+   * Run `done` once the sheet's own snap has settled — on transitionend, or on a
+   * timer if that never arrives. Both are needed: transitionend BUBBLES, so a
+   * child's transition (the handle pill's hover) would fire it early, and it does
+   * not fire at all when the transition never starts — setting transition and
+   * transform in one frame straight out of transition:none, which every drag
+   * settle does — nor when a re-open cancels it (transitioncancel replaces it).
+   */
+  function onSheetSettled(done: () => void): void {
+    let finished = false;
+    const handler = (e: TransitionEvent): void => {
+      if (e.target !== geocodeBar) return; // a child's transition, not the sheet's
+      finish();
+    };
+    function finish(): void {
+      if (finished) return;
+      finished = true;
+      geocodeBar.removeEventListener('transitionend', handler);
+      clearTimeout(timer);
+      done();
+    }
+    geocodeBar.addEventListener('transitionend', handler);
+    // Declared last but read inside finish() — only ever reached asynchronously.
+    const timer = setTimeout(finish, SHEET_ANIM_MS + 50);
+  }
+
   function animateTo(offsetPx: number): void {
     geocodeBar.style.willChange = 'transform';
     geocodeBar.style.transition = `transform ${SHEET_ANIM_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
     geocodeBar.style.transform = sheetTransform(offsetPx);
-    geocodeBar.addEventListener('transitionend', function clearWillChange(e: TransitionEvent) {
-      // Same bubbling hazard as finishHide below: .geocode-bar__handle-pill has
-      // its own transition, and its events would clear willChange mid-animation.
-      if (e.target !== geocodeBar) return;
-      geocodeBar.removeEventListener('transitionend', clearWillChange);
-      geocodeBar.style.willChange = '';
-    });
+    onSheetSettled(() => { geocodeBar.style.willChange = ''; });
   }
 
   /**
@@ -646,27 +666,11 @@ export function addReverseGeocoding(
       // fire at the end of the NEW transition, hiding the freshly-opened sheet.
       sheetState = 'hidden';
       animateTo(geocodeBar.offsetHeight + 20);
-      const finishHide = (e?: TransitionEvent): void => {
-        // transitionend bubbles: a child's transition (the Copy button's colour
-        // swap, a profile button) would otherwise tear the sheet down mid-flight.
-        // Returning early here rather than using { once: true } matters — once
-        // would let a child's event consume the listener before the sheet's own.
-        if (e && e.target !== geocodeBar) return;
-        // Unbind on the first real invocation, including the timer path, so
-        // repeated dismissals don't pile up listeners for the life of the page.
-        geocodeBar.removeEventListener('transitionend', finishHide);
-        if (sheetState !== 'hidden') return; // re-opened before the transition ended
+      onSheetSettled(() => {
+        if (sheetState !== 'hidden') return; // re-opened before the snap settled
         geocodeBar.style.display = 'none';
         geocodeBar.style.transform = '';
-      };
-      geocodeBar.addEventListener('transitionend', finishHide);
-      // transitionend is not guaranteed: it never fires if the transition doesn't
-      // start (setting transition and transform in one frame straight after
-      // transition:none, which is exactly what a drag-dismiss does) and it is
-      // replaced by transitioncancel if a re-open interrupts it. Without a
-      // fallback the sheet keeps display:flex with a stale inline transform,
-      // leaving the reopen path to fight state that should already be cleared.
-      setTimeout(finishHide, SHEET_ANIM_MS + 50);
+      });
       geocodeBar.classList.remove('geocode-bar--peek', 'geocode-bar--min');
       barHandle.setAttribute('aria-expanded', 'false');
     } else {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -7,7 +7,7 @@
 import L from 'leaflet';
 import { geosearch, arcgisOnlineProvider, geocodeService } from 'esri-leaflet-geocoder';
 import type { AppState } from './types';
-import { onGuidanceRender, renderGuidanceDashboard, setGuidanceCosting, startGuidance, stopGuidance } from './guidance';
+import { onGuidanceRender, setGuidanceCosting, startGuidance, stopGuidance } from './guidance';
 import type { Costing } from './routing';
 import { escapeHtml } from './html';
 
@@ -439,7 +439,6 @@ export function addReverseGeocoding(
     '  <div class="geocode-bar__handle-pill"></div>' +
     '</div>' +
     '<div class="geocode-bar__body">' +
-    '  <div class="geocode-bar__dashboard"></div>' +
     '  <div class="geocode-bar__profile" role="group" aria-label="Navigation type">' +
     '    <button type="button" class="geocode-bar__profile-btn geocode-bar__profile-btn--active" data-costing="auto" aria-pressed="true">Drive</button>' +
     '    <button type="button" class="geocode-bar__profile-btn" data-costing="bicycle" aria-pressed="false">Bike</button>' +
@@ -452,7 +451,6 @@ export function addReverseGeocoding(
     '</div>';
   document.body.appendChild(geocodeBar);
 
-  const dashboardEl = geocodeBar.querySelector<HTMLElement>('.geocode-bar__dashboard')!;
   const barAddrEl  = geocodeBar.querySelector<HTMLElement>('.geocode-bar__addr')!;
   const barCopyBtn = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__copy')!;
   const barNavBtn  = geocodeBar.querySelector<HTMLButtonElement>('.geocode-bar__nav')!;
@@ -490,8 +488,6 @@ export function addReverseGeocoding(
   }
 
   function renderNavigationTray(): void {
-    dashboardEl.innerHTML = renderGuidanceDashboard(state);
-    dashboardEl.classList.toggle('geocode-bar__dashboard--visible', dashboardEl.innerHTML !== '');
     barNavBtn.textContent = isNavigating() ? 'Stop' : 'Start';
     barNavBtn.setAttribute('aria-label', isNavigating() ? 'Stop navigation' : 'Start navigation');
     barNavBtn.classList.toggle('geocode-bar__nav--stop', isNavigating());

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -83,6 +83,16 @@ let storedDeactivatePolling: (() => void) | null = null;
 let arrivedTimer: ReturnType<typeof setTimeout> | null = null;
 const guidanceRenderListeners = new Set<() => void>();
 
+/**
+ * Mounts the turn-by-turn banner and captures the GPS polling callbacks.
+ *
+ * The banner is a fixed element on document.body rather than a Leaflet control:
+ * it spans the top of the viewport, which no single control corner does, and it
+ * has to sit above the corner containers rather than stack inside one.
+ * renderGuidanceDashboard() returns '' while idle, so the banner is only
+ * visible during navigation — that's when covering the search bar is the right
+ * trade, and it stays out of the way entirely the rest of the time.
+ */
 export function addGuidanceControl(
   map: L.Map,
   state: AppState,
@@ -90,9 +100,24 @@ export function addGuidanceControl(
   deactivatePolling: () => void,
 ): void {
   void map;
-  void state;
   storedActivatePolling = activatePolling;
   storedDeactivatePolling = deactivatePolling;
+
+  const banner = document.createElement('div');
+  banner.className = 'guidance-banner';
+  // Announce maneuver changes without stealing focus from the map.
+  banner.setAttribute('role', 'status');
+  banner.setAttribute('aria-live', 'polite');
+  document.body.appendChild(banner);
+
+  const renderBanner = (): void => {
+    const html = renderGuidanceDashboard(state);
+    banner.innerHTML = html;
+    banner.classList.toggle('guidance-banner--visible', html !== '');
+  };
+
+  renderBanner();
+  onGuidanceRender(renderBanner);
 }
 
 // ── Public state-machine API ───────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -476,11 +476,14 @@ const overlayDefs: OverlayDef[] = [
 layersControl = addLayersControl(map, layerDefs, overlayDefs, ['hillshade', 'cycle-blend', 'hiking-routes', 'cycling-routes']);
 
 addOfflineDownloadControl(map, showToast);
+// Registered here, not with the other controls below: Leaflet stacks a corner's
+// controls in registration order, so this puts draw-zone directly beneath the
+// download button in the top-right column.
+addDrawZoneControl(map, customZonesOverlay, showToast, () => layersControl?.setOverlayEnabled('custom-squeeze-zones', true));
 addSearchControl(map, state, showToast);
 addReverseGeocoding(map, state, showToast);
 addGuidanceControl(map, state, activatePolling, deactivatePolling);
 addCompassControl(map, state);
-addDrawZoneControl(map, customZonesOverlay, showToast, () => layersControl?.setOverlayEnabled('custom-squeeze-zones', true));
 
 // ── Version badge + changelog panel ───────────────────────────────────────────
 const versionBadge = document.createElement('button');

--- a/src/style.css
+++ b/src/style.css
@@ -428,16 +428,24 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* ── Reverse geocode bottom sheet ── */
+/* Right-anchored, not centred, and never full-width: the bottom-left control
+   cluster (zoom / locate / scale / version / attribution) sits under a centred
+   full-width sheet, and in peek every pixel of the visible band belongs to an
+   interactive child, so those controls are unreachable until the sheet is
+   minimized (#253). 67vw leaves a clear left column at phone widths; the 480px
+   cap keeps the sheet from ballooning on desktop.
+   The transform carries only translateY — see sheetTransform() in geocoding.ts. */
 .geocode-bar {
   position: fixed;
   bottom: 0;
-  left: 50%;
-  transform: translateX(-50%) translateY(0);
-  width: min(480px, 100vw);
+  right: env(safe-area-inset-right, 0px);
+  left: auto;
+  transform: translateY(0);
+  width: min(480px, 67vw);
   height: 60vh;
   min-height: calc(130px + var(--sai-bottom));
   background: #fff;
-  border-radius: 12px 12px 0 0;
+  border-radius: 12px 0 0 0;
   box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);
   z-index: 1500;
   font-family: system-ui, sans-serif;
@@ -850,6 +858,15 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      (zoom, version-badge) from stretching to match wider siblings like
      the attribution. */
   align-items: flex-start;
+  /* Stay clear of the right-anchored geocode-bar. The buttons are all narrow
+     enough to fit regardless, but the attribution runs ~330px with a base map
+     plus Hillshade and would otherwise sit permanently under the sheet — OSM's
+     tile usage policy wants that credit visible, so cap the column and let it
+     wrap instead. Mirrors the sheet's own width formula. */
+  max-width: calc(
+    100vw - min(480px, 67vw)
+    - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 20px
+  );
 }
 
 .leaflet-bottom.leaflet-left .leaflet-control-toggle {

--- a/src/style.css
+++ b/src/style.css
@@ -233,6 +233,40 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   to { transform: rotate(360deg); }
 }
 
+/* ── Turn-by-turn banner ───────────────────────────────────────────────────
+   Container for the dashboard above, mounted on document.body by
+   addGuidanceControl(). Top of the viewport, the convention for navigation
+   apps and where the eye already is when driving. Only rendered while
+   navigating (renderGuidanceDashboard returns '' when idle), so it covers the
+   search bar and top-right controls exactly when they matter least.
+   z-index clears the Leaflet control corners (1000) and the geocode sheet
+   (1500) but stays under toasts and modals (3000). */
+.guidance-banner {
+  display: none;
+  position: fixed;
+  top: calc(8px + env(safe-area-inset-top, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(520px, calc(100vw - 16px));
+  box-sizing: border-box;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(17, 24, 39, 0.95);
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+  z-index: 1600;
+  /* Read-only status: never intercept taps meant for the map beneath. */
+  pointer-events: none;
+}
+
+.guidance-banner--visible {
+  display: flex;
+}
+
 
 /* Destination marker — red pin with white border */
 .guidance-dest-marker {
@@ -411,7 +445,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 .geocode-bar--min .geocode-bar__handle,
 .geocode-bar--peek .geocode-bar__handle,
-.geocode-bar--peek .geocode-bar__dashboard,
 .geocode-bar--peek .geocode-bar__profile,
 .geocode-bar--peek .geocode-bar__profile-btn,
 .geocode-bar--peek .geocode-bar__nav,
@@ -458,23 +491,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   padding-bottom: max(8px, env(safe-area-inset-bottom, 8px));
   min-height: 44px;
   flex-shrink: 0;
-}
-
-.geocode-bar__dashboard {
-  display: none;
-  flex: 1 0 100%;
-  min-width: 0;
-  box-sizing: border-box;
-  padding: 8px 10px;
-  border-radius: 8px;
-  background: rgba(17, 24, 39, 0.95);
-  color: #fff;
-}
-
-.geocode-bar__dashboard--visible {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
 }
 
 .geocode-bar__profile {

--- a/src/style.css
+++ b/src/style.css
@@ -405,12 +405,13 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* ── Reverse geocode bottom sheet ── */
-/* Right-anchored, not centred, and never full-width: the bottom-left control
-   cluster (zoom / locate / scale / version / attribution) sits under a centred
-   full-width sheet, and in peek every pixel of the visible band belongs to an
-   interactive child, so those controls are unreachable until the sheet is
-   minimized (#253). 67vw leaves a clear left column at phone widths; the 480px
-   cap keeps the sheet from ballooning on desktop.
+/* Right-anchored rather than centred, and capped at 480px so it doesn't balloon
+   on a wide monitor. The sheet must never obscure the bottom-left cluster
+   (zoom, ruler, version, attribution) — in peek every pixel of its visible band
+   belongs to a pointer-events:auto child, so anything underneath is unreachable,
+   not merely hidden (#253). That separation is VERTICAL, not horizontal: the
+   attribution alone runs ~330px, most of a phone's width, so no side-by-side
+   split can clear it. The cluster rides above the sheet via --sheet-h below.
    The transform carries only translateY — see sheetTransform() in geocoding.ts. */
 .geocode-bar {
   position: fixed;
@@ -418,11 +419,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   right: env(safe-area-inset-right, 0px);
   left: auto;
   transform: translateY(0);
-  width: min(480px, 67vw);
-  height: 60vh;
+  width: min(480px, 100vw);
+  height: 30vh;
   min-height: calc(130px + var(--sai-bottom));
   background: #fff;
-  border-radius: 12px 0 0 0;
+  border-radius: 12px 12px 0 0;
   box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.18);
   z-index: 1500;
   font-family: system-ui, sans-serif;
@@ -713,9 +714,12 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   }
 
 
-  /* Bottom-left control group: scale — match bottom offset of right group */
+  /* Bottom-left control group — rides above the navigation sheet via --sheet-h
+     (set in geocoding.ts snapTo). The sheet must never cover zoom, the ruler,
+     or the attribution; see the .geocode-bar comment for why the separation is
+     vertical rather than side-by-side. */
   .leaflet-bottom.leaflet-left {
-    bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(10px + env(safe-area-inset-bottom, 0px) + var(--sheet-h, 0px));
     left: calc(10px + env(safe-area-inset-left, 0px));
   }
 
@@ -767,9 +771,11 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 @media (min-width: 769px) {
 
-  /* Bottom-left control group: scale — match bottom offset of right group */
+  /* Bottom-left control group — same lift as mobile. Still needed here: at
+     ~800px wide the 480px right-anchored sheet reaches left far enough to
+     overlap a full-width attribution. */
   .leaflet-bottom.leaflet-left {
-    bottom: 10px;
+    bottom: calc(10px + var(--sheet-h, 0px));
     left: 10px;
   }
 
@@ -817,15 +823,9 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      (zoom, version-badge) from stretching to match wider siblings like
      the attribution. */
   align-items: flex-start;
-  /* Stay clear of the right-anchored geocode-bar. The buttons are all narrow
-     enough to fit regardless, but the attribution runs ~330px with a base map
-     plus Hillshade and would otherwise sit permanently under the sheet — OSM's
-     tile usage policy wants that credit visible, so cap the column and let it
-     wrap instead. Mirrors the sheet's own width formula. */
-  max-width: calc(
-    100vw - min(480px, 67vw)
-    - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 20px
-  );
+  /* Match animateTo()'s curve in geocoding.ts so the cluster rides with the
+     sheet instead of snapping after it lands. */
+  transition: bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .leaflet-bottom.leaflet-left .leaflet-control-toggle {

--- a/src/style.css
+++ b/src/style.css
@@ -160,42 +160,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #fff;
 }
 
-/* ── Routed-guidance pill ──────────────────────────────────────────────────
-   Bottom-left pill driven by guidance.ts state machine. Hidden when idle;
-   compact during routing; expanded with maneuver / off-route / arrived
-   variants while a destination is set. */
-
-.guidance-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  border-radius: 16px;
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  white-space: nowrap;
-  min-width: 0;
-  max-width: 360px;
-  padding: 10px 14px;
-  background: rgba(0, 0, 0, 0.88);
-  color: #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  transition: padding 0.2s ease, background-color 0.2s ease;
-}
-
-.guidance-panel--idle {
-  display: none;
-}
-
-.guidance-panel--arrived {
-  background: rgba(34, 197, 94, 0.92);
-  text-align: center;
-  font-weight: 600;
-}
-
-.guidance-panel--off-route {
-  background: rgba(245, 158, 11, 0.92);
-  color: #1f2937;
-}
+/* ── Guidance dashboard content ────────────────────────────────────────────
+   The markup renderGuidanceDashboard() emits: maneuver row, summary row, and
+   the routing / arrived status variants. Styles the content only — its
+   container is styled where the container lives. */
 
 .guidance-row {
   display: flex;
@@ -265,31 +233,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   to { transform: rotate(360deg); }
 }
 
-.guidance-btn {
-  align-self: flex-start;
-  padding: 6px 14px;
-  border: none;
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.15);
-  color: inherit;
-}
-
-.guidance-btn:hover {
-  background: rgba(255, 255, 255, 0.25);
-}
-
-.guidance-btn--stop {
-  background: #ef4444;
-  color: #fff;
-}
-
-.guidance-btn--cancel {
-  background: rgba(239, 68, 68, 0.7);
-  color: #fff;
-}
 
 /* Destination marker — red pin with white border */
 .guidance-dest-marker {
@@ -880,7 +823,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
    locate → recording → zoom → scale → version-badge → attribution.
    Registration order doesn't match this so we use explicit `order`. */
 .leaflet-bottom.leaflet-left .leaflet-control-toggle { order: 1; }
-.leaflet-bottom.leaflet-left .guidance-panel         { order: 2; }
 .leaflet-bottom.leaflet-left .leaflet-control-zoom   { order: 3; }
 .leaflet-bottom.leaflet-left .leaflet-control-scale  { order: 4; }
 .leaflet-bottom.leaflet-left #version-badge          { order: 5; }

--- a/src/style.css
+++ b/src/style.css
@@ -823,9 +823,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      (zoom, version-badge) from stretching to match wider siblings like
      the attribution. */
   align-items: flex-start;
-  /* Match animateTo()'s curve in geocoding.ts so the cluster rides with the
-     sheet instead of snapping after it lands. */
-  transition: bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Rides with the sheet rather than snapping after it lands. Duration comes
+     from SHEET_ANIM_MS via --sheet-anim (set in geocoding.ts), so the two can't
+     drift; the fallback only applies before the first snap publishes it. */
+  transition: bottom var(--sheet-anim, 300ms) cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .leaflet-bottom.leaflet-left .leaflet-control-toggle {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 import { readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
@@ -9,6 +10,14 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
   plugins: [
+    // HTTPS for `npm run dev` only. A phone on the LAN reaches the dev server by
+    // IP, and a plain-http origin is not a secure context — which silently
+    // disables geolocation (Safari reports PERMISSION_DENIED without ever asking
+    // iOS), crypto.randomUUID (used by the consent gate), and service workers.
+    // The cert is self-signed, so iOS shows a one-time warning to accept.
+    // apply:'serve' is explicit: the plugin only sets server.https, which `build`
+    // ignores, but the production output must never depend on this being here.
+    { ...basicSsl(), apply: 'serve' },
     VitePWA({
       // injectManifest: we ship a hand-written service worker (src/sw.ts) so the
       // navigation handler can guarantee a non-blank document and capture its own


### PR DESCRIPTION
## Summary

A UI pass over the map chrome, driven by testing on a phone. **Supersedes #254** — that PR's commit is the first of the six here, so this branch contains it in full.

Fixes #253

## The core problem

The navigation sheet was centred and full-width, sitting on top of the bottom-left control cluster. It wasn't merely hiding it: `.geocode-bar--peek` sets `pointer-events: none`, but the children that re-enable it fill the *entire* visible peek band. Zoom, ruler, version and attribution were genuinely unreachable until the sheet was minimized. Locate sits highest in the cluster and survived, which is why it read as "zoom is broken."

The separation had to be **vertical**. Side-by-side cannot work: the attribution alone runs ~330 px, most of a phone's width, so no horizontal split clears it. `snapTo` now publishes `--sheet-h` and the cluster adds it to its bottom offset — in both breakpoints, since at ~800 px wide the right-anchored sheet still reaches far enough left to overlap.

With the cluster lifted, the sheet no longer has to dodge anything, so it keeps full width on mobile and the cluster's `max-width` cap is gone.

## Commits

1. **Right-anchor the sheet** — capped at 480 px so it doesn't balloon on desktop. Four call sites wrote `translateX(-50%)` inline; all now go through `sheetTransform()`, since one missed edit sends the sheet off-screen only once the user drags.
2. **Draw-zone control** → top-right, directly beneath download (Leaflet stacks by registration order). Label dropped; the pencil gains `U+FE0E` so iOS renders it monochrome instead of a colour emoji.
3. **Dead CSS removed** — `.guidance-panel` and `.guidance-btn` are applied by nothing (zero hits across `src/` and `index.html`), left over from `8b730f1`. Separate commit, no behaviour change.
4. **Turn-by-turn moved to a top banner** — `addGuidanceControl()` was a no-op stub and now owns it. A fixed element rather than a Leaflet control: it spans the top, which no corner does, and must paint above the corner containers. `pointer-events: none` so it can't repeat the #253 mistake.
5. **HTTPS for `npm run dev`** — a phone hits the dev server by IP, and plain http is not a secure context: geolocation reports PERMISSION_DENIED without ever consulting iOS, and `crypto.randomUUID` (consent) is undefined. Pinned to `@vitejs/plugin-basic-ssl@^1.2.0` (2.x needs Vite 6+) and `apply: 'serve'` so the build can't depend on it.
6. **Cluster lift + pin-drop fixes** — see below.

## Pin drop now opens the sheet unconditionally

Every `showGeocodeBar` call sat *inside* the geocoder callback, so a request that never returned left no sheet at all. The ESRI key is referrer-restricted and fails silently on an origin that isn't allowlisted, which is exactly what a new dev origin looks like. Dropping a pin is the user's action and shouldn't depend on a third party answering.

Coordinates now show immediately; the geocoder only *upgrades* the label — without snapping (so it can't yank a minimized sheet back to peek) and only when the pin hasn't moved on (so a late reply can't overwrite a newer one).

## Sheet teardown no longer depends on `transitionend`

`display: none` was restored only from that handler, which is unreliable twice over: the event **bubbles**, so a child's transition could tear the sheet down mid-flight; and it doesn't fire at all when the transition fails to start — setting `transition` and `transform` in one frame straight out of `transition: none`, which is exactly what a drag-dismiss does — nor when a re-open cancels it. A target check plus a timer fallback make the hidden state deterministic. The duration moves to `SHEET_ANIM_MS` so the timeout, the transition, and the cluster's `transition: bottom` can't drift.

Also: sheet height halved to `30vh`, long-press hold cut to 250 ms (`LONG_PRESS_MS`).

## Test plan

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (216) ✅ · production build verified unaffected by the SSL plugin.

New tests cover `sheetTransform()` emitting no horizontal component — the guard against the four-site drift.

## Assumptions and gaps

- **Geometry is not unit-testable here.** jsdom has no layout engine, so overlap can't be asserted; `getBoundingClientRect()` returns zeros. Verification is manual.
- **Desktop confirmed** by the maintainer. **Mobile confirmation of the final state is still outstanding** — specifically that dropping a pin always opens the sheet, and that zoom / ruler / attribution stay clear through a peek↔min↔dismiss cycle.
- `min-height` is still `130px + safe-area`, which now exceeds `30vh` on viewports under ~430 px tall; there the sheet is exactly peek height with no drag-up travel. Flagged, not fixed.
