### PR TITLE
feat(map): single bottom-left control column, search failure reporting, results toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "size-limit": [
     {
       "path": "dist/assets/index-*.js",
-      "limit": "122 kB",
+      "limit": "124 kB",
       "gzip": true
     }
   ]

--- a/src/compass.ts
+++ b/src/compass.ts
@@ -60,5 +60,5 @@ export function addCompassControl(map: L.Map, state: AppState): void {
     },
   });
 
-  new Control({ position: 'topright' }).addTo(map);
+  new Control({ position: 'bottomleft' }).addTo(map);
 }

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -55,7 +55,9 @@ export function setupCollapsibleLabel(
 export function makeToggleControl(config: ToggleControlConfig): L.Control {
   const Ctrl = L.Control.extend({
     onAdd(): HTMLElement {
-      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      // ctrl-<id> gives the bottom-left cluster a stable hook to order this
+      // control by; every toggle otherwise shares the same class.
+      const container = L.DomUtil.create('div', `leaflet-control-toggle ctrl-${config.id}`) as HTMLDivElement;
       container.title = config.disabledTitle;
 
       const img = L.DomUtil.create('img') as HTMLImageElement;

--- a/src/custom-zones.ts
+++ b/src/custom-zones.ts
@@ -415,7 +415,7 @@ export function addDrawZoneControl(
   // avoids typing L.Control.extend()'s return value in strict TypeScript.
   const DrawZoneControl = L.Control.extend({
     onAdd(): HTMLElement {
-      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      const container = L.DomUtil.create('div', 'leaflet-control-toggle ctrl-draw-zone') as HTMLDivElement;
       container.title = 'Draw a custom squeeze zone';
 
       // Icon only — the title attribute carries the description. U+FE0E is the
@@ -439,5 +439,5 @@ export function addDrawZoneControl(
   // bar's column, where a second button crowded the input on narrow screens.
   // Leaflet stacks a corner's controls in registration order, so this lands
   // below both (see the addDrawZoneControl call in main.ts).
-  new (DrawZoneControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topright' }).addTo(map);
+  new (DrawZoneControl as new (opts: L.ControlOptions) => L.Control)({ position: 'bottomleft' }).addTo(map);
 }

--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -254,9 +254,9 @@ describe('sheetTransform', () => {
   });
 
   it('never emits a horizontal component', () => {
-    // The sheet is right-anchored in CSS (#253). A translateX here would fight
-    // that anchor and push it off-screen — and because four call sites write
-    // this transform, a stale one is invisible until the user drags.
+    // The sheet is centred by CSS (left/right + margin auto), so a translateX
+    // here would fight that centring and push it off-screen. Four call sites
+    // write this transform, so a stale one is invisible until the user drags.
     for (const offset of [0, 137, -20, 999]) {
       expect(sheetTransform(offset)).not.toContain('translateX');
     }

--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -10,6 +10,7 @@ import {
   sheetSettleTarget,
   sheetTransform,
   isReplyForPin,
+  describeSearchFailure,
 } from './geocoding';
 
 // ── Minimal stubs ─────────────────────────────────────────────────────────────
@@ -278,3 +279,62 @@ describe('isReplyForPin', () => {
     expect(isReplyForPin(null, { lat: 47.6, lng: -122.3 })).toBe(false);
   });
 });
+
+describe('describeSearchFailure', () => {
+  const online = { hasApiKey: true, online: true };
+
+  it('blames the connection first, before anything else', () => {
+    // Offline outranks every other cause: nothing else is actionable until the
+    // connection is back, whatever status the last attempt happened to return.
+    const msg = describeSearchFailure({ code: 500 }, { hasApiKey: false, online: false });
+    expect(msg).toMatch(/offline/i);
+  });
+
+  it('names a missing API key as a build configuration problem', () => {
+    const msg = describeSearchFailure(null, { hasApiKey: false, online: true });
+    expect(msg).toMatch(/no ArcGIS API key/i);
+  });
+
+  it('explains an unauthorised origin rather than blaming the query', () => {
+    // The local-dev case: a referrer-restricted key on an origin that isn't
+    // allowlisted. Must read as configuration, not as a bad search.
+    for (const code of [403, 498, 499]) {
+      const msg = describeSearchFailure({ code }, online);
+      expect(msg).toMatch(/doesn’t allow this site/i);
+      expect(msg).not.toMatch(/reword|zoom/i);
+    }
+  });
+
+  it('distinguishes rate limiting from an outage', () => {
+    expect(describeSearchFailure({ code: 429 }, online)).toMatch(/rate-limited/i);
+    expect(describeSearchFailure({ code: 503 }, online)).toMatch(/temporarily down/i);
+    expect(describeSearchFailure({ code: 503 }, online)).toContain('503');
+  });
+
+  it('covers a rejected request that carries no status code', () => {
+    // DNS failure, CORS rejection, blocked request: fetch rejects with no code.
+    expect(describeSearchFailure({ message: 'Failed to fetch' }, online))
+      .toMatch(/blocked or timed out/i);
+    expect(describeSearchFailure(null, online)).toMatch(/blocked or timed out/i);
+  });
+
+  it('falls back to reporting an unexpected status verbatim', () => {
+    expect(describeSearchFailure({ code: 418 }, online)).toContain('418');
+  });
+
+  it('never tells the user to reword their search', () => {
+    // That advice belongs only to a genuine zero-match result; suggesting it
+    // during an outage is what #260 was filed for.
+    const cases: Array<[SearchFailureArgs[0], SearchFailureArgs[1]]> = [
+      [{ code: 403 }, online],
+      [{ code: 500 }, online],
+      [null, { hasApiKey: false, online: true }],
+      [null, { hasApiKey: true, online: false }],
+    ];
+    for (const [err, opts] of cases) {
+      expect(describeSearchFailure(err, opts)).not.toMatch(/reword|zooming out/i);
+    }
+  });
+});
+
+type SearchFailureArgs = Parameters<typeof describeSearchFailure>;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -186,7 +186,7 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
   const searchControl = geosearch({
     placeholder: SEARCH_PLACEHOLDER,
     title: 'Search for places or addresses',
-    position: 'topleft',
+    position: 'bottomleft',
     expanded: true,
     useMapBounds: 7,
     zoomToResult: false,
@@ -247,13 +247,24 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
 
   function showDropdown(): void {
     const rect = wrapper.getBoundingClientRect();
-    dropdownEl.style.top = `${rect.bottom + 2}px`;
+    const margin = 4;
+    // Display first: offsetHeight/offsetWidth are 0 while hidden, and both the
+    // flip decision and the left clamp depend on measuring real content.
     dropdownEl.style.display = 'block';
+
+    // The search bar lives in the bottom-left cluster, so there is normally no
+    // room beneath it — open upward unless below genuinely fits.
+    const roomBelow = window.innerHeight - rect.bottom - margin;
+    const height = dropdownEl.offsetHeight;
+    const top = height <= roomBelow
+      ? rect.bottom + 2
+      : Math.max(margin, rect.top - height - 2);
+    dropdownEl.style.top = `${top}px`;
+
     // Clamp left so the dropdown never overflows the right viewport edge on
     // narrow phones — otherwise its content (e.g. the "POI" badge) gets clipped.
-    // Width is read after display so the measured value reflects the CSS bounds.
-    const maxLeft = window.innerWidth - dropdownEl.offsetWidth - 4;
-    dropdownEl.style.left = `${Math.max(4, Math.min(rect.left, maxLeft))}px`;
+    const maxLeft = window.innerWidth - dropdownEl.offsetWidth - margin;
+    dropdownEl.style.left = `${Math.max(margin, Math.min(rect.left, maxLeft))}px`;
     syncResultsToggle();
   }
 
@@ -267,7 +278,7 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
   // below the search bar it belongs to.
   const ResultsToggleControl = L.Control.extend({
     onAdd(): HTMLElement {
-      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      const container = L.DomUtil.create('div', 'leaflet-control-toggle ctrl-results') as HTMLDivElement;
       container.setAttribute('role', 'button');
       container.setAttribute('tabindex', '0');
       const icon = L.DomUtil.create('span', 'leaflet-control-toggle__icon') as HTMLSpanElement;
@@ -289,7 +300,7 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
       return container;
     },
   });
-  new (ResultsToggleControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topleft' }).addTo(map);
+  new (ResultsToggleControl as new (opts: L.ControlOptions) => L.Control)({ position: 'bottomleft' }).addTo(map);
 
   // Dropdown is dismissed only via the close button inside it.
   dropdownEl.addEventListener('click', (e: MouseEvent) => {
@@ -570,12 +581,12 @@ export const DISMISS_BELOW_MIN_PX = 40;
 export const MIN_BELOW_PEEK_PX = 80;
 
 /**
- * Transform for the geocode-bar at a given vertical offset. The sheet is
- * right-anchored (see .geocode-bar in style.css), so the transform carries ONLY
- * the vertical offset — a horizontal component here would fight the CSS anchor
- * and push the sheet off-screen. Centralized because four call sites write this
- * (snap, open, touch-drag, mouse-drag) and one missed edit is invisible until
- * the user drags.
+ * Transform for the geocode-bar at a given vertical offset. Carries ONLY the
+ * vertical offset: the sheet is centred by CSS (left/right + margin auto, see
+ * .geocode-bar in style.css) precisely so no horizontal component is needed
+ * here. Adding one would fight that centring and push the sheet off-screen.
+ * Centralized because four call sites write this (snap, open, touch-drag,
+ * mouse-drag) and one missed edit is invisible until the user drags.
  */
 export function sheetTransform(offsetPx: number): string {
   return `translateY(${offsetPx}px)`;

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -335,15 +335,26 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
   const results = L.featureGroup().addTo(map);
   const markerRefs: L.Marker[] = [];
 
+  /**
+   * Drop the result list and its markers together. They have to stay in
+   * lockstep: the toggle's visibility is derived from the list, so a list that
+   * outlives its markers can be revealed to offer rows that fly the map to
+   * coordinates nothing is pinned at any more.
+   */
+  function clearResults(): void {
+    results.clearLayers();
+    markerRefs.length = 0;
+    dropdownEl.innerHTML = '';
+    hideDropdown(); // also re-syncs the toggle, which is now empty
+  }
+
   // When the search icon is clicked to expand the control, dismiss the old
   // dropdown and clear previous result pins so the user starts fresh.
   let _wasExpanded = false;
   new MutationObserver(() => {
     const isExpanded = wrapper.classList.contains('geocoder-control-expanded');
     if (isExpanded && !_wasExpanded) {
-      hideDropdown();
-      results.clearLayers();
-      markerRefs.length = 0;
+      clearResults();
     }
     _wasExpanded = isExpanded;
   }).observe(wrapper, { attributes: true, attributeFilter: ['class'] });
@@ -425,8 +436,9 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
     pendingSearch = false;
     L.DomUtil.removeClass(wrapper, 'geocoder-control-loading');
     collapseSearch();
-    results.clearLayers();
-    markerRefs.length = 0;
+    // Clears the previous list too, so a zero-result search can't leave the
+    // toggle offering the last search's rows with no markers behind them.
+    clearResults();
     if (data.results.length) {
       // Add numbered markers in reverse order so marker #1 renders on top.
       for (let i = data.results.length - 1; i >= 0; i--) {

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -120,23 +120,31 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
   // Most recent provider failure, or null after any success. The results handler
   // reads this to tell an outage apart from a genuine zero-match search — the
   // two need opposite advice, and previously both rendered as "no results".
-  let lastProviderError: SearchProviderError | null = null;
+  // Written only by results(), never by suggest(). The two are unserialised, so
+  // a shared field would let a slow autocomplete reply land after a submitted
+  // search and flip what the results handler reads — reporting an outage for a
+  // search that succeeded, or blaming the query for a submit that failed.
+  let lastResultsError: SearchProviderError | null = null;
+
   // suggest() runs per keystroke, so an outage would otherwise toast on every
   // letter typed. One notice per window is enough to explain what's happening.
+  // This throttle covers autocomplete ONLY — a submitted search is reported by
+  // the results handler, which knows whether anything actually matched.
   const FAILURE_NOTICE_INTERVAL_MS = 15000;
   let lastNoticeAt = 0;
 
-  function noticeSearchFailure(): void {
+  function failureMessage(error: SearchProviderError | null): string {
+    return describeSearchFailure(error, {
+      hasApiKey: Boolean(apikey),
+      online: navigator.onLine,
+    });
+  }
+
+  function noticeSuggestFailure(error: SearchProviderError | null): void {
     const now = Date.now();
     if (now - lastNoticeAt < FAILURE_NOTICE_INTERVAL_MS) return;
     lastNoticeAt = now;
-    showMessage(
-      describeSearchFailure(lastProviderError, {
-        hasApiKey: Boolean(apikey),
-        online: navigator.onLine,
-      }),
-      6000,
-    );
+    showMessage(failureMessage(error), 6000);
   }
 
   // Wrap a provider so that errors in results() and suggest() are logged and
@@ -161,12 +169,16 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
           // Keep converting errors to empty results so the widget stays happy,
           // but remember the failure — discarding it here is what made outages
           // indistinguishable from a search that simply matched nothing.
-          lastProviderError = error ? (error as SearchProviderError) : null;
+          const failure = error ? (error as SearchProviderError) : null;
+          if (method === 'results') lastResultsError = failure;
           if (error) {
             // Logged unconditionally: a keyless build is exactly when every
             // request fails, and the old gate stayed silent in that case.
             console.warn('Search provider error:', error);
-            noticeSearchFailure();
+            // Only autocomplete notifies here. Notifying for 'results' too would
+            // double-toast every failed submit, since the results handler
+            // reports that case itself.
+            if (method === 'suggest') noticeSuggestFailure(failure);
           }
           cb(null, error ? [] : results);
         });
@@ -274,8 +286,8 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
     else showDropdown();
   }
 
-  // topleft, registered after the search control, so Leaflet stacks it directly
-  // below the search bar it belongs to.
+  // Position is bottomleft like everything else; its place in the column comes
+  // from the explicit CSS `order`, not from registration order.
   const ResultsToggleControl = L.Control.extend({
     onAdd(): HTMLElement {
       const container = L.DomUtil.create('div', 'leaflet-control-toggle ctrl-results') as HTMLDivElement;
@@ -536,14 +548,8 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
     } else {
       // Only blame the query when the service actually answered. Telling someone
       // to reword their search during an outage is worse than saying nothing.
-      if (lastProviderError !== null) {
-        showMessage(
-          describeSearchFailure(lastProviderError, {
-            hasApiKey: Boolean(apikey),
-            online: navigator.onLine,
-          }),
-          6000,
-        );
+      if (lastResultsError !== null) {
+        showMessage(failureMessage(lastResultsError), 6000);
       } else {
         showMessage('No results found. Try zooming out or rewording your search.');
       }

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -144,6 +144,9 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
     const now = Date.now();
     if (now - lastNoticeAt < FAILURE_NOTICE_INTERVAL_MS) return;
     lastNoticeAt = now;
+    // Console and toast share the window. suggest() fires per keystroke, so an
+    // outage would otherwise flood the console even while the toast stayed quiet.
+    console.warn('Search provider error (autocomplete):', error);
     showMessage(failureMessage(error), 6000);
   }
 
@@ -172,13 +175,16 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
           const failure = error ? (error as SearchProviderError) : null;
           if (method === 'results') lastResultsError = failure;
           if (error) {
-            // Logged unconditionally: a keyless build is exactly when every
-            // request fails, and the old gate stayed silent in that case.
-            console.warn('Search provider error:', error);
-            // Only autocomplete notifies here. Notifying for 'results' too would
-            // double-toast every failed submit, since the results handler
-            // reports that case itself.
-            if (method === 'suggest') noticeSuggestFailure(failure);
+            if (method === 'suggest') {
+              // Throttled (console included) — see noticeSuggestFailure.
+              noticeSuggestFailure(failure);
+            } else {
+              // Submits are user-initiated and rare, so every one is logged.
+              // Unconditionally, unlike before: a keyless build is exactly when
+              // every request fails, and the old gate stayed silent for it.
+              // The toast for this case comes from the results handler.
+              console.warn('Search provider error:', error);
+            }
           }
           cb(null, error ? [] : results);
         });

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -42,6 +42,51 @@ function applyMapZoomClass(map: L.Map): void {
   el.classList.toggle('map-zoom-close', z >= 12);
 }
 
+/** Shape of the error esri-leaflet hands back; every field is best-effort. */
+export interface SearchProviderError {
+  code?: number;
+  message?: string;
+}
+
+/**
+ * Explain a search failure in terms the user can act on. The causes need
+ * genuinely different responses — an unauthorised key is a config problem
+ * nobody browsing can fix, while a 429 just needs a moment — so a single
+ * "search failed" string would be worse than useless.
+ *
+ * Pure so it can be unit-tested: the widget itself is not reachable under jsdom.
+ */
+export function describeSearchFailure(
+  error: SearchProviderError | null,
+  opts: { hasApiKey: boolean; online: boolean },
+): string {
+  if (!opts.online) {
+    return 'Address search needs a connection — you appear to be offline.';
+  }
+  if (!opts.hasApiKey) {
+    return 'Address search isn\u2019t available: this build has no ArcGIS API key configured.';
+  }
+
+  const code = error?.code;
+  // ArcGIS returns 403 for a referrer/origin the key doesn't allow, and
+  // 498/499 for an invalid or missing token. All three are key configuration,
+  // not anything the person searching did.
+  if (code === 403 || code === 498 || code === 499) {
+    return 'Address search was refused by ArcGIS \u2014 the API key doesn\u2019t allow this site.';
+  }
+  if (code === 429) {
+    return 'Address search is rate-limited right now \u2014 try again in a moment.';
+  }
+  if (typeof code === 'number' && code >= 500) {
+    return `Address search is temporarily down \u2014 ArcGIS returned ${code}.`;
+  }
+  // A rejected fetch (DNS, CORS, blocked request) arrives with no status code.
+  if (code === undefined) {
+    return 'Address search couldn\u2019t reach ArcGIS \u2014 the request was blocked or timed out.';
+  }
+  return `Address search failed \u2014 ArcGIS returned ${code}.`;
+}
+
 function zoomForAddrType(addrType: string): number {
   switch (addrType) {
     case 'PointAddress': case 'StreetAddress': case 'SubAddress': case 'StreetInt': return 17;
@@ -59,7 +104,7 @@ let _clearSearchSelection: (() => void) | null = null;
 let _showGeocodeBar: ((label: string, copyText: string, latlng: L.LatLng) => void) | null = null;
 const SEARCH_PLACEHOLDER = '';
 
-export function addSearchControl(map: L.Map, state: AppState, onNoResults: (message: string) => void): void {
+export function addSearchControl(map: L.Map, state: AppState, showMessage: (message: string, durationMs?: number) => void): void {
   // state is read in the results callback (for future extensibility)
   void state;
 
@@ -72,7 +117,27 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
       'Set VITE_ESRI_API_KEY in your .env file.'
     );
   }
-  const logProviderErrors = Boolean(apikey);
+  // Most recent provider failure, or null after any success. The results handler
+  // reads this to tell an outage apart from a genuine zero-match search — the
+  // two need opposite advice, and previously both rendered as "no results".
+  let lastProviderError: SearchProviderError | null = null;
+  // suggest() runs per keystroke, so an outage would otherwise toast on every
+  // letter typed. One notice per window is enough to explain what's happening.
+  const FAILURE_NOTICE_INTERVAL_MS = 15000;
+  let lastNoticeAt = 0;
+
+  function noticeSearchFailure(): void {
+    const now = Date.now();
+    if (now - lastNoticeAt < FAILURE_NOTICE_INTERVAL_MS) return;
+    lastNoticeAt = now;
+    showMessage(
+      describeSearchFailure(lastProviderError, {
+        hasApiKey: Boolean(apikey),
+        online: navigator.onLine,
+      }),
+      6000,
+    );
+  }
 
   // Wrap a provider so that errors in results() and suggest() are logged and
   // silenced rather than propagated. Wrapping before construction avoids
@@ -93,7 +158,16 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
         cb: (err: null, results: unknown[]) => void,
       ): unknown {
         return orig(text, key, bounds, (error: unknown, results: unknown[]) => {
-          if (error && logProviderErrors) console.warn('Search provider error:', error);
+          // Keep converting errors to empty results so the widget stays happy,
+          // but remember the failure — discarding it here is what made outages
+          // indistinguishable from a search that simply matched nothing.
+          lastProviderError = error ? (error as SearchProviderError) : null;
+          if (error) {
+            // Logged unconditionally: a keyless build is exactly when every
+            // request fails, and the old gate stayed silent in that case.
+            console.warn('Search provider error:', error);
+            noticeSearchFailure();
+          }
           cb(null, error ? [] : results);
         });
       };
@@ -144,9 +218,31 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
   dropdownEl.style.display = 'none';
   document.body.appendChild(dropdownEl);
 
+  // Toggle button for the results list, mounted below the search bar. Only
+  // meaningful once a search has produced results, so it stays hidden until then.
+  let resultsToggleEl: HTMLElement | null = null;
+
+  /** Results survive hiding — innerHTML is preserved — so they can be revealed. */
+  function hasResults(): boolean {
+    return dropdownEl.innerHTML !== '';
+  }
+
+  function isDropdownOpen(): boolean {
+    return dropdownEl.style.display === 'block';
+  }
+
+  function syncResultsToggle(): void {
+    if (resultsToggleEl === null) return;
+    resultsToggleEl.style.display = hasResults() ? '' : 'none';
+    const open = isDropdownOpen();
+    resultsToggleEl.setAttribute('aria-pressed', open ? 'true' : 'false');
+    resultsToggleEl.title = open ? 'Hide search results' : 'Show search results';
+  }
+
   function hideDropdown(): void {
     dropdownEl.style.display = 'none';
     // Preserve innerHTML so it can be restored when clicking a marker.
+    syncResultsToggle();
   }
 
   function showDropdown(): void {
@@ -158,7 +254,42 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
     // Width is read after display so the measured value reflects the CSS bounds.
     const maxLeft = window.innerWidth - dropdownEl.offsetWidth - 4;
     dropdownEl.style.left = `${Math.max(4, Math.min(rect.left, maxLeft))}px`;
+    syncResultsToggle();
   }
+
+  function toggleDropdown(): void {
+    if (!hasResults()) return;
+    if (isDropdownOpen()) hideDropdown();
+    else showDropdown();
+  }
+
+  // topleft, registered after the search control, so Leaflet stacks it directly
+  // below the search bar it belongs to.
+  const ResultsToggleControl = L.Control.extend({
+    onAdd(): HTMLElement {
+      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      container.setAttribute('role', 'button');
+      container.setAttribute('tabindex', '0');
+      const icon = L.DomUtil.create('span', 'leaflet-control-toggle__icon') as HTMLSpanElement;
+      icon.textContent = '\u2630'; // ☰ — plain text glyph, no emoji presentation
+      container.appendChild(icon);
+      L.DomEvent.disableClickPropagation(container);
+      L.DomEvent.on(container, 'click', (e: Event) => {
+        toggleDropdown();
+        e.stopImmediatePropagation();
+      });
+      L.DomEvent.on(container, 'keydown', (e: Event) => {
+        const key = (e as KeyboardEvent).key;
+        if (key !== 'Enter' && key !== ' ') return;
+        e.preventDefault();
+        toggleDropdown();
+      });
+      resultsToggleEl = container;
+      syncResultsToggle(); // starts hidden: no results yet
+      return container;
+    },
+  });
+  new (ResultsToggleControl as new (opts: L.ControlOptions) => L.Control)({ position: 'topleft' }).addTo(map);
 
   // Dropdown is dismissed only via the close button inside it.
   dropdownEl.addEventListener('click', (e: MouseEvent) => {
@@ -380,7 +511,19 @@ export function addSearchControl(map: L.Map, state: AppState, onNoResults: (mess
         easeLinearity: 0.25,
       });
     } else {
-      onNoResults('No results found. Try zooming out or rewording your search.');
+      // Only blame the query when the service actually answered. Telling someone
+      // to reword their search during an outage is worse than saying nothing.
+      if (lastProviderError !== null) {
+        showMessage(
+          describeSearchFailure(lastProviderError, {
+            hasApiKey: Boolean(apikey),
+            online: navigator.onLine,
+          }),
+          6000,
+        );
+      } else {
+        showMessage('No results found. Try zooming out or rewording your search.');
+      }
     }
   });
 }

--- a/src/layers-control.ts
+++ b/src/layers-control.ts
@@ -63,7 +63,7 @@ export class LayersControl extends L.Control {
     options?: L.ControlOptions,
     defaultOverlayIds: string[] = [],
   ) {
-    super(options || { position: 'topright' });
+    super(options || { position: 'bottomleft' });
     this.baseMaps = baseMaps;
     this.overlays = overlays;
     this.defaultOverlayIds = defaultOverlayIds;
@@ -72,13 +72,23 @@ export class LayersControl extends L.Control {
   onAdd(map: L.Map): HTMLElement {
     this.map = map;
 
-    const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+    const container = L.DomUtil.create('div', 'leaflet-control-toggle ctrl-layers') as HTMLDivElement;
     this.containerEl = container;
     container.title = 'Click to choose map layer';
 
-    // Icon: layered squares
-    const icon = L.DomUtil.create('span', 'layers-control__icon') as HTMLSpanElement;
-    icon.innerHTML = '⚙'; // Alternative: could use an SVG or emoji
+    // Stacked-sheets glyph — the conventional map-layers icon. The gear it
+    // replaces read as app settings, which is not what this opens.
+    // Shares .leaflet-control-toggle__icon with the other buttons so it can't
+    // drift out of size with them; the old bespoke class was bumped to 20px
+    // under .leaflet-touch while the rest stayed 16px.
+    const icon = L.DomUtil.create('span', 'leaflet-control-toggle__icon') as HTMLSpanElement;
+    icon.innerHTML =
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" ' +
+      'stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">' +
+      '<path d="M8 1.75 14.25 5 8 8.25 1.75 5 8 1.75Z"/>' +
+      '<path d="M2.6 7.7 8 10.5l5.4-2.8"/>' +
+      '<path d="M2.6 10.5 8 13.3l5.4-2.8"/>' +
+      '</svg>';
     icon.id = 'layers-control-btn';
 
     container.appendChild(icon);
@@ -515,7 +525,7 @@ export function addLayersControl(
   overlays?: OverlayDef[],
   defaultOverlayIds?: string[],
 ): LayersControl {
-  const control = new LayersControl(baseMaps, overlays, { position: 'topright' }, defaultOverlayIds);
+  const control = new LayersControl(baseMaps, overlays, { position: 'bottomleft' }, defaultOverlayIds);
   control.addTo(map);
   return control;
 }

--- a/src/offline-download.ts
+++ b/src/offline-download.ts
@@ -547,7 +547,7 @@ export function addOfflineDownloadControl(
   let containerEl: HTMLElement | null = null;
   const Ctrl = L.Control.extend({
     onAdd(): HTMLElement {
-      const container = L.DomUtil.create('div', 'leaflet-control-toggle') as HTMLDivElement;
+      const container = L.DomUtil.create('div', 'leaflet-control-toggle ctrl-download') as HTMLDivElement;
       containerEl = container;
       container.title = 'Download: Select a region and zoom range to cache for offline use';
 
@@ -595,6 +595,6 @@ export function addOfflineDownloadControl(
   });
 
   new (Ctrl as new (opts: L.ControlOptions) => L.Control)({
-    position: 'topright',
+    position: 'bottomleft',
   }).addTo(map);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -422,19 +422,23 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* ── Reverse geocode bottom sheet ── */
-/* Right-anchored rather than centred, and capped at 480px so it doesn't balloon
-   on a wide monitor. The sheet must never obscure the bottom-left cluster
-   (zoom, ruler, version, attribution) — in peek every pixel of its visible band
-   belongs to a pointer-events:auto child, so anything underneath is unreachable,
-   not merely hidden (#253). That separation is VERTICAL, not horizontal: the
-   attribution alone runs ~330px, most of a phone's width, so no side-by-side
-   split can clear it. The cluster rides above the sheet via --sheet-h below.
-   The transform carries only translateY — see sheetTransform() in geocoding.ts. */
+/* Centred, capped at 480px so it doesn't balloon on a wide monitor. The sheet
+   must never obscure the bottom-left control cluster — in peek every pixel of
+   its visible band belongs to a pointer-events:auto child, so anything beneath
+   is unreachable, not merely hidden (#253). That separation is VERTICAL: the
+   cluster rides above the sheet via --sheet-h, which is why the sheet can be
+   centred and full-width here without covering anything.
+
+   Centred with left/right + margin auto rather than left:50% + translateX(-50%)
+   on purpose: the transform must stay purely vertical, because four call sites
+   write it and sheetTransform() is what keeps them from drifting. Folding a
+   horizontal component back in would reintroduce exactly that hazard. */
 .geocode-bar {
   position: fixed;
   bottom: 0;
+  left: env(safe-area-inset-left, 0px);
   right: env(safe-area-inset-right, 0px);
-  left: auto;
+  margin-inline: auto;
   transform: translateY(0);
   width: min(480px, 100vw);
   height: 30vh;
@@ -669,6 +673,14 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   color: #333;
 }
 
+/* Inline SVG icons (layers) fill the same box as the glyph ones, and inherit
+   the colour above via stroke="currentColor". */
+.leaflet-control-toggle__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .leaflet-control-toggle__label {
   font-size: 12px;
   font-weight: 500;
@@ -840,6 +852,13 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      (zoom, version-badge) from stretching to match wider siblings like
      the attribution. */
   align-items: flex-start;
+  /* Eleven controls stack here now. On a short viewport (landscape especially)
+     that can exceed the height available, and a control pushed off-screen is
+     unreachable — the same failure #253 was about. Bound the column to the
+     space between the top edge and the sheet, and scroll inside it if needed. */
+  max-height: calc(100vh - var(--sheet-h, 0px) - 20px - env(safe-area-inset-top, 0px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   /* Rides with the sheet rather than snapping after it lands. Duration comes
      from SHEET_ANIM_MS via --sheet-anim (set in geocoding.ts), so the two can't
      drift; the fallback only applies before the first snap publishes it. */
@@ -854,13 +873,30 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 }
 
 /* Bottom-left cluster reading order (top → bottom):
-   locate → recording → zoom → scale → version-badge → attribution.
-   Registration order doesn't match this so we use explicit `order`. */
-.leaflet-bottom.leaflet-left .leaflet-control-toggle { order: 1; }
-.leaflet-bottom.leaflet-left .leaflet-control-zoom   { order: 3; }
-.leaflet-bottom.leaflet-left .leaflet-control-scale  { order: 4; }
-.leaflet-bottom.leaflet-left #version-badge          { order: 5; }
-.leaflet-bottom.leaflet-left .leaflet-control-attribution { order: 6; }
+   the full stack is listed below. Registration order doesn't match it, so the
+   ordering is explicit. */
+/* Every control now lives in this one column, so order is explicit rather than
+   registration-dependent. Search sits just above the scale bar, within thumb
+   reach; the results toggle stays directly beneath it since the two are a pair.
+   Attribution stays last — it's the least interactive thing here. */
+.leaflet-bottom.leaflet-left .ctrl-layers            { order: 0; }
+.leaflet-bottom.leaflet-left .ctrl-download          { order: 1; }
+.leaflet-bottom.leaflet-left .ctrl-draw-zone         { order: 2; }
+.leaflet-bottom.leaflet-left .compass-rose           { order: 3; }
+.leaflet-bottom.leaflet-left .ctrl-locate            { order: 4; }
+.leaflet-bottom.leaflet-left .leaflet-control-zoom   { order: 5; }
+.leaflet-bottom.leaflet-left .geocoder-control       { order: 6; }
+.leaflet-bottom.leaflet-left .ctrl-results           { order: 7; }
+.leaflet-bottom.leaflet-left .leaflet-control-scale  { order: 8; }
+.leaflet-bottom.leaflet-left #version-badge          { order: 9; }
+.leaflet-bottom.leaflet-left .leaflet-control-attribution { order: 10; }
+
+/* Breathing room between the search pair and the readouts below it, separating
+   the things you act on from the things you only read. Applied to the scale's
+   top rather than the search's bottom so the gap survives the results toggle
+   being hidden. !important is needed to beat the .leaflet-control margin reset
+   in the mobile block above. */
+.leaflet-bottom.leaflet-left .leaflet-control-scale { margin-top: 10px !important; }
 
 /* Unify the bottom-left cluster visually with the zoom + version-badge,
    but keep the U-shaped left/right/bottom border that visualizes the
@@ -1313,22 +1349,6 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
 
 /* ── Custom Layers Control ──────────────────────────────────────────── */
 
-.layers-control__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  width: 16px;
-  height: 16px;
-  line-height: 1;
-}
-
-.leaflet-touch .layers-control__icon {
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-}
-
 /* Layers Popover ─────────────────────────────────────────────────── */
 
 .layers-popover {
@@ -1704,7 +1724,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
   transition: transform 0.12s linear;
 }
 .compass-rose--active { opacity: 1; cursor: default; }
-.compass-rose--unavailable { display: none; }
+/* Keeps its 36px slot rather than display:none. The compass appears only after
+   a permission grant, and collapsing the row would shift every control above it
+   the moment it resolves — the stack has to be stable to be usable. */
+.compass-rose--unavailable { visibility: hidden; pointer-events: none; }
 
 /* Rider-placed "unsafe here" marker in the cue-events overlay — a neutral triangle
    glyph, deliberately distinct from the outcome-colored circular cue points.

--- a/src/style.css
+++ b/src/style.css
@@ -856,7 +856,10 @@ body { height: 100%; width: 100%; padding: 0; margin: 0; }
      that can exceed the height available, and a control pushed off-screen is
      unreachable — the same failure #253 was about. Bound the column to the
      space between the top edge and the sheet, and scroll inside it if needed. */
-  max-height: calc(100vh - var(--sheet-h, 0px) - 20px - env(safe-area-inset-top, 0px));
+  max-height: calc(
+    100vh - var(--sheet-h, 0px)
+    - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 20px
+  );
   overflow-y: auto;
   overscroll-behavior: contain;
   /* Rides with the sheet rather than snapping after it lands. Duration comes


### PR DESCRIPTION
## Summary

Search failures were invisible, or worse, blamed on the user.

`wrapProvider()` converted every provider error into an empty result set, discarding the error before anything downstream could tell an outage apart from a genuine zero-match search. Two symptoms:

- **Typing gave no feedback.** Autocomplete failures produced an empty dropdown, indistinguishable from "no matches yet."
- **Submitting misled.** A total outage reported *"No results found. Try zooming out or rewording your search."* — advice that cannot help when the service is down.

Fixes #260, fixes #261

## Explaining the cause, not just the failure

The causes want opposite responses from the user, so a single "search failed" string would be barely better than silence. `describeSearchFailure()` maps cause to message:

| Condition | Message says |
|---|---|
| Offline | Needs a connection — checked first, since nothing else is actionable until it returns |
| No API key in build | Not configured; nothing the user can do |
| 403 / 498 / 499 | The key doesn't allow this site — configuration, not their query |
| 429 | Rate-limited, try again shortly |
| 5xx | Temporarily down, with the status |
| No status code | Request blocked or timed out (DNS, CORS, blocked request) |
| Other | Reports the status verbatim |

**403 is the local-dev case you'd hit**: the ArcGIS key is referrer-restricted, so a dev origin that isn't allowlisted is rejected on every keystroke while production works fine.

Autocomplete failures notify too, throttled to one notice per 15 s so a per-keystroke outage doesn't spam. A genuine zero-match search keeps its existing message — that advice is correct there and only there.

Provider errors are now **always** logged. The old `logProviderErrors = Boolean(apikey)` gate skipped logging when no key was configured, which is precisely when every request fails.

## Results list toggle (#261)

Results stay on the map as numbered markers after the list is closed, but the list could previously only be recovered by clicking one of those markers. Adds a toggle below the search bar — appears once results exist, hides and reveals the same list (`hideDropdown()` already preserved `innerHTML`), keyboard operable with `aria-pressed` tracking state.

## Test plan

7 tests on `describeSearchFailure()`, which is pure (235 total). Beyond the per-cause assertions, two encode the actual intent:

- **Offline outranks every other cause**, even when the last attempt returned a 500.
- **No failure message ever says "reword" or "zoom out"** — asserted across all failure shapes. That's the specific misdirection #260 was filed for, and the assertion fails if anyone later routes an error into the no-results branch.

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (235) ✅ · `npm run size` 121.64 kB / 124 kB

## Assumptions and gaps

- **Not browser-verified.** The cause mapping is unit-tested, but neither the throttling nor the toggle is reachable under jsdom — both need the Leaflet widget. Worth exercising with the dev server on an origin the ArcGIS key doesn't allow, which reproduces the 403 path directly.
- **Error shape is best-effort.** `SearchProviderError` treats `code` and `message` as optional because esri-leaflet's error object isn't contractually typed; an unrecognised shape falls through to the no-status-code branch rather than throwing.
- **Bundle cap raised 122 → 124 kB, the second raise today** (120 → 122 → 124). Flagging that the 2 kB convention step is now smaller than a typical change here, so the cap is tracking growth rather than constraining it. Worth an audit of what's actually growing rather than another nudge next time.
