### PR TITLE
fix(a11y): stop the guidance banner re-announcing on every GPS fix

### DIFF
--- a/src/guidance.test.ts
+++ b/src/guidance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import L from 'leaflet';
-import { setGuidanceCosting, updateGuidance, stopGuidance } from './guidance';
+import { guidanceAnnouncement, setGuidanceCosting, updateGuidance, stopGuidance } from './guidance';
 import { createInitialState } from './types';
 import type { AppState } from './types';
 import type { Route, RouteStep } from './routing';
@@ -299,5 +299,60 @@ describe('stopGuidance', () => {
     stopGuidance(state, map);
     expect(ac.signal.aborted).toBe(true);
     expect(state.guidance.recalcInFlight).toBeNull();
+  });
+});
+
+describe('guidanceAnnouncement', () => {
+  const dest = { lat: 1, lng: 1, label: 'Pike Place Market' };
+
+  it('says nothing when idle', () => {
+    expect(guidanceAnnouncement(createInitialState())).toBe('');
+  });
+
+  it('is unchanged when only distance and ETA move', () => {
+    // The whole point of #258: these fields change on every accepted GPS fix,
+    // and the banner shows them. If they leaked into the announcement, a screen
+    // reader would re-read the instruction about once a second.
+    const state = createInitialState();
+    setGuiding(state, makeRoute([[0, 0], [1, 1]]), dest);
+
+    state.guidance.distanceToManeuverM = 400;
+    state.guidance.distanceToDestinationM = 1200;
+    const first = guidanceAnnouncement(state);
+
+    state.guidance.distanceToManeuverM = 120;
+    state.guidance.distanceToDestinationM = 900;
+    expect(guidanceAnnouncement(state)).toBe(first);
+  });
+
+  it('changes when the maneuver advances', () => {
+    const state = createInitialState();
+    setGuiding(state, makeRoute([[0, 0], [1, 1]], [
+      { instruction: 'Turn left onto Pine', type: 15, lengthM: 100, durationS: 60, streetNames: [], beginShapeIndex: 0 },
+      { instruction: 'Turn right onto 1st', type: 10, lengthM: 100, durationS: 60, streetNames: [], beginShapeIndex: 1 },
+    ]), dest);
+
+    expect(guidanceAnnouncement(state)).toBe('Turn left onto Pine');
+    state.guidance.currentStepIdx = 1;
+    expect(guidanceAnnouncement(state)).toBe('Turn right onto 1st');
+  });
+
+  it('announces each status transition distinctly', () => {
+    const state = createInitialState();
+    setGuiding(state, makeRoute([[0, 0], [1, 1]]), dest);
+
+    state.guidance.status = 'routing';
+    expect(guidanceAnnouncement(state)).toBe('Routing to Pike Place Market');
+    state.guidance.status = 'off-route';
+    expect(guidanceAnnouncement(state)).toBe('Off route, recalculating');
+    state.guidance.status = 'arrived';
+    expect(guidanceAnnouncement(state)).toBe('Arrived at Pike Place Market');
+  });
+
+  it('survives a step index past the end of the route', () => {
+    const state = createInitialState();
+    setGuiding(state, makeRoute([[0, 0], [1, 1]]), dest);
+    state.guidance.currentStepIdx = 99;
+    expect(guidanceAnnouncement(state)).toBe('Go');
   });
 });

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -84,6 +84,30 @@ let arrivedTimer: ReturnType<typeof setTimeout> | null = null;
 const guidanceRenderListeners = new Set<() => void>();
 
 /**
+ * Text a screen reader should hear, which is deliberately NOT what the banner
+ * shows. The visible dashboard carries distance and ETA, and those change on
+ * every accepted GPS fix — putting them in a live region re-announces the whole
+ * instruction roughly once a second, which is unusable. This returns only what
+ * genuinely changes: the current maneuver, and status transitions.
+ */
+export function guidanceAnnouncement(state: AppState): string {
+  const g = state.guidance;
+  if (g.status === 'idle') return '';
+  if (g.status === 'routing') {
+    return `Routing to ${g.destination?.label ?? 'destination'}`;
+  }
+  if (g.status === 'arrived') {
+    return g.destination ? `Arrived at ${g.destination.label}` : 'Arrived';
+  }
+  if (g.status === 'off-route') return 'Off route, recalculating';
+
+  const route = g.route;
+  if (!route) return '';
+  const step = route.steps[Math.min(g.currentStepIdx, route.steps.length - 1)];
+  return step?.instruction ?? '';
+}
+
+/**
  * Mounts the turn-by-turn banner and captures the GPS polling callbacks.
  *
  * The banner is a fixed element on document.body rather than a Leaflet control:
@@ -92,6 +116,10 @@ const guidanceRenderListeners = new Set<() => void>();
  * renderGuidanceDashboard() returns '' while idle, so the banner is only
  * visible during navigation — that's when covering the search bar is the right
  * trade, and it stays out of the way entirely the rest of the time.
+ *
+ * Sighted and assistive output are split on purpose: the banner is aria-hidden
+ * and repaints on every fix, while a separate live region receives only
+ * guidanceAnnouncement() and only when that text actually changes (#258).
  */
 export function addGuidanceControl(
   map: L.Map,
@@ -105,15 +133,32 @@ export function addGuidanceControl(
 
   const banner = document.createElement('div');
   banner.className = 'guidance-banner';
-  // Announce maneuver changes without stealing focus from the map.
-  banner.setAttribute('role', 'status');
-  banner.setAttribute('aria-live', 'polite');
+  // Hidden from assistive tech: it repaints on every GPS fix, and the live
+  // region below is what announces. Without this the banner's own text would
+  // be read again on each repaint.
+  banner.setAttribute('aria-hidden', 'true');
   document.body.appendChild(banner);
 
+  const live = document.createElement('div');
+  live.className = 'sr-only';
+  live.setAttribute('role', 'status');
+  live.setAttribute('aria-live', 'polite');
+  document.body.appendChild(live);
+
+  let lastAnnounced = '';
   const renderBanner = (): void => {
     const html = renderGuidanceDashboard(state);
     banner.innerHTML = html;
     banner.classList.toggle('guidance-banner--visible', html !== '');
+
+    // Writing identical text to a live region still re-announces it, so compare
+    // before touching the DOM. The announcement excludes distance/ETA, so this
+    // stays quiet through the fixes that only move those.
+    const announcement = guidanceAnnouncement(state);
+    if (announcement !== lastAnnounced) {
+      lastAnnounced = announcement;
+      live.textContent = announcement;
+    }
   };
 
   renderBanner();

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -89,6 +89,11 @@ const guidanceRenderListeners = new Set<() => void>();
  * every accepted GPS fix — putting them in a live region re-announces the whole
  * instruction roughly once a second, which is unusable. This returns only what
  * genuinely changes: the current maneuver, and status transitions.
+ *
+ * The wording intentionally differs from renderGuidanceDashboard()'s, which is
+ * abbreviated to fit the banner ("Off route — recalculating…" vs "Off route,
+ * recalculating"). Spoken copy wants punctuation a reader handles well and no
+ * ellipses. Keep the two in step when adding a status.
  */
 export function guidanceAnnouncement(state: AppState): string {
   const g = state.guidance;
@@ -143,6 +148,9 @@ export function addGuidanceControl(
   live.className = 'sr-only';
   live.setAttribute('role', 'status');
   live.setAttribute('aria-live', 'polite');
+  // Announce the region as a whole. textContent replacement is already atomic in
+  // practice, but this removes any doubt about partial reads across readers.
+  live.setAttribute('aria-atomic', 'true');
   document.body.appendChild(live);
 
   let lastAnnounced = '';

--- a/src/style.css
+++ b/src/style.css
@@ -267,6 +267,23 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   display: flex;
 }
 
+/* Available to assistive tech, invisible on screen. Used for the guidance live
+   region, which carries only the maneuver — the banner shows distance and ETA
+   but is aria-hidden, so those don't re-announce on every fix (#258).
+   Not display:none or visibility:hidden: both remove the node from the
+   accessibility tree, which would silence the announcement entirely. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 
 /* Destination marker — red pin with white border */
 .guidance-dest-marker {


### PR DESCRIPTION
## Summary

The guidance banner carried `role="status" aria-live="polite"` and repaints on every accepted GPS fix, so a screen reader re-read the full maneuver + distance + ETA roughly once a second while navigating. Distance alone changes the text, so the live region fired continuously.

This was a regression in kind introduced by #257: before that, the dashboard lived in the sheet with no live region and never announced at all. Adding one made it announce correctly *and* far too often.

Fixes #258

## Approach

Split what is **shown** from what is **announced** — the two have genuinely different update rates, so one element can't serve both.

- The banner keeps repainting every fix (correct — the distance should tick down on screen) and is now `aria-hidden`.
- A separate visually-hidden live region receives `guidanceAnnouncement()`, which returns only the current maneuver instruction and status transitions (routing / off-route / arrived). Never distance or ETA.
- The text is compared before writing, because re-writing identical content to a live region announces it again.

`.sr-only` uses the clip-rect pattern rather than `display: none` or `visibility: hidden` — both remove the node from the accessibility tree, which would silence the announcement entirely and quietly turn this fix into a regression.

## Test plan

5 tests on `guidanceAnnouncement()`, which is pure over `AppState` (228 total). The central one asserts the announcement is **unchanged when only distance and ETA move** — the exact defect.

Verified they're real guards, not tautologies: temporarily leaking `distanceToManeuverM` into the announcement, reproducing #258's defect, fails three of them including that one.

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (228) ✅ · `npm run size` 121.06 kB / 122 kB

## Assumptions and gaps

- **Not verified with a real screen reader.** The tests cover *what* text is produced and *when* it changes, which is where the bug was, but whether VoiceOver announces it the way we intend is not something jsdom can tell us. Worth a VoiceOver pass on iOS before trusting it fully.
- Announcement wording (`"Off route, recalculating"`, `"Arrived at X"`) is written for speech rather than reused from the visual strings, which are abbreviated for space. Deliberate, but it does mean two sets of copy to keep in step.
- **Bundle headroom is thin**: 121.06 kB against the 122 kB cap, and CI historically reads ~0.3 kB above local, so expect ~121.4 kB there. Under the cap but below the ≥1 kB headroom convention — the cap likely needs another look regardless of this PR.
