### PR TITLE
fix(search): stop the map stealing focus from the search box on load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -552,7 +552,7 @@ document.addEventListener('keydown', (e) => {
 
 // The map is deliberately NOT focused here any more. This ran after
 // addSearchControl, so it stole focus from the search box the instant it was
-// given (#263), and the empty-input blur handler then collapsed the control
+// given (#265), and the empty-input blur handler then collapsed the control
 // 150ms later — the search looked like it opened and shut itself.
 //
 // Nothing is lost: Leaflet's keyboard handler focuses the map container on the

--- a/src/main.ts
+++ b/src/main.ts
@@ -550,8 +550,15 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape' && changelogPanel.classList.contains('visible')) closeChangelog();
 });
 
-// Focus map for keyboard zoom shortcuts
-document.getElementById('map')?.focus();
+// The map is deliberately NOT focused here any more. This ran after
+// addSearchControl, so it stole focus from the search box the instant it was
+// given (#263), and the empty-input blur handler then collapsed the control
+// 150ms later — the search looked like it opened and shut itself.
+//
+// Nothing is lost: Leaflet's keyboard handler focuses the map container on the
+// first mousedown over it (Keyboard._onMouseDown), so zoom and pan shortcuts
+// start working as soon as the map is touched. Focus on load belongs to the
+// thing you can type into.
 document.body.style.zoom = '100%';
 
 // ── Offline detection ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

After #264 gave the search box focus on load, it visibly opened and collapsed a moment later, and typing did nothing.

`main.ts` focused the map container for keyboard zoom shortcuts, and that line runs **after** `addSearchControl()`. Every load did:

1. `addSearchControl()` focuses the search input
2. `main.ts` focuses the map container, blurring it
3. The input's blur handler sees an empty value and collapses the control 150 ms later

Two features competing for one focus, with the later one silently winning.

Fixes #265

## What dropping it costs

Nothing meaningful. Leaflet's keyboard handler focuses the map container on the first mousedown over it (`Keyboard._onMouseDown`, confirmed in the library source), so zoom and pan shortcuts start working as soon as the map is interacted with.

## Test plan

`npm run type-check` ✅ · `npm run lint` ✅ · `npm test` (237) ✅

**Verified in a browser by the maintainer**: typing immediately after reload now enters the search box and stays; map zoom shortcuts still work after clicking the map.

## Assumptions and gaps

- **No test covers this, and none realistically can.** jsdom has no meaningful focus semantics, so #264 passed review and CI while being defeated by a line 70 lines away in another file. This class of defect — two modules contending for one piece of global state — is only observable by loading the page.
- Removing the call means keyboard zoom shortcuts require one map interaction first. Deliberate: focus on load belongs to the input, and the shortcuts return the instant the map is touched.