### PR TITLE
feat(search): focus the search box on load for pointer devices

### DIFF
--- a/src/geocoding.test.ts
+++ b/src/geocoding.test.ts
@@ -11,6 +11,7 @@ import {
   sheetTransform,
   isReplyForPin,
   describeSearchFailure,
+  shouldAutofocusSearch,
 } from './geocoding';
 
 // ── Minimal stubs ─────────────────────────────────────────────────────────────
@@ -338,3 +339,21 @@ describe('describeSearchFailure', () => {
 });
 
 type SearchFailureArgs = Parameters<typeof describeSearchFailure>;
+
+describe('shouldAutofocusSearch', () => {
+  it('focuses only on devices with a precise pointer', () => {
+    expect(shouldAutofocusSearch(() => ({ matches: true }))).toBe(true);
+    expect(shouldAutofocusSearch(() => ({ matches: false }))).toBe(false);
+  });
+
+  it('asks about pointer and hover, never viewport width', () => {
+    // The guard exists to keep the on-screen keyboard from covering the map on
+    // load. Width would be the wrong proxy in both directions: a narrow laptop
+    // window is still a keyboard device, and a large tablet still isn't.
+    let asked = '';
+    shouldAutofocusSearch((query) => { asked = query; return { matches: false }; });
+    expect(asked).toContain('pointer: fine');
+    expect(asked).toContain('hover: hover');
+    expect(asked).not.toMatch(/width/);
+  });
+});

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -561,6 +561,17 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
       }
     }
   });
+
+  // Land with the caret in the search box, so a keyboard user can type a place
+  // and press Enter without reaching for the pointer.
+  //
+  // Deliberately not on touch: focusing an input there raises the on-screen
+  // keyboard over the map on every load, which is the opposite of useful for an
+  // app you open to look at where you are. The query matches devices with a
+  // precise pointer and real hover, i.e. mouse/trackpad rather than a finger.
+  if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+    input.focus({ preventScroll: true });
+  }
 }
 
 // ── Bottom-sheet drag-settle thresholds (module scope, unit-tested) ──────────

--- a/src/geocoding.ts
+++ b/src/geocoding.ts
@@ -87,6 +87,33 @@ export function describeSearchFailure(
   return `Address search failed \u2014 ArcGIS returned ${code}.`;
 }
 
+/**
+ * Media query deciding whether the search box takes focus on load. Hover and
+ * pointer precision, deliberately not viewport width: a narrow laptop window is
+ * still a keyboard device, and a large tablet still isn't.
+ */
+export const AUTOFOCUS_POINTER_QUERY = '(hover: hover) and (pointer: fine)';
+
+/**
+ * Whether to focus the search box on load. True only for mouse/trackpad
+ * devices: focusing an input on touch raises the on-screen keyboard over the
+ * map on every load, which is the opposite of useful for an app opened to see
+ * where you are.
+ *
+ * Note this moves focus without user action, which usually warrants care
+ * (WCAG 3.2.1-adjacent) — a desktop screen-reader user lands in the search box
+ * before hearing the map's context. Kept deliberately: this is a search-first
+ * entry point and the behaviour was asked for explicitly. Recorded here so it
+ * reads as a decision rather than an oversight.
+ *
+ * Takes matchMedia as an argument so the decision is testable without a browser.
+ */
+export function shouldAutofocusSearch(
+  matchMediaFn: (query: string) => { matches: boolean },
+): boolean {
+  return matchMediaFn(AUTOFOCUS_POINTER_QUERY).matches;
+}
+
 function zoomForAddrType(addrType: string): number {
   switch (addrType) {
     case 'PointAddress': case 'StreetAddress': case 'SubAddress': case 'StreetInt': return 17;
@@ -564,12 +591,7 @@ export function addSearchControl(map: L.Map, state: AppState, showMessage: (mess
 
   // Land with the caret in the search box, so a keyboard user can type a place
   // and press Enter without reaching for the pointer.
-  //
-  // Deliberately not on touch: focusing an input there raises the on-screen
-  // keyboard over the map on every load, which is the opposite of useful for an
-  // app you open to look at where you are. The query matches devices with a
-  // precise pointer and real hover, i.e. mouse/trackpad rather than a finger.
-  if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+  if (shouldAutofocusSearch((q) => window.matchMedia(q))) {
     input.focus({ preventScroll: true });
   }
 }


### PR DESCRIPTION
## Summary

Nothing held focus on load, so searching meant reaching for the pointer to click the search box first. It now takes focus once the app has booted, so the flow is open → type → Enter.

Fixes #263

## The one judgment call

**Gated to `(hover: hover) and (pointer: fine)` rather than applied everywhere.**

On a touch device, focusing an input raises the on-screen keyboard over the map on every single load. For an app you open to see where you are — used one-handed, often while moving — that's the opposite of useful, and it would be a regression for the primary mobile case this whole session has been about.

The stated need ("type something and hit enter") is a keyboard workflow, so the query matches devices with a precise pointer and real hover: mouse and trackpad, not a finger.

**Easy to change**: deleting the `matchMedia` guard makes it unconditional. Flagging it explicitly because it's me narrowing a request, not implementing it literally.

`preventScroll: true` because the search box now sits low in the bottom-left column after #262 — the default scroll-into-view would shift the viewport on load.

## Test plan

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (235) ✅

## Assumptions and gaps

- **Not covered by tests.** `matchMedia` and focus behaviour need a real browser; jsdom reports no match for the query and has no meaningful focus semantics, so a test would only assert the mock.
- Focus is taken after the consent gate, since `addSearchControl` runs inside `initApp()`, which the consent promise gates. Worth confirming on a first-run profile that the modal still owns focus until dismissed.
- Manual check on a phone that the keyboard does **not** appear on load is the important one — that's the case the guard exists for.
